### PR TITLE
Set crates.io versions of dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,12 +39,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "base64"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
-
-[[package]]
 name = "bitmaps"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -444,20 +438,6 @@ name = "serde"
 version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc855a42c7967b7c369eb5860f7164ef1f6f81c20c7cc1141f2a604e18723b03"
-dependencies = [
- "serde_derive",
-]
-
-[[package]]
-name = "serde_derive"
-version = "1.0.140"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f2122636b9fe3b81f1cb25099fcf2d3f542cdb1d45940d56c713158884a05da"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "sha2"
@@ -509,18 +489,20 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-common"
-version = "0.0.0"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=36a5007#36a5007611ab095f7821bef00d3fae2953c9ad47"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f2a07a2f4c8f684b5e0bc1013937339300d6c8112b76c6c46bbefc47bdd5905"
 dependencies = [
  "soroban-env-macros",
  "static_assertions",
- "stellar-xdr 0.0.0 (git+https://github.com/stellar/rs-stellar-xdr?rev=94e01c7b)",
+ "stellar-xdr",
 ]
 
 [[package]]
 name = "soroban-env-guest"
-version = "0.0.0"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=36a5007#36a5007611ab095f7821bef00d3fae2953c9ad47"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b23a935c79be02a5ef0d0d069427caa14d3464c22659366683dc6f7a52fcc4d0"
 dependencies = [
  "soroban-env-common",
  "static_assertions",
@@ -528,8 +510,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-host"
-version = "0.0.0"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=36a5007#36a5007611ab095f7821bef00d3fae2953c9ad47"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "958d9ab7dde5088d1609fff47ce4822b8d0fcbe33f6a51dea5ffae30063b4d4b"
 dependencies = [
  "backtrace",
  "dyn-fmt",
@@ -549,12 +532,13 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-macros"
-version = "0.0.0"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=36a5007#36a5007611ab095f7821bef00d3fae2953c9ad47"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e07a8cf5452fce96ce19df1ba6874e6f92b2dc64302c71aa8460349c08cedc"
 dependencies = [
  "proc-macro2",
  "quote",
- "stellar-xdr 0.0.0 (git+https://github.com/stellar/rs-stellar-xdr?rev=540ed24e)",
+ "stellar-xdr",
  "syn",
 ]
 
@@ -584,31 +568,33 @@ dependencies = [
  "soroban-liquidity-pool-contract",
  "soroban-sdk",
  "soroban-token-contract",
- "stellar-xdr 0.0.0 (git+https://github.com/stellar/rs-stellar-xdr?rev=94e01c7b)",
+ "stellar-xdr",
 ]
 
 [[package]]
-name = "soroban-macros"
-version = "0.0.0"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=32b76650#32b76650ca806f74390010d3779f00a0e2d9c376"
+name = "soroban-sdk"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d04fbc12245a6c5796961ee873de3cf40736025da39e40f950330d190229469"
+dependencies = [
+ "ed25519-dalek",
+ "soroban-env-guest",
+ "soroban-env-host",
+ "soroban-sdk-macros",
+]
+
+[[package]]
+name = "soroban-sdk-macros"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "618d5edb62ffe6c4290b2c71f1ad9cef40b1087ffc391811f3adcb722538b8ad"
 dependencies = [
  "darling",
  "itertools",
  "proc-macro2",
  "quote",
- "stellar-xdr 0.0.0 (git+https://github.com/stellar/rs-stellar-xdr?rev=94e01c7b)",
+ "stellar-xdr",
  "syn",
-]
-
-[[package]]
-name = "soroban-sdk"
-version = "0.0.0"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=32b76650#32b76650ca806f74390010d3779f00a0e2d9c376"
-dependencies = [
- "ed25519-dalek",
- "soroban-env-guest",
- "soroban-env-host",
- "soroban-macros",
 ]
 
 [[package]]
@@ -624,8 +610,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-token-contract"
-version = "0.0.0"
-source = "git+https://github.com/stellar/soroban-token-contract?rev=a1e9ed0#a1e9ed05eb46fc81d93b03a13dd5cbf8659a7875"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7094d7bbac749618a83f1ec08a3c220d680ab80160046d9f3912e124d97c1096"
 dependencies = [
  "ed25519-dalek",
  "soroban-sdk",
@@ -639,17 +626,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stellar-xdr"
-version = "0.0.0"
-source = "git+https://github.com/stellar/rs-stellar-xdr?rev=540ed24e#540ed24edc66b5301459ed3269129670160e51e0"
-dependencies = [
- "base64",
- "serde",
-]
-
-[[package]]
-name = "stellar-xdr"
-version = "0.0.0"
-source = "git+https://github.com/stellar/rs-stellar-xdr?rev=94e01c7b#94e01c7bbb3622e12907e1ceb95ab85f4e55e085"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "015594b09942b9f9cbe6972ba8c7de3a05a25c4994bbc7282f5f2fa6d28a81c4"
 
 [[package]]
 name = "strsim"

--- a/custom_types/Cargo.toml
+++ b/custom_types/Cargo.toml
@@ -16,7 +16,7 @@ export = []
 testutils = ["soroban-sdk/testutils"]
 
 [dependencies]
-soroban-sdk = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "32b76650" }
+soroban-sdk = "0.0.3"
 
 [dev_dependencies]
 soroban-custom-types-contract = { path = ".", default-features = false, features = ["testutils"] }

--- a/hello_world/Cargo.toml
+++ b/hello_world/Cargo.toml
@@ -16,7 +16,7 @@ export = []
 testutils = ["soroban-sdk/testutils"]
 
 [dependencies]
-soroban-sdk = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "32b76650" }
+soroban-sdk = "0.0.3"
 
 [dev_dependencies]
 soroban-hello-world-contract = { path = ".", default-features = false, features = ["testutils"] }

--- a/increment/Cargo.toml
+++ b/increment/Cargo.toml
@@ -16,7 +16,7 @@ export = []
 testutils = ["soroban-sdk/testutils"]
 
 [dependencies]
-soroban-sdk = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "32b76650" }
+soroban-sdk = "0.0.3"
 
 [dev_dependencies]
 soroban-increment-contract = { path = ".", default-features = false, features = ["testutils"] }

