### PR TITLE
Make it possible to test using the token contract WASM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,6 +170,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "downcast-rs"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
+
+[[package]]
 name = "dyn-fmt"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -279,6 +285,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
+name = "libm"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da83a57f3f5ba3680950aa3cbc806fc297bc0b289d42e8942ed528ace71b8145"
+
+[[package]]
 name = "log"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -292,6 +304,12 @@ name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
+name = "memory_units"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8452105ba047068f40ff7093dd1d9da90898e63dd61736462e9cdda6a90ad3c3"
 
 [[package]]
 name = "miniz_oxide"
@@ -324,6 +342,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-rational"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
+dependencies = [
+ "autocfg",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -346,6 +376,12 @@ name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
+name = "parity-wasm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be5e13c266502aadf83426d87d81a0f5d1ef45b8027f5a471c360abfe4bfae92"
 
 [[package]]
 name = "ppv-lite86"
@@ -502,6 +538,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f2a07a2f4c8f684b5e0bc1013937339300d6c8112b76c6c46bbefc47bdd5905"
 dependencies = [
  "soroban-env-macros",
+ "soroban-wasmi",
  "static_assertions",
  "stellar-xdr",
 ]
@@ -531,8 +568,10 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "num-traits",
+ "parity-wasm",
  "sha2 0.10.2",
  "soroban-env-common",
+ "soroban-wasmi",
  "static_assertions",
  "thiserror",
  "tinyvec",
@@ -573,6 +612,7 @@ dependencies = [
  "ed25519-dalek",
  "rand",
  "sha2 0.10.2",
+ "soroban-env-host",
  "soroban-liquidity-pool-contract",
  "soroban-sdk",
  "soroban-token-contract",
@@ -624,6 +664,40 @@ checksum = "7094d7bbac749618a83f1ec08a3c220d680ab80160046d9f3912e124d97c1096"
 dependencies = [
  "ed25519-dalek",
  "soroban-sdk",
+]
+
+[[package]]
+name = "soroban-wasmi"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ba96c441aa5a924f5d59114b43b2f8eab4ebbf7041dbf1c38fbae04620cb518"
+dependencies = [
+ "parity-wasm",
+ "soroban-wasmi-validation",
+ "soroban-wasmi_core",
+]
+
+[[package]]
+name = "soroban-wasmi-validation"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8983fe9f704b4f4c171ac02de77fcc85cba9fd65ad951e381525a8d6b58c374b"
+dependencies = [
+ "parity-wasm",
+]
+
+[[package]]
+name = "soroban-wasmi_core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0db272b8e5d09022d701f74b58994710587cd7d5d7c4b1f00376a141edfbded"
+dependencies = [
+ "downcast-rs",
+ "libm",
+ "memory_units",
+ "num-rational",
+ "num-traits",
+ "parity-wasm",
 ]
 
 [[package]]

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ export RUSTFLAGS=-Dwarnings
 
 test: fmt
 	cargo test
+	cd liquidity_pool && cargo test --features testutils,token-wasm
 
 build: fmt
 	cargo build --target wasm32-unknown-unknown --release

--- a/liquidity_pool/Cargo.toml
+++ b/liquidity_pool/Cargo.toml
@@ -11,6 +11,7 @@ crate-type = ["cdylib", "rlib"]
 default = ["export"]
 export = []
 testutils = ["soroban-sdk/testutils", "soroban-token-contract/testutils", "dep:ed25519-dalek", "dep:sha2", "dep:stellar-xdr"]
+token-wasm = ["soroban-env-host/vm"]
 
 [dependencies]
 soroban-sdk = "0.0.3"
@@ -20,5 +21,6 @@ ed25519-dalek = { version = "1.0.1", optional = true }
 sha2 = { version = "0.10.2", optional = true }
 
 [dev_dependencies]
+soroban-env-host = { version = "0.0.3" }
 soroban-liquidity-pool-contract = { path = ".", default-features = false, features = ["testutils"] }
 rand = { version = "0.7.3" }

--- a/liquidity_pool/src/token_contract.rs
+++ b/liquidity_pool/src/token_contract.rs
@@ -1,10 +1,10 @@
 use soroban_sdk::{Binary, Env, FixedBinary};
 use soroban_token_contract::public_types::U256;
 
-#[cfg(not(feature = "testutils"))]
+#[cfg(any(not(feature = "testutils"), feature = "token-wasm"))]
 pub const TOKEN_CONTRACT: &[u8] = include_bytes!("../../soroban_token_contract.wasm");
 
-#[cfg(not(feature = "testutils"))]
+#[cfg(any(not(feature = "testutils"), feature = "token-wasm"))]
 pub fn create_contract(e: &Env, token_a: &U256, token_b: &U256) -> FixedBinary<32> {
     let bin = Binary::from_slice(e, TOKEN_CONTRACT);
     let mut salt = Binary::new(&e);
@@ -14,11 +14,10 @@ pub fn create_contract(e: &Env, token_a: &U256, token_b: &U256) -> FixedBinary<3
     e.create_contract_from_contract(bin, salt)
 }
 
-#[cfg(feature = "testutils")]
-use soroban_sdk::IntoVal;
-#[cfg(feature = "testutils")]
+#[cfg(all(feature = "testutils", not(feature = "token-wasm")))]
 pub fn create_contract(e: &Env, token_a: &U256, token_b: &U256) -> FixedBinary<32> {
     use sha2::{Digest, Sha256};
+    use soroban_sdk::IntoVal;
     use std::vec::Vec;
     use stellar_xdr::{Hash, HashIdPreimage, HashIdPreimageContractId, Uint256, WriteXdr};
 


### PR DESCRIPTION
### What

Adds new feature "token-wasm" that enables using the WASM. Adds a new line to Makefile to actually run this test.

### Why

Resolves #29.

### Known limitations

Doesn't pass tests right now because the WASM itself doesn't work.