### PR TITLE
Clean up binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -555,7 +555,7 @@ name = "soroban-hello-world-contract"
 version = "0.0.0"
 dependencies = [
  "soroban-hello-world-contract",
- "soroban-sdk 0.0.0 (git+https://github.com/stellar/rs-stellar-contract-sdk?rev=7e3422e)",
+ "soroban-sdk",
 ]
 
 [[package]]
@@ -566,7 +566,7 @@ dependencies = [
  "rand",
  "sha2 0.10.2",
  "soroban-liquidity-pool-contract",
- "soroban-sdk 0.0.0 (git+https://github.com/stellar/rs-soroban-sdk?rev=9d77da8)",
+ "soroban-sdk",
  "soroban-token-contract",
  "stellar-xdr 0.0.0 (git+https://github.com/stellar/rs-stellar-xdr?rev=94e01c7b)",
 ]
@@ -574,19 +574,6 @@ dependencies = [
 [[package]]
 name = "soroban-macros"
 version = "0.0.0"
-source = "git+https://github.com/stellar/rs-stellar-contract-sdk?rev=7e3422e#7e3422eddbe29e3349bd9d28d0ca10955ee9ec27"
-dependencies = [
- "darling",
- "itertools",
- "proc-macro2",
- "quote",
- "stellar-xdr 0.0.0 (git+https://github.com/stellar/rs-stellar-xdr?rev=94e01c7b)",
- "syn",
-]
-
-[[package]]
-name = "soroban-macros"
-version = "0.0.0"
 source = "git+https://github.com/stellar/rs-soroban-sdk?rev=9d77da8#9d77da85fda39afa0be9333c20b3bdfbcc167fb3"
 dependencies = [
  "darling",
@@ -600,23 +587,12 @@ dependencies = [
 [[package]]
 name = "soroban-sdk"
 version = "0.0.0"
-source = "git+https://github.com/stellar/rs-stellar-contract-sdk?rev=7e3422e#7e3422eddbe29e3349bd9d28d0ca10955ee9ec27"
-dependencies = [
- "ed25519-dalek",
- "soroban-env-guest",
- "soroban-env-host",
- "soroban-macros 0.0.0 (git+https://github.com/stellar/rs-stellar-contract-sdk?rev=7e3422e)",
-]
-
-[[package]]
-name = "soroban-sdk"
-version = "0.0.0"
 source = "git+https://github.com/stellar/rs-soroban-sdk?rev=9d77da8#9d77da85fda39afa0be9333c20b3bdfbcc167fb3"
 dependencies = [
  "ed25519-dalek",
  "soroban-env-guest",
  "soroban-env-host",
- "soroban-macros 0.0.0 (git+https://github.com/stellar/rs-soroban-sdk?rev=9d77da8)",
+ "soroban-macros",
 ]
 
 [[package]]
@@ -625,7 +601,7 @@ version = "0.0.0"
 dependencies = [
  "ed25519-dalek",
  "rand",
- "soroban-sdk 0.0.0 (git+https://github.com/stellar/rs-soroban-sdk?rev=9d77da8)",
+ "soroban-sdk",
  "soroban-single-offer-contract",
  "soroban-token-contract",
 ]
@@ -636,7 +612,7 @@ version = "0.0.0"
 source = "git+https://github.com/stellar/soroban-token-contract?rev=46463cc#46463cc6f57d4a55832a68b3df38857046e2b0b8"
 dependencies = [
  "ed25519-dalek",
- "soroban-sdk 0.0.0 (git+https://github.com/stellar/rs-soroban-sdk?rev=9d77da8)",
+ "soroban-sdk",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -567,7 +567,7 @@ dependencies = [
  "sha2 0.10.2",
  "soroban-liquidity-pool-contract",
  "soroban-sdk 0.0.0 (git+https://github.com/stellar/rs-soroban-sdk?rev=9d77da8)",
- "soroban-token-contract 0.0.0 (git+https://github.com/stellar/soroban-token-contract?rev=46463cc)",
+ "soroban-token-contract",
  "stellar-xdr 0.0.0 (git+https://github.com/stellar/rs-stellar-xdr?rev=94e01c7b)",
 ]
 
@@ -625,9 +625,9 @@ version = "0.0.0"
 dependencies = [
  "ed25519-dalek",
  "rand",
- "soroban-sdk 0.0.0 (git+https://github.com/stellar/rs-stellar-contract-sdk?rev=7e3422e)",
+ "soroban-sdk 0.0.0 (git+https://github.com/stellar/rs-soroban-sdk?rev=9d77da8)",
  "soroban-single-offer-contract",
- "soroban-token-contract 0.0.0 (git+https://github.com/stellar/rs-stellar-token-contract?rev=d0f6b11)",
+ "soroban-token-contract",
 ]
 
 [[package]]
@@ -637,15 +637,6 @@ source = "git+https://github.com/stellar/soroban-token-contract?rev=46463cc#4646
 dependencies = [
  "ed25519-dalek",
  "soroban-sdk 0.0.0 (git+https://github.com/stellar/rs-soroban-sdk?rev=9d77da8)",
-]
-
-[[package]]
-name = "soroban-token-contract"
-version = "0.0.0"
-source = "git+https://github.com/stellar/rs-stellar-token-contract?rev=d0f6b11#d0f6b11bb3771d61da2340836227d68a31615e68"
-dependencies = [
- "ed25519-dalek",
- "soroban-sdk 0.0.0 (git+https://github.com/stellar/rs-stellar-contract-sdk?rev=7e3422e)",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -555,7 +555,7 @@ name = "soroban-hello-world-contract"
 version = "0.0.0"
 dependencies = [
  "soroban-hello-world-contract",
- "soroban-sdk",
+ "soroban-sdk 0.0.0 (git+https://github.com/stellar/rs-stellar-contract-sdk?rev=7e3422e)",
 ]
 
 [[package]]
@@ -566,8 +566,8 @@ dependencies = [
  "rand",
  "sha2 0.10.2",
  "soroban-liquidity-pool-contract",
- "soroban-sdk",
- "soroban-token-contract",
+ "soroban-sdk 0.0.0 (git+https://github.com/stellar/rs-soroban-sdk?rev=9d77da8)",
+ "soroban-token-contract 0.0.0 (git+https://github.com/stellar/soroban-token-contract?rev=46463cc)",
  "stellar-xdr 0.0.0 (git+https://github.com/stellar/rs-stellar-xdr?rev=94e01c7b)",
 ]
 
@@ -585,6 +585,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "soroban-macros"
+version = "0.0.0"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=9d77da8#9d77da85fda39afa0be9333c20b3bdfbcc167fb3"
+dependencies = [
+ "darling",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "stellar-xdr 0.0.0 (git+https://github.com/stellar/rs-stellar-xdr?rev=94e01c7b)",
+ "syn",
+]
+
+[[package]]
 name = "soroban-sdk"
 version = "0.0.0"
 source = "git+https://github.com/stellar/rs-stellar-contract-sdk?rev=7e3422e#7e3422eddbe29e3349bd9d28d0ca10955ee9ec27"
@@ -592,7 +605,18 @@ dependencies = [
  "ed25519-dalek",
  "soroban-env-guest",
  "soroban-env-host",
- "soroban-macros",
+ "soroban-macros 0.0.0 (git+https://github.com/stellar/rs-stellar-contract-sdk?rev=7e3422e)",
+]
+
+[[package]]
+name = "soroban-sdk"
+version = "0.0.0"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=9d77da8#9d77da85fda39afa0be9333c20b3bdfbcc167fb3"
+dependencies = [
+ "ed25519-dalek",
+ "soroban-env-guest",
+ "soroban-env-host",
+ "soroban-macros 0.0.0 (git+https://github.com/stellar/rs-soroban-sdk?rev=9d77da8)",
 ]
 
 [[package]]
@@ -601,9 +625,18 @@ version = "0.0.0"
 dependencies = [
  "ed25519-dalek",
  "rand",
- "soroban-sdk",
+ "soroban-sdk 0.0.0 (git+https://github.com/stellar/rs-stellar-contract-sdk?rev=7e3422e)",
  "soroban-single-offer-contract",
- "soroban-token-contract",
+ "soroban-token-contract 0.0.0 (git+https://github.com/stellar/rs-stellar-token-contract?rev=d0f6b11)",
+]
+
+[[package]]
+name = "soroban-token-contract"
+version = "0.0.0"
+source = "git+https://github.com/stellar/soroban-token-contract?rev=46463cc#46463cc6f57d4a55832a68b3df38857046e2b0b8"
+dependencies = [
+ "ed25519-dalek",
+ "soroban-sdk 0.0.0 (git+https://github.com/stellar/rs-soroban-sdk?rev=9d77da8)",
 ]
 
 [[package]]
@@ -612,7 +645,7 @@ version = "0.0.0"
 source = "git+https://github.com/stellar/rs-stellar-token-contract?rev=d0f6b11#d0f6b11bb3771d61da2340836227d68a31615e68"
 dependencies = [
  "ed25519-dalek",
- "soroban-sdk",
+ "soroban-sdk 0.0.0 (git+https://github.com/stellar/rs-stellar-contract-sdk?rev=7e3422e)",
 ]
 
 [[package]]

--- a/hello_world/Cargo.toml
+++ b/hello_world/Cargo.toml
@@ -16,9 +16,7 @@ export = []
 testutils = ["soroban-sdk/testutils"]
 
 [dependencies]
-soroban-sdk = { git = "https://github.com/stellar/rs-stellar-contract-sdk", rev = "7e3422e" }
-# switch to this once the repos are renamed
-# soroban-sdk = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "7e3422e" }
+soroban-sdk = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "9d77da8" }
 
 [dev_dependencies]
 soroban-hello-world-contract = { path = ".", default-features = false, features = ["testutils"] }

--- a/hello_world/src/lib.rs
+++ b/hello_world/src/lib.rs
@@ -48,31 +48,29 @@ impl HelloContract {
 #[cfg(test)]
 mod test {
     use super::*;
-    use soroban_sdk::{vec, Binary, Env, IntoVal};
+    use soroban_sdk::{vec, Env, FixedBinary, IntoVal};
 
     #[test]
     fn test() {
         let env = Env::default();
-        let contract_id = Binary::from_array(&env, [0; 32]);
-        env.register_contract(contract_id.clone(), HelloContract);
+        let contract_id = FixedBinary::from_array(&env, [0; 32]);
+        env.register_contract(&contract_id, HelloContract);
 
-        let (words, count) =
-            __hello::call_internal(&env, &contract_id, &Recipient::World.into_val(&env));
+        let (words, count) = hello::invoke(&env, &contract_id, &Recipient::World.into_val(&env));
         assert_eq!(
             words,
             vec![&env, Symbol::from_str("Hello"), Symbol::from_str("World")]
         );
         assert_eq!(count, 1);
 
-        let (words, count) =
-            __hello::call_internal(&env, &contract_id, &Recipient::World.into_val(&env));
+        let (words, count) = hello::invoke(&env, &contract_id, &Recipient::World.into_val(&env));
         assert_eq!(
             words,
             vec![&env, Symbol::from_str("Hello"), Symbol::from_str("World")]
         );
         assert_eq!(count, 2);
 
-        let (words, count) = __hello::call_internal(
+        let (words, count) = hello::invoke(
             &env,
             &contract_id,
             &Recipient::Person(Person {

--- a/liquidity_pool/Cargo.toml
+++ b/liquidity_pool/Cargo.toml
@@ -15,12 +15,9 @@ testutils = ["soroban-sdk/testutils", "soroban-token-contract/testutils", "dep:e
 [dependencies]
 ed25519-dalek = { version = "1.0.1", optional = true }
 sha2 = { version = "0.10.2", optional = true }
-soroban-token-contract = { git = "https://github.com/stellar/rs-stellar-token-contract", rev = "d0f6b11", default-features = false  }
-# soroban-token-contract = { git = "https://github.com/stellar/soroban-token-contract", rev = "d0f6b11", default-features = false  }
+soroban-token-contract = { git = "https://github.com/stellar/soroban-token-contract", rev = "46463cc", default-features = false  }
 # soroban-token-contract = { path = "../../soroban-token-contract", default-features = false  }
-soroban-sdk = { git = "https://github.com/stellar/rs-stellar-contract-sdk", rev = "7e3422e" }
-# switch to this once the repos are renamed
-# soroban-sdk = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "7e3422e" }
+soroban-sdk = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "9d77da8" }
 # soroban-sdk = { path = "../../rs-soroban-sdk/sdk" }
 stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr", rev = "94e01c7b", features = ["next", "std"], optional = true }
 

--- a/liquidity_pool/src/lib.rs
+++ b/liquidity_pool/src/lib.rs
@@ -8,7 +8,7 @@ pub mod testutils;
 mod token_contract;
 
 use crate::token_contract::create_contract;
-use soroban_sdk::{contractimpl, BigInt, Binary, Env, IntoVal, RawVal};
+use soroban_sdk::{contractimpl, BigInt, Binary, Env, FixedBinary, IntoVal, RawVal};
 use soroban_token_contract as token;
 use token::public_types::{Authorization, Identifier, KeyedAuthorization, U256};
 
@@ -33,15 +33,15 @@ fn get_contract_id(e: &Env) -> Identifier {
     Identifier::Contract(e.get_current_contract().into())
 }
 
-fn get_token_a(e: &Env) -> Binary {
+fn get_token_a(e: &Env) -> FixedBinary<32> {
     e.contract_data().get(DataKey::TokenA)
 }
 
-fn get_token_b(e: &Env) -> Binary {
+fn get_token_b(e: &Env) -> FixedBinary<32> {
     e.contract_data().get(DataKey::TokenB)
 }
 
-fn get_token_share(e: &Env) -> Binary {
+fn get_token_share(e: &Env) -> FixedBinary<32> {
     e.contract_data().get(DataKey::TokenShare)
 }
 
@@ -57,7 +57,7 @@ fn get_reserve_b(e: &Env) -> BigInt {
     e.contract_data().get(DataKey::ReserveB)
 }
 
-fn get_balance(e: &Env, contract_id: Binary) -> BigInt {
+fn get_balance(e: &Env, contract_id: FixedBinary<32>) -> BigInt {
     token::balance(e, &contract_id, &get_contract_id(e))
 }
 
@@ -123,7 +123,7 @@ fn mint_shares(e: &Env, to: Identifier, amount: BigInt) {
     put_total_shares(e, total + amount);
 }
 
-fn transfer(e: &Env, contract_id: Binary, to: Identifier, amount: BigInt) {
+fn transfer(e: &Env, contract_id: FixedBinary<32>, to: Identifier, amount: BigInt) {
     token::xfer(e, &contract_id, &KeyedAuthorization::Contract, &to, &amount);
 }
 
@@ -138,7 +138,7 @@ fn transfer_b(e: &Env, to: Identifier, amount: BigInt) {
 pub trait LiquidityPoolTrait {
     fn initialize(e: Env, token_a: U256, token_b: U256);
 
-    fn share_id(e: Env) -> Binary;
+    fn share_id(e: Env) -> FixedBinary<32>;
 
     fn deposit(e: Env, to: Identifier);
 
@@ -174,7 +174,7 @@ impl LiquidityPoolTrait for LiquidityPool {
         put_reserve_b(&e, BigInt::from_u32(&e, 0));
     }
 
-    fn share_id(e: Env) -> Binary {
+    fn share_id(e: Env) -> FixedBinary<32> {
         get_token_share(&e)
     }
 

--- a/liquidity_pool/src/test.rs
+++ b/liquidity_pool/src/test.rs
@@ -3,7 +3,7 @@
 use crate::testutils::{register_test_contract as register_liqpool, LiquidityPool};
 use ed25519_dalek::Keypair;
 use rand::{thread_rng, RngCore};
-use soroban_sdk::{BigInt, Binary, Env, FixedBinary};
+use soroban_sdk::{BigInt, Env, FixedBinary};
 use soroban_token_contract::public_types::Identifier;
 use soroban_token_contract::testutils::{
     register_test_contract as register_token, to_ed25519, Token,
@@ -51,14 +51,6 @@ fn create_liqpool_contract(
     (id, liqpool)
 }
 
-fn contract_id_to_array(contract_id: Binary) -> [u8; 32] {
-    let mut res: [u8; 32] = Default::default();
-    for (i, b) in contract_id.into_iter().enumerate() {
-        res[i] = b;
-    }
-    res
-}
-
 #[test]
 fn test() {
     let e: Env = Default::default();
@@ -73,7 +65,7 @@ fn test() {
     let token2 = create_token_contract(&e, &contract2, &admin2);
     let (contract_pool, liqpool) = create_liqpool_contract(&e, &contract1, &contract2);
     let pool_id = Identifier::Contract(FixedBinary::from_array(&e, contract_pool));
-    let contract_share = contract_id_to_array(liqpool.share_id());
+    let contract_share: [u8; 32] = liqpool.share_id().try_into().unwrap(); // TODO: This should be just into
     let token_share = Token::new(&e, &contract_share);
 
     token1.mint(&admin1, &user1_id, &BigInt::from_u32(&e, 1000));

--- a/liquidity_pool/src/testutils.rs
+++ b/liquidity_pool/src/testutils.rs
@@ -1,29 +1,29 @@
 #![cfg(feature = "testutils")]
 
-use soroban_sdk::{BigInt, Binary, Env, FixedBinary};
+use soroban_sdk::{BigInt, Env, FixedBinary};
 use soroban_token_contract::public_types::Identifier;
 
 pub fn register_test_contract(e: &Env, contract_id: &[u8; 32]) {
-    let contract_id = Binary::from_array(e, *contract_id);
-    e.register_contract(contract_id, crate::LiquidityPool {});
+    let contract_id = FixedBinary::from_array(e, *contract_id);
+    e.register_contract(&contract_id, crate::LiquidityPool {});
 }
 
-pub use crate::__deposit::call_internal as deposit;
-pub use crate::__initialize::call_internal as initialize;
-pub use crate::__share_id::call_internal as share_id;
-pub use crate::__swap::call_internal as swap;
-pub use crate::__withdraw::call_internal as withdraw;
+pub use crate::deposit::invoke as deposit;
+pub use crate::initialize::invoke as initialize;
+pub use crate::share_id::invoke as share_id;
+pub use crate::swap::invoke as swap;
+pub use crate::withdraw::invoke as withdraw;
 
 pub struct LiquidityPool {
     env: Env,
-    contract_id: Binary,
+    contract_id: FixedBinary<32>,
 }
 
 impl LiquidityPool {
     pub fn new(env: &Env, contract_id: &[u8; 32]) -> Self {
         Self {
             env: env.clone(),
-            contract_id: Binary::from_slice(env, contract_id),
+            contract_id: FixedBinary::from_array(env, *contract_id),
         }
     }
 
@@ -33,7 +33,7 @@ impl LiquidityPool {
         initialize(&self.env, &self.contract_id, &token_a, &token_b)
     }
 
-    pub fn share_id(&self) -> Binary {
+    pub fn share_id(&self) -> FixedBinary<32> {
         share_id(&self.env, &self.contract_id)
     }
 

--- a/liquidity_pool/src/token_contract.rs
+++ b/liquidity_pool/src/token_contract.rs
@@ -26,22 +26,10 @@ pub fn create_contract(e: &Env, token_a: &U256, token_b: &U256) -> FixedBinary<3
         let mut salt_bin = Binary::new(&e);
         salt_bin.append(&token_a.clone().into());
         salt_bin.append(&token_b.clone().into());
-        let salt_bin = e.compute_hash_sha256(salt_bin);
-        let mut salt_bytes: [u8; 32] = Default::default();
-        for i in 0..salt_bin.len() {
-            salt_bytes[i as usize] = salt_bin.get(i).unwrap();
-        }
-        Uint256(salt_bytes)
+        Uint256(e.compute_hash_sha256(salt_bin).try_into().unwrap()) // TODO: Should be into
     };
 
-    let contract_id = {
-        let contract_id_bin = e.get_current_contract();
-        let mut contract_id_bytes: [u8; 32] = Default::default();
-        for i in 0..contract_id_bin.len() {
-            contract_id_bytes[i as usize] = contract_id_bin.get(i).unwrap();
-        }
-        Hash(contract_id_bytes)
-    };
+    let contract_id = Hash(e.get_current_contract().try_into().unwrap()); // TODO: Should be into
 
     let new_contract_id = {
         let pre_image =

--- a/liquidity_pool/src/token_contract.rs
+++ b/liquidity_pool/src/token_contract.rs
@@ -5,13 +5,13 @@ use soroban_token_contract::public_types::U256;
 pub const TOKEN_CONTRACT: &[u8] = include_bytes!("../../wasm/soroban_token_contract.wasm");
 
 #[cfg(not(feature = "testutils"))]
-pub fn create_contract(e: &Env, token_a: &U256, token_b: &U256) -> FixedBinary {
+pub fn create_contract(e: &Env, token_a: &U256, token_b: &U256) -> FixedBinary<32> {
     let bin = Binary::from_slice(e, TOKEN_CONTRACT);
     let mut salt = Binary::new(&e);
     salt.append(&token_a.clone().into());
     salt.append(&token_b.clone().into());
     let salt = e.compute_hash_sha256(salt);
-    e.create_contract_from_contract(bin, salt).into()
+    e.create_contract_from_contract(bin.try_into().unwrap(), salt.into()).into() // TODO: The arguments to create_contract_from_contract should not need conversions
 }
 
 #[cfg(feature = "testutils")]

--- a/liquidity_pool/src/token_contract.rs
+++ b/liquidity_pool/src/token_contract.rs
@@ -1,23 +1,23 @@
-use soroban_sdk::{Binary, Env};
+use soroban_sdk::{Binary, Env, FixedBinary};
 use soroban_token_contract::public_types::U256;
 
 #[cfg(not(feature = "testutils"))]
 pub const TOKEN_CONTRACT: &[u8] = include_bytes!("../../wasm/soroban_token_contract.wasm");
 
 #[cfg(not(feature = "testutils"))]
-pub fn create_contract(e: &Env, token_a: &U256, token_b: &U256) -> Binary {
+pub fn create_contract(e: &Env, token_a: &U256, token_b: &U256) -> FixedBinary {
     let bin = Binary::from_slice(e, TOKEN_CONTRACT);
     let mut salt = Binary::new(&e);
     salt.append(&token_a.clone().into());
     salt.append(&token_b.clone().into());
-    salt = e.compute_hash_sha256(salt);
+    let salt = e.compute_hash_sha256(salt);
     e.create_contract_from_contract(bin, salt).into()
 }
 
 #[cfg(feature = "testutils")]
 use soroban_sdk::IntoVal;
 #[cfg(feature = "testutils")]
-pub fn create_contract(e: &Env, token_a: &U256, token_b: &U256) -> Binary {
+pub fn create_contract(e: &Env, token_a: &U256, token_b: &U256) -> FixedBinary<32> {
     use sha2::{Digest, Sha256};
     use std::vec::Vec;
     use stellar_xdr::{Hash, HashIdPreimage, HashIdPreimageContractId, Uint256, WriteXdr};
@@ -26,7 +26,7 @@ pub fn create_contract(e: &Env, token_a: &U256, token_b: &U256) -> Binary {
         let mut salt_bin = Binary::new(&e);
         salt_bin.append(&token_a.clone().into());
         salt_bin.append(&token_b.clone().into());
-        salt_bin = e.compute_hash_sha256(salt_bin);
+        let salt_bin = e.compute_hash_sha256(salt_bin);
         let mut salt_bytes: [u8; 32] = Default::default();
         for i in 0..salt_bin.len() {
             salt_bytes[i as usize] = salt_bin.get(i).unwrap();
@@ -52,5 +52,5 @@ pub fn create_contract(e: &Env, token_a: &U256, token_b: &U256) -> Binary {
     };
 
     soroban_token_contract::testutils::register_test_contract(e, &new_contract_id);
-    Binary::from_array(e, new_contract_id)
+    FixedBinary::from_array(e, new_contract_id)
 }

--- a/liquidity_pool/src/token_contract.rs
+++ b/liquidity_pool/src/token_contract.rs
@@ -11,7 +11,8 @@ pub fn create_contract(e: &Env, token_a: &U256, token_b: &U256) -> FixedBinary<3
     salt.append(&token_a.clone().into());
     salt.append(&token_b.clone().into());
     let salt = e.compute_hash_sha256(salt);
-    e.create_contract_from_contract(bin.try_into().unwrap(), salt.into()).into() // TODO: The arguments to create_contract_from_contract should not need conversions
+    e.create_contract_from_contract(bin.try_into().unwrap(), salt.into())
+        .into() // TODO: The arguments to create_contract_from_contract should not need conversions
 }
 
 #[cfg(feature = "testutils")]

--- a/single_offer/Cargo.toml
+++ b/single_offer/Cargo.toml
@@ -14,13 +14,9 @@ testutils = ["soroban-sdk/testutils", "soroban-token-contract/testutils", "dep:e
 
 [dependencies]
 ed25519-dalek = { version = "1.0.1", optional = true }
-soroban-token-contract = { git = "https://github.com/stellar/rs-stellar-token-contract", rev = "d0f6b11", default-features = false  }
-# switch to this once the repos are renamed
-# soroban-token-contract = { git = "https://github.com/stellar/soroban-token-contract", rev = "d0f6b11", default-features = false  }
+soroban-token-contract = { git = "https://github.com/stellar/soroban-token-contract", rev = "46463cc", default-features = false  }
 # soroban-token-contract = { path = "../../soroban-token-contract", default-features = false  }
-soroban-sdk = { git = "https://github.com/stellar/rs-stellar-contract-sdk", rev = "7e3422e" }
-# switch to this once the repos are renamed
-# soroban-sdk = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "7e3422e" }
+soroban-sdk = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "9d77da8" }
 # soroban-sdk = { path = "../../rs-soroban-sdk/sdk" }
 
 [dev_dependencies]

--- a/single_offer/src/cryptography.rs
+++ b/single_offer/src/cryptography.rs
@@ -44,7 +44,7 @@ fn check_ed25519_auth(
     };
     let msg_bin = Message::V0(msg).serialize(e);
 
-    e.verify_sig_ed25519(auth.signature.into(), auth.public_key.into(), msg_bin);
+    e.verify_sig_ed25519(auth.public_key.into(), msg_bin, auth.signature.into());
 }
 
 fn check_account_auth(
@@ -76,9 +76,9 @@ fn check_account_auth(
         }
 
         e.verify_sig_ed25519(
-            sig.signature.into(),
             sig.public_key.clone().into(),
             msg_bin.clone(),
+            sig.signature.into(),
         );
         // TODO: Check for overflow
         weight += account.signer_weight(&sig.public_key);

--- a/single_offer/src/lib.rs
+++ b/single_offer/src/lib.rs
@@ -7,7 +7,7 @@ mod cryptography;
 mod test;
 pub mod testutils;
 
-use soroban_sdk::{contractimpl, contracttype, vec, BigInt, Binary, Env, IntoVal, RawVal};
+use soroban_sdk::{contractimpl, contracttype, vec, BigInt, Env, FixedBinary, IntoVal, RawVal};
 use soroban_token_contract as token;
 use token::public_types::{
     Authorization, Identifier, KeyedAccountAuthorization, KeyedAuthorization,
@@ -43,15 +43,15 @@ fn get_contract_id(e: &Env) -> Identifier {
     Identifier::Contract(e.get_current_contract().into())
 }
 
-fn get_sell_token(e: &Env) -> Binary {
+fn get_sell_token(e: &Env) -> FixedBinary<32> {
     e.contract_data().get(DataKey::SellToken)
 }
 
-fn get_buy_token(e: &Env) -> Binary {
+fn get_buy_token(e: &Env) -> FixedBinary<32> {
     e.contract_data().get(DataKey::BuyToken)
 }
 
-fn get_balance(e: &Env, contract_id: Binary) -> BigInt {
+fn get_balance(e: &Env, contract_id: FixedBinary<32>) -> BigInt {
     token::balance(e, &contract_id, &get_contract_id(e))
 }
 
@@ -75,7 +75,7 @@ fn get_price(e: &Env) -> Price {
     e.contract_data().get(DataKey::Price)
 }
 
-fn transfer(e: &Env, contract_id: Binary, to: Identifier, amount: BigInt) {
+fn transfer(e: &Env, contract_id: FixedBinary<32>, to: Identifier, amount: BigInt) {
     token::xfer(e, &contract_id, &KeyedAuthorization::Contract, &to, &amount);
 }
 

--- a/single_offer/src/testutils.rs
+++ b/single_offer/src/testutils.rs
@@ -4,31 +4,31 @@ use crate::cryptography::Domain;
 use crate::Price;
 use ed25519_dalek::Keypair;
 use soroban_sdk::testutils::ed25519::Sign;
-use soroban_sdk::{BigInt, Binary, Env, EnvVal, FixedBinary, IntoVal, Vec};
+use soroban_sdk::{BigInt, Env, EnvVal, FixedBinary, IntoVal, Vec};
 use soroban_token_contract::public_types::{Authorization, Identifier, Message, MessageV0};
 
 pub fn register_test_contract(e: &Env, contract_id: &[u8; 32]) {
-    let contract_id = Binary::from_array(e, *contract_id);
-    e.register_contract(contract_id, crate::SingleOffer {});
+    let contract_id = FixedBinary::from_array(e, *contract_id);
+    e.register_contract(&contract_id, crate::SingleOffer {});
 }
 
-pub use crate::__get_price::call_internal as get_price;
-pub use crate::__initialize::call_internal as initialize;
-pub use crate::__nonce::call_internal as nonce;
-pub use crate::__trade::call_internal as trade;
-pub use crate::__updt_price::call_internal as updt_price;
-pub use crate::__withdraw::call_internal as withdraw;
+pub use crate::get_price::invoke as get_price;
+pub use crate::initialize::invoke as initialize;
+pub use crate::nonce::invoke as nonce;
+pub use crate::trade::invoke as trade;
+pub use crate::updt_price::invoke as updt_price;
+pub use crate::withdraw::invoke as withdraw;
 
 pub struct SingleOffer {
     env: Env,
-    contract_id: Binary,
+    contract_id: FixedBinary<32>,
 }
 
 impl SingleOffer {
     pub fn new(env: &Env, contract_id: &[u8; 32]) -> Self {
         Self {
             env: env.clone(),
-            contract_id: Binary::from_slice(env, contract_id),
+            contract_id: FixedBinary::from_array(env, *contract_id),
         }
     }
 


### PR DESCRIPTION
### What

Bumps dependencies, making binary interfaces more uniform.

### Why

General tidiness.

### Known limitations

Left a few TODO's with text containing "be info" and "just info" that can be fixed when we bump dependencies to https://github.com/stellar/rs-soroban-sdk/pull/372. The error in `create_contract_from_contract` also introduced a TODO, see 9a1f2a3.