--- a/liquidity_pool/Cargo.toml
+++ b/liquidity_pool/Cargo.toml
@@ -13,12 +13,12 @@ export = []
 testutils = ["soroban-sdk/testutils", "soroban-token-contract/testutils", "dep:ed25519-dalek", "dep:sha2", "dep:stellar-xdr"]
 
 [dependencies]
+soroban-sdk = "0.0.3"
+soroban-token-contract = { version = "0.0.2", default-features = false  }
+stellar-xdr = { version = "0.0.1", features = ["next", "std"], optional = true }
 ed25519-dalek = { version = "1.0.1", optional = true }
 sha2 = { version = "0.10.2", optional = true }
-soroban-token-contract = { git = "https://github.com/stellar/soroban-token-contract", rev = "a1e9ed0", default-features = false  }
-soroban-sdk = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "32b76650" }
-stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr", rev = "94e01c7b", features = ["next", "std"], optional = true }
 
 [dev_dependencies]
-rand = { version = "0.7.3" }
 soroban-liquidity-pool-contract = { path = ".", default-features = false, features = ["testutils"] }
+rand = { version = "0.7.3" }

--- a/single_offer/Cargo.toml
+++ b/single_offer/Cargo.toml
@@ -13,10 +13,10 @@ export = []
 testutils = ["soroban-sdk/testutils", "soroban-token-contract/testutils", "dep:ed25519-dalek"]
 
 [dependencies]
+soroban-sdk = "0.0.3"
+soroban-token-contract = { version = "0.0.2", default-features = false  }
 ed25519-dalek = { version = "1.0.1", optional = true }
-soroban-token-contract = { git = "https://github.com/stellar/soroban-token-contract", rev = "a1e9ed0", default-features = false  }
-soroban-sdk = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "32b76650" }
 
 [dev_dependencies]
-rand = { version = "0.7.3" }
 soroban-single-offer-contract = { path = ".", default-features = false, features = ["testutils"] }
+rand = { version = "0.7.3" }


### PR DESCRIPTION
### What
Set crates.io versions of dependencies.

### Why
It is pretty important for the developer experience that when developers check out these examples that they are locked only to a released SDK. For that reason it is important no `patch` entries or `git` URLs are present.