### PR TITLE
Run CI on dev branch

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,7 +2,7 @@ name: Rust
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
   pull_request:
 
 env:


### PR DESCRIPTION
### What

Run CI on `dev`.

### Why

Allow us to safely continue with development on `dev` without interfering with people learning from `main`.

### Known limitations

N/A