### PR TITLE
Remove self-circular testutils deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -519,7 +519,6 @@ dependencies = [
 name = "soroban-cross-contract-calls-contract"
 version = "0.0.0"
 dependencies = [
- "soroban-cross-contract-calls-contract",
  "soroban-sdk",
 ]
 
@@ -527,7 +526,6 @@ dependencies = [
 name = "soroban-custom-types-contract"
 version = "0.0.0"
 dependencies = [
- "soroban-custom-types-contract",
  "soroban-sdk",
 ]
 
@@ -592,7 +590,6 @@ dependencies = [
 name = "soroban-hello-world-contract"
 version = "0.0.0"
 dependencies = [
- "soroban-hello-world-contract",
  "soroban-sdk",
 ]
 
@@ -600,7 +597,6 @@ dependencies = [
 name = "soroban-increment-contract"
 version = "0.0.0"
 dependencies = [
- "soroban-increment-contract",
  "soroban-sdk",
 ]
 
@@ -612,7 +608,6 @@ dependencies = [
  "rand",
  "sha2 0.10.2",
  "soroban-env-host",
- "soroban-liquidity-pool-contract",
  "soroban-sdk",
  "soroban-token-contract",
  "stellar-xdr",
@@ -650,7 +645,6 @@ dependencies = [
  "ed25519-dalek",
  "rand",
  "soroban-sdk",
- "soroban-single-offer-contract",
  "soroban-token-contract",
 ]
 
@@ -661,7 +655,6 @@ dependencies = [
  "ed25519-dalek",
  "rand",
  "soroban-sdk",
- "soroban-single-offer-contract-xfer-from",
  "soroban-token-contract",
 ]
 

--- a/cross_contract_calls/Cargo.toml
+++ b/cross_contract_calls/Cargo.toml
@@ -19,4 +19,4 @@ testutils = ["soroban-sdk/testutils"]
 soroban-sdk = "0.0.3"
 
 [dev_dependencies]
-soroban-cross-contract-calls-contract = { path = ".", default-features = false, features = ["testutils"] }
+soroban-sdk = { version = "0.0.3", features = ["testutils"] }

--- a/cross_contract_calls/src/lib.rs
+++ b/cross_contract_calls/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
 
-mod a;
-mod b;
+pub mod a;
+pub mod b;
 mod test;

--- a/custom_types/Cargo.toml
+++ b/custom_types/Cargo.toml
@@ -19,4 +19,4 @@ testutils = ["soroban-sdk/testutils"]
 soroban-sdk = "0.0.3"
 
 [dev_dependencies]
-soroban-custom-types-contract = { path = ".", default-features = false, features = ["testutils"] }
+soroban-sdk = { version = "0.0.3", features = ["testutils"] }

--- a/hello_world/Cargo.toml
+++ b/hello_world/Cargo.toml
@@ -19,4 +19,4 @@ testutils = ["soroban-sdk/testutils"]
 soroban-sdk = "0.0.3"
 
 [dev_dependencies]
-soroban-hello-world-contract = { path = ".", default-features = false, features = ["testutils"] }
+soroban-sdk = { version = "0.0.3", features = ["testutils"] }

--- a/increment/Cargo.toml
+++ b/increment/Cargo.toml
@@ -19,4 +19,4 @@ testutils = ["soroban-sdk/testutils"]
 soroban-sdk = "0.0.3"
 
 [dev_dependencies]
-soroban-increment-contract = { path = ".", default-features = false, features = ["testutils"] }
+soroban-sdk = { version = "0.0.3", features = ["testutils"] }

--- a/liquidity_pool/Cargo.toml
+++ b/liquidity_pool/Cargo.toml
@@ -15,7 +15,7 @@ token-wasm = ["soroban-env-host/vm"]
 
 [dependencies]
 soroban-sdk = "0.0.3"
-soroban-token-contract = { version = "0.0.2", default-features = false  }
+soroban-token-contract = { version = "0.0.2", default-features = false }
 stellar-xdr = { version = "0.0.1", features = ["next", "std"], optional = true }
 ed25519-dalek = { version = "1.0.1", optional = true }
 sha2 = { version = "0.10.2", optional = true }
@@ -23,4 +23,8 @@ sha2 = { version = "0.10.2", optional = true }
 [dev_dependencies]
 soroban-env-host = { version = "0.0.3" }
 soroban-sdk = { version = "0.0.3", features = ["testutils"] }
+soroban-token-contract = { version = "0.0.2", default-features = false, features = ["testutils"] }
+stellar-xdr = { version = "0.0.1", features = ["next", "std"] }
+ed25519-dalek = { version = "1.0.1" }
+sha2 = { version = "0.10.2" }
 rand = { version = "0.7.3" }

--- a/liquidity_pool/Cargo.toml
+++ b/liquidity_pool/Cargo.toml
@@ -22,5 +22,5 @@ sha2 = { version = "0.10.2", optional = true }
 
 [dev_dependencies]
 soroban-env-host = { version = "0.0.3" }
-soroban-liquidity-pool-contract = { path = ".", default-features = false, features = ["testutils"] }
+soroban-sdk = { version = "0.0.3", features = ["testutils"] }
 rand = { version = "0.7.3" }

--- a/liquidity_pool/src/lib.rs
+++ b/liquidity_pool/src/lib.rs
@@ -1,8 +1,5 @@
 #![no_std]
 
-#[cfg(feature = "testutils")]
-extern crate std;
-
 mod test;
 pub mod testutils;
 mod token_contract;

--- a/liquidity_pool/src/testutils.rs
+++ b/liquidity_pool/src/testutils.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "testutils")]
+#![cfg(any(test, feature = "testutils"))]
 
 use soroban_sdk::{BigInt, Env, FixedBinary};
 use soroban_token_contract::public_types::Identifier;

--- a/liquidity_pool/src/token_contract.rs
+++ b/liquidity_pool/src/token_contract.rs
@@ -1,10 +1,10 @@
 use soroban_sdk::{Binary, Env, FixedBinary};
 use soroban_token_contract::public_types::U256;
 
-#[cfg(any(not(feature = "testutils"), feature = "token-wasm"))]
+#[cfg(any(not(any(test, feature = "testutils")), feature = "token-wasm"))]
 pub const TOKEN_CONTRACT: &[u8] = include_bytes!("../../soroban_token_contract.wasm");
 
-#[cfg(any(not(feature = "testutils"), feature = "token-wasm"))]
+#[cfg(any(not(any(test, feature = "testutils")), feature = "token-wasm"))]
 pub fn create_contract(e: &Env, token_a: &U256, token_b: &U256) -> FixedBinary<32> {
     let bin = Binary::from_slice(e, TOKEN_CONTRACT);
     let mut salt = Binary::new(&e);
@@ -14,7 +14,10 @@ pub fn create_contract(e: &Env, token_a: &U256, token_b: &U256) -> FixedBinary<3
     e.create_contract_from_contract(bin, salt)
 }
 
-#[cfg(all(feature = "testutils", not(feature = "token-wasm")))]
+#[cfg(all(any(test, feature = "testutils"), not(feature = "token-wasm")))]
+extern crate std;
+
+#[cfg(all(any(test, feature = "testutils"), not(feature = "token-wasm")))]
 pub fn create_contract(e: &Env, token_a: &U256, token_b: &U256) -> FixedBinary<32> {
     use sha2::{Digest, Sha256};
     use soroban_sdk::IntoVal;

--- a/liquidity_pool/src/token_contract.rs
+++ b/liquidity_pool/src/token_contract.rs
@@ -1,10 +1,11 @@
+#![allow(unused)]
 use soroban_sdk::{Binary, Env, FixedBinary};
 use soroban_token_contract::public_types::U256;
 
-#[cfg(any(not(any(test, feature = "testutils")), feature = "token-wasm"))]
+#[cfg(not(all(any(test, feature = "testutils"), not(feature = "token-wasm"))))]
 pub const TOKEN_CONTRACT: &[u8] = include_bytes!("../../soroban_token_contract.wasm");
 
-#[cfg(any(not(any(test, feature = "testutils")), feature = "token-wasm"))]
+#[cfg(not(all(any(test, feature = "testutils"), not(feature = "token-wasm"))))]
 pub fn create_contract(e: &Env, token_a: &U256, token_b: &U256) -> FixedBinary<32> {
     let bin = Binary::from_slice(e, TOKEN_CONTRACT);
     let mut salt = Binary::new(&e);

--- a/liquidity_pool/src/token_contract.rs
+++ b/liquidity_pool/src/token_contract.rs
@@ -2,6 +2,18 @@
 use soroban_sdk::{Binary, Env, FixedBinary};
 use soroban_token_contract::public_types::U256;
 
+// Creating the token contract happens a couple different ways depending on the
+// situation:
+//
+// In tests, or when imported with testutils, without the token-wasm
+// feature, we use the imported token contract library and register it manually
+// as a test contract.
+//
+// In tests, when token-wasm feature is enabled, we use the embedded token wasm
+// file.
+//
+// Outside of tests and testutils, we use the embedded token wasm file.
+
 #[cfg(not(all(any(test, feature = "testutils"), not(feature = "token-wasm"))))]
 pub const TOKEN_CONTRACT: &[u8] = include_bytes!("../../soroban_token_contract.wasm");
 

--- a/single_offer/Cargo.toml
+++ b/single_offer/Cargo.toml
@@ -14,9 +14,11 @@ testutils = ["soroban-sdk/testutils", "soroban-token-contract/testutils", "dep:e
 
 [dependencies]
 soroban-sdk = "0.0.3"
-soroban-token-contract = { version = "0.0.2", default-features = false  }
+soroban-token-contract = { version = "0.0.2", default-features = false }
 ed25519-dalek = { version = "1.0.1", optional = true }
 
 [dev_dependencies]
 soroban-sdk = { version = "0.0.3", features = ["testutils"] }
+soroban-token-contract = { version = "0.0.2", default-features = false, features = ["testutils"] }
+ed25519-dalek = { version = "1.0.1" }
 rand = { version = "0.7.3" }

--- a/single_offer/Cargo.toml
+++ b/single_offer/Cargo.toml
@@ -18,5 +18,5 @@ soroban-token-contract = { version = "0.0.2", default-features = false  }
 ed25519-dalek = { version = "1.0.1", optional = true }
 
 [dev_dependencies]
-soroban-single-offer-contract = { path = ".", default-features = false, features = ["testutils"] }
+soroban-sdk = { version = "0.0.3", features = ["testutils"] }
 rand = { version = "0.7.3" }

--- a/single_offer/src/testutils.rs
+++ b/single_offer/src/testutils.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "testutils")]
+#![cfg(any(test, feature = "testutils"))]
 
 use crate::cryptography::Domain;
 use crate::Price;

--- a/single_offer_xfer_from/Cargo.toml
+++ b/single_offer_xfer_from/Cargo.toml
@@ -19,4 +19,6 @@ ed25519-dalek = { version = "1.0.1", optional = true }
 
 [dev_dependencies]
 soroban-sdk = { version = "0.0.3", features = ["testutils"] }
+soroban-token-contract = { version = "0.0.2", default-features = false, features = ["testutils"] }
+ed25519-dalek = { version = "1.0.1" }
 rand = { version = "0.7.3" }

--- a/single_offer_xfer_from/Cargo.toml
+++ b/single_offer_xfer_from/Cargo.toml
@@ -18,5 +18,5 @@ soroban-token-contract = { version = "0.0.2", default-features = false  }
 ed25519-dalek = { version = "1.0.1", optional = true }
 
 [dev_dependencies]
-soroban-single-offer-contract-xfer-from = { path = ".", default-features = false, features = ["testutils"] }
+soroban-sdk = { version = "0.0.3", features = ["testutils"] }
 rand = { version = "0.7.3" }

--- a/single_offer_xfer_from/src/testutils.rs
+++ b/single_offer_xfer_from/src/testutils.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "testutils")]
+#![cfg(any(test, feature = "testutils"))]
 
 use crate::cryptography::Domain;
 use crate::Price;


### PR DESCRIPTION
### What
Remove self-circular testutils dev dependencies.

### Why

It causes errors in rust-analyzer which doesn't expect the circular reference. It is also reasonably confusing to others because (e.g. @graydon had questions about it) and requires a decent amount of discussion to knowledge share why it exists.

The circular reference was added to activate things that are gated behind `testutils` feature, so that those things are always activated during tests. However, Rust provides a built-in way for us to do this today, without needing the circular reference. All we need to do is use the `#[cfg(test)]` attribute. If we have items that need to be testutils for externals and we want them to always be activated within the crates own tests, then we can use `#[cfg(any(test, feature = "testutils"))]`. We already use this pattern in the SDK macros for any `testutils`.

See https://github.com/stellar/rs-soroban-sdk/pull/401