### PR TITLE
Add optimized release profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,13 @@ members = [
     "liquidity_pool",
     "single_offer",
 ]
+
+[profile.release]
+opt-level = "z"
+overflow-checks = true
+debug = 0
+strip = "symbols"
+debug-assertions = false
+panic = "abort"
+codegen-units = 1
+lto = true


### PR DESCRIPTION
### What
Add optimized release profile that removes debuginfo and other things.

### Why
There are several reasons.

1. The .wasm files are huge without running with this.
2. Not running with this modified profile causes rustc nightly to do something differently with the link section containing the env interface. What's unique about that link section is it is inserted by the SDK. There might be a bug in rustc nightly, or maybe it is a bug that's been fixed and in a few weeks we'll find the env interface version no longer being populated in certain situations. We'll keep an eye on it.