### PR TITLE
Simple authorization example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -516,6 +516,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "soroban-authorization-contract"
+version = "0.0.0"
+dependencies = [
+ "ed25519-dalek",
+ "rand",
+ "soroban-authorization-contract",
+ "soroban-sdk",
+]
+
+[[package]]
 name = "soroban-cross-contract-calls-contract"
 version = "0.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 
 members = [
+    "authorization",
     "hello_world",
     "increment",
     "custom_types",

--- a/authorization/Cargo.toml
+++ b/authorization/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "soroban-authorization-contract"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[features]
+default = ["export"]
+export = []
+testutils = ["soroban-sdk/testutils", "dep:ed25519-dalek"]
+
+[dependencies]
+soroban-sdk = "0.0.3"
+ed25519-dalek = { version = "1.0.1", optional = true }
+
+[dev_dependencies]
+soroban-authorization-contract = { path = ".", default-features = false, features = ["testutils"] }
+rand = { version = "0.7.3" }

--- a/authorization/src/cryptography.rs
+++ b/authorization/src/cryptography.rs
@@ -1,0 +1,101 @@
+use soroban_sdk::{serde::Serialize, Account, BigInt, Env, EnvVal};
+
+use crate::{
+    public_types::{
+        Identifier, KeyedAccountAuthorization, KeyedAuthorization, KeyedEd25519Signature, Message,
+        MessageV0, U256,
+    },
+    DataKey,
+};
+
+// Nonce management
+pub fn read_nonce(e: &Env, id: Identifier) -> BigInt {
+    let key = DataKey::Nonce(id);
+    if let Some(nonce) = e.contract_data().get(key) {
+        nonce.unwrap()
+    } else {
+        BigInt::zero(e)
+    }
+}
+
+pub fn read_and_increment_nonce(e: &Env, id: Identifier) -> BigInt {
+    let key = DataKey::Nonce(id.clone());
+    let nonce = read_nonce(e, id);
+    e.contract_data()
+        .set(key, nonce.clone() + BigInt::from_u32(e, 1));
+    nonce
+}
+
+#[repr(u32)]
+pub enum Domain {
+    SaveData = 0,
+}
+
+fn check_ed25519_auth(e: &Env, auth: &KeyedEd25519Signature, domain: Domain, parameters: EnvVal) {
+    let msg = MessageV0 {
+        nonce: read_and_increment_nonce(&e, Identifier::Ed25519(auth.public_key.clone())),
+        domain: domain as u32,
+        parameters: parameters.try_into().unwrap(),
+    };
+    let msg_bin = Message::V0(msg).serialize(e);
+
+    e.verify_sig_ed25519(
+        auth.public_key.clone().into(),
+        msg_bin,
+        auth.signature.clone().into(),
+    );
+}
+
+fn check_account_auth(
+    e: &Env,
+    auth: &KeyedAccountAuthorization,
+    domain: Domain,
+    parameters: EnvVal,
+) {
+    let acc = Account::from_public_key(&auth.public_key).unwrap();
+
+    let msg = MessageV0 {
+        nonce: read_and_increment_nonce(&e, Identifier::Account(auth.clone().public_key)),
+        domain: domain as u32,
+        parameters: parameters.try_into().unwrap(),
+    };
+    let msg_bin = Message::V0(msg).serialize(e);
+
+    let threshold = acc.medium_threshold();
+    let mut weight = 0u32;
+
+    let sigs = &auth.signatures;
+    let mut prev_pk: Option<U256> = None;
+    for sig in sigs.iter().map(Result::unwrap) {
+        // Cannot take multiple signatures from the same key
+        if let Some(prev) = prev_pk {
+            if prev >= sig.public_key {
+                panic!("signature out of order")
+            }
+        }
+
+        e.verify_sig_ed25519(
+            sig.public_key.clone().into(),
+            msg_bin.clone(),
+            sig.signature.into(),
+        );
+        // TODO: Check for overflow
+        weight += acc.signer_weight(&sig.public_key);
+
+        prev_pk = Some(sig.public_key);
+    }
+
+    if weight < threshold {
+        panic!("insufficient signing weight")
+    }
+}
+
+pub fn check_auth(e: &Env, auth: &KeyedAuthorization, domain: Domain, parameters: EnvVal) {
+    match auth {
+        KeyedAuthorization::Contract => {
+            e.get_invoking_contract();
+        }
+        KeyedAuthorization::Ed25519(kea) => check_ed25519_auth(e, kea, domain, parameters),
+        KeyedAuthorization::Account(kaa) => check_account_auth(e, kaa, domain, parameters),
+    }
+}

--- a/authorization/src/lib.rs
+++ b/authorization/src/lib.rs
@@ -8,7 +8,7 @@ mod public_types;
 mod test;
 
 use public_types::{Identifier, KeyedAuthorization};
-use soroban_sdk::{contractimpl, contracttype, BigInt, Env, IntoVal};
+use soroban_sdk::{contractimpl, contracttype, BigInt, Env, IntoVal, Symbol};
 
 #[derive(Clone)]
 #[contracttype]
@@ -27,7 +27,7 @@ impl AuthContract {
             &e,
             &auth,
             nonce.clone(),
-            cryptography::Domain::SaveData,
+            Symbol::from_str("save_data"),
             (nonce, num.clone()).into_val(&e),
         );
 

--- a/authorization/src/lib.rs
+++ b/authorization/src/lib.rs
@@ -1,0 +1,39 @@
+#![no_std]
+
+#[cfg(feature = "testutils")]
+extern crate std;
+
+mod cryptography;
+mod public_types;
+mod test;
+
+use public_types::{Identifier, KeyedAuthorization};
+use soroban_sdk::{contractimpl, contracttype, BigInt, Env, IntoVal};
+
+#[derive(Clone)]
+#[contracttype]
+pub enum DataKey {
+    Acc(Identifier),
+    Nonce(Identifier),
+}
+
+pub struct AuthContract;
+
+#[contractimpl(export_if = "export")]
+impl AuthContract {
+    pub fn save_data(e: Env, auth: KeyedAuthorization, num: BigInt) {
+        cryptography::check_auth(
+            &e,
+            &auth,
+            cryptography::Domain::SaveData,
+            (vec![&e, num]).into_val(&e),
+        );
+
+        let auth_id = auth.get_identifier(&e);
+        e.contract_data().set(DataKey::Acc(auth_id), num);
+    }
+
+    pub fn nonce(e: Env, to: Identifier) -> BigInt {
+        cryptography::read_nonce(&e, to)
+    }
+}

--- a/authorization/src/lib.rs
+++ b/authorization/src/lib.rs
@@ -21,12 +21,14 @@ pub struct AuthContract;
 
 #[contractimpl(export_if = "export")]
 impl AuthContract {
-    pub fn save_data(e: Env, auth: KeyedAuthorization, num: BigInt) {
+    // Saves data that corresponds to an Identifier, with that Identifiers authorization
+    pub fn save_data(e: Env, auth: KeyedAuthorization, nonce: BigInt, num: BigInt) {
         cryptography::check_auth(
             &e,
             &auth,
+            nonce.clone(),
             cryptography::Domain::SaveData,
-            (vec![&e, num]).into_val(&e),
+            (nonce, num.clone()).into_val(&e),
         );
 
         let auth_id = auth.get_identifier(&e);

--- a/authorization/src/public_types.rs
+++ b/authorization/src/public_types.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{contracttype, Env, EnvVal, FixedBinary, Vec};
+use soroban_sdk::{contracttype, Env, EnvVal, FixedBinary, Symbol, Vec};
 
 pub type U256 = FixedBinary<32>;
 pub type U512 = FixedBinary<64>;
@@ -57,7 +57,7 @@ pub enum Identifier {
 #[derive(Clone)]
 #[contracttype]
 pub struct MessageV0 {
-    pub domain: u32,
+    pub function: Symbol,
     pub parameters: Vec<EnvVal>,
 }
 

--- a/authorization/src/public_types.rs
+++ b/authorization/src/public_types.rs
@@ -1,0 +1,69 @@
+use soroban_sdk::{contracttype, BigInt, Env, EnvVal, FixedBinary, Vec};
+
+pub type U256 = FixedBinary<32>;
+pub type U512 = FixedBinary<64>;
+
+#[derive(Clone)]
+#[contracttype]
+pub struct KeyedEd25519Signature {
+    pub public_key: U256,
+    pub signature: U512,
+}
+
+pub type AccountAuthorization = Vec<KeyedEd25519Signature>;
+
+#[derive(Clone)]
+#[contracttype]
+pub struct KeyedAccountAuthorization {
+    pub public_key: U256,
+    pub signatures: AccountAuthorization,
+}
+
+#[derive(Clone)]
+#[contracttype]
+pub enum Authorization {
+    Contract,
+    Ed25519(U512),
+    Account(AccountAuthorization),
+}
+
+#[derive(Clone)]
+#[contracttype]
+pub enum KeyedAuthorization {
+    Contract,
+    Ed25519(KeyedEd25519Signature),
+    Account(KeyedAccountAuthorization),
+}
+
+impl KeyedAuthorization {
+    pub fn get_identifier(&self, env: &Env) -> Identifier {
+        match self {
+            KeyedAuthorization::Contract => Identifier::Contract(env.get_invoking_contract()),
+            KeyedAuthorization::Ed25519(kea) => Identifier::Ed25519(kea.public_key.clone()),
+            KeyedAuthorization::Account(kaa) => Identifier::Account(kaa.public_key.clone()),
+        }
+    }
+}
+
+#[derive(Clone)]
+#[contracttype]
+pub enum Identifier {
+    Contract(U256),
+    Ed25519(U256),
+    Account(U256),
+}
+
+// TODO: This is missing fields
+#[derive(Clone)]
+#[contracttype]
+pub struct MessageV0 {
+    pub nonce: BigInt,
+    pub domain: u32,
+    pub parameters: Vec<EnvVal>,
+}
+
+#[derive(Clone)]
+#[contracttype]
+pub enum Message {
+    V0(MessageV0),
+}

--- a/authorization/src/public_types.rs
+++ b/authorization/src/public_types.rs
@@ -1,7 +1,7 @@
-use soroban_sdk::{contracttype, Env, EnvVal, FixedBinary, Symbol, Vec};
+use soroban_sdk::{contracttype, BytesN, Env, EnvVal, Symbol, Vec};
 
-pub type U256 = FixedBinary<32>;
-pub type U512 = FixedBinary<64>;
+pub type U256 = BytesN<32>;
+pub type U512 = BytesN<64>;
 
 #[derive(Clone)]
 #[contracttype]

--- a/authorization/src/public_types.rs
+++ b/authorization/src/public_types.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{contracttype, BigInt, Env, EnvVal, FixedBinary, Vec};
+use soroban_sdk::{contracttype, Env, EnvVal, FixedBinary, Vec};
 
 pub type U256 = FixedBinary<32>;
 pub type U512 = FixedBinary<64>;
@@ -57,7 +57,6 @@ pub enum Identifier {
 #[derive(Clone)]
 #[contracttype]
 pub struct MessageV0 {
-    pub nonce: BigInt,
     pub domain: u32,
     pub parameters: Vec<EnvVal>,
 }

--- a/authorization/src/test.rs
+++ b/authorization/src/test.rs
@@ -23,7 +23,7 @@ fn make_auth(e: &Env, kp: &Keypair, nonce: &BigInt, data: &BigInt) -> KeyedAutho
     args.push(data.clone().into_env_val(&e));
 
     let msg = Message::V0(MessageV0 {
-        domain: cryptography::Domain::SaveData as u32,
+        function: Symbol::from_str("save_data"),
         parameters: args,
     });
     KeyedAuthorization::Ed25519(KeyedEd25519Signature {
@@ -43,5 +43,21 @@ fn test() {
 
     let nonce = nonce::invoke(&env, &contract_id, &to_ed25519(&env, &user1));
     let auth = make_auth(&env, &user1, &nonce, &data);
+    save_data::invoke(&env, &contract_id, &auth, &nonce, &data)
+}
+
+#[test]
+#[should_panic(expected = "Failed ED25519 verification")]
+fn bad_data() {
+    let env = Env::default();
+    let contract_id = FixedBinary::from_array(&env, [0; 32]);
+    env.register_contract(&contract_id, AuthContract);
+
+    let user1 = generate_keypair();
+    let signed_data = BigInt::from_u32(&env, 1);
+    let data = BigInt::from_u32(&env, 2);
+
+    let nonce = nonce::invoke(&env, &contract_id, &to_ed25519(&env, &user1));
+    let auth = make_auth(&env, &user1, &nonce, &signed_data);
     save_data::invoke(&env, &contract_id, &auth, &nonce, &data)
 }

--- a/authorization/src/test.rs
+++ b/authorization/src/test.rs
@@ -7,7 +7,7 @@ use ed25519_dalek::Keypair;
 use rand::thread_rng;
 use soroban_sdk::testutils::ed25519::Sign;
 
-use soroban_sdk::{Env, EnvVal, FixedBinary, Vec};
+use soroban_sdk::{BytesN, Env, EnvVal, Vec};
 
 pub fn to_ed25519(e: &Env, kp: &Keypair) -> Identifier {
     Identifier::Ed25519(kp.public.to_bytes().into_val(e))
@@ -27,7 +27,7 @@ fn make_auth(e: &Env, kp: &Keypair, nonce: &BigInt, data: &BigInt) -> KeyedAutho
         parameters: args,
     });
     KeyedAuthorization::Ed25519(KeyedEd25519Signature {
-        public_key: FixedBinary::from_array(&e, kp.public.to_bytes()),
+        public_key: BytesN::from_array(&e, kp.public.to_bytes()),
         signature: kp.sign(msg).unwrap().into_val(e),
     })
 }
@@ -35,7 +35,7 @@ fn make_auth(e: &Env, kp: &Keypair, nonce: &BigInt, data: &BigInt) -> KeyedAutho
 #[test]
 fn test() {
     let env = Env::default();
-    let contract_id = FixedBinary::from_array(&env, [0; 32]);
+    let contract_id = BytesN::from_array(&env, [0; 32]);
     env.register_contract(&contract_id, AuthContract);
 
     let user1 = generate_keypair();
@@ -50,7 +50,7 @@ fn test() {
 #[should_panic(expected = "Failed ED25519 verification")]
 fn bad_data() {
     let env = Env::default();
-    let contract_id = FixedBinary::from_array(&env, [0; 32]);
+    let contract_id = BytesN::from_array(&env, [0; 32]);
     env.register_contract(&contract_id, AuthContract);
 
     let user1 = generate_keypair();

--- a/authorization/src/test.rs
+++ b/authorization/src/test.rs
@@ -1,0 +1,47 @@
+#![cfg(test)]
+
+use crate::public_types::{KeyedEd25519Signature, Message, MessageV0, U256};
+
+use super::*;
+use ed25519_dalek::Keypair;
+use rand::thread_rng;
+use soroban_sdk::testutils::ed25519::Sign;
+
+use soroban_sdk::{Env, EnvVal, FixedBinary, Vec};
+
+pub fn to_ed25519(e: &Env, kp: &Keypair) -> Identifier {
+    Identifier::Ed25519(kp.public.to_bytes().into_val(e))
+}
+
+fn generate_keypair() -> Keypair {
+    Keypair::generate(&mut thread_rng())
+}
+
+fn make_auth(e: &Env, contract_id: &U256, kp: &Keypair, data: &BigInt) -> KeyedAuthorization {
+    let id = to_ed25519(&e, &kp);
+
+    let mut args: Vec<EnvVal> = Vec::new(&e);
+    args.push(data.clone().into_env_val(&e));
+    let msg = Message::V0(MessageV0 {
+        nonce: nonce::invoke(&e, &contract_id, &id),
+        domain: cryptography::Domain::SaveData as u32,
+        parameters: args,
+    });
+    KeyedAuthorization::Ed25519(KeyedEd25519Signature {
+        public_key: FixedBinary::from_array(&e, kp.public.to_bytes()),
+        signature: kp.sign(msg).unwrap().into_val(e),
+    })
+}
+
+#[test]
+fn test() {
+    let env = Env::default();
+    let contract_id = FixedBinary::from_array(&env, [0; 32]);
+    env.register_contract(&contract_id, AuthContract);
+
+    let user1 = generate_keypair();
+    let data = BigInt::from_u32(&env, 2);
+
+    let auth = make_auth(&env, &contract_id, &user1, &data);
+    save_data::invoke(&env, &contract_id, &auth, &data)
+}


### PR DESCRIPTION
Resolves https://github.com/stellar/soroban-examples/issues/58, and does both https://github.com/stellar/stellar-protocol/issues/1287 and https://github.com/stellar/soroban-token-contract/issues/81 for this contract.

The nonce change is a little awkward because `KeyedAuthorization::Contract` doesn't use one. The nonce passed into the contract function in that case can be anything.
