### PR TITLE
Check if rust-analyzer can parse project

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,7 +12,7 @@ jobs:
 
   complete:
     if: always()
-    needs: [fmt, build-and-test]
+    needs: [fmt, rust-analyzer-compat, build-and-test]
     runs-on: ubuntu-latest
     steps:
     - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
@@ -24,6 +24,15 @@ jobs:
     - uses: actions/checkout@v3
     - run: rustup update
     - run: cargo fmt --all --check
+
+  rust-analyzer-compat:
+     runs-on: ubuntu-latest
+     steps:
+     - uses: actions/checkout@v3
+     - run: rustup update
+     - run: rustup +nightly component add rust-analyzer
+     - name: Check if rust-analyzer encounters any errors parsing project
+       run: rustup run nightly rust-analyzer analysis-stats . 2>&1 | (! grep ERROR)
 
   build-and-test:
     strategy:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -543,7 +543,6 @@ version = "0.0.0"
 dependencies = [
  "ed25519-dalek",
  "rand",
- "soroban-authorization-contract",
  "soroban-sdk",
  "soroban-sdk-auth",
 ]
@@ -654,7 +653,6 @@ dependencies = [
  "rand",
  "sha2 0.10.2",
  "soroban-liquidity-pool-contract",
- "soroban-liquidity-pool-router-contract",
  "soroban-sdk",
  "soroban-sdk-auth",
  "soroban-token-contract",
@@ -739,7 +737,6 @@ dependencies = [
  "soroban-sdk",
  "soroban-sdk-auth",
  "soroban-single-offer-contract",
- "soroban-single-offer-router-contract",
  "soroban-token-contract",
  "stellar-xdr",
 ]

--- a/authorization/Cargo.toml
+++ b/authorization/Cargo.toml
@@ -18,5 +18,7 @@ soroban-sdk-auth = "0.0.0"
 ed25519-dalek = { version = "1.0.1", optional = true }
 
 [dev_dependencies]
-soroban-authorization-contract = { path = ".", default-features = false, features = ["testutils"] }
+soroban-sdk = { version = "0.0.3", features = ["testutils"] }
+soroban-sdk-auth = { version = "0.0.0", features = ["testutils"] }
+ed25519-dalek = { version = "1.0.1" }
 rand = { version = "0.7.3" }

--- a/liquidity_pool_router/Cargo.toml
+++ b/liquidity_pool_router/Cargo.toml
@@ -15,12 +15,18 @@ testutils = ["soroban-sdk/testutils", "soroban-token-contract/testutils","soroba
 [dependencies]
 soroban-sdk = "0.0.3"
 soroban-sdk-auth = "0.0.0"
-soroban-token-contract = { version = "0.0.2", default-features = false  }
-soroban-liquidity-pool-contract = { path = "../liquidity_pool", version = "0.0.0", default-features = false  }
+soroban-token-contract = { version = "0.0.2", default-features = false }
+soroban-liquidity-pool-contract = { path = "../liquidity_pool", version = "0.0.0", default-features = false }
 ed25519-dalek = { version = "1.0.1", optional = true }
 stellar-xdr = { version = "0.0.1", features = ["next", "std"], optional = true }
 sha2 = { version = "0.10.2", optional = true }
 
 [dev_dependencies]
-soroban-liquidity-pool-router-contract = { path = ".", default-features = false, features = ["testutils"] }
+soroban-sdk = { version = "0.0.3", features = ["testutils"] }
+soroban-sdk-auth = { version = "0.0.0", features = ["testutils"] }
+soroban-token-contract = { version = "0.0.2", default-features = false, features = ["testutils"] }
+soroban-liquidity-pool-contract = { path = "../liquidity_pool", version = "0.0.0", default-features = false, features = ["testutils"] }
+stellar-xdr = { version = "0.0.1", features = ["next", "std"] }
+ed25519-dalek = { version = "1.0.1" }
+sha2 = { version = "0.10.2" }
 rand = { version = "0.7.3" }

--- a/liquidity_pool_router/src/lib.rs
+++ b/liquidity_pool_router/src/lib.rs
@@ -1,6 +1,6 @@
 #![no_std]
 
-#[cfg(feature = "testutils")]
+#[cfg(any(test, feature = "testutils"))]
 extern crate std;
 
 mod pool_contract;

--- a/liquidity_pool_router/src/pool_contract.rs
+++ b/liquidity_pool_router/src/pool_contract.rs
@@ -1,16 +1,16 @@
 use soroban_sdk::{BytesN, Env};
 
-#[cfg(any(not(feature = "testutils"), feature = "offer-wasm"))]
+#[cfg(not(all(any(test, feature = "testutils"), not(feature = "token-wasm"))))]
 pub const POOL_CONTRACT: &[u8] = include_bytes!("../../soroban_liquidity_pool_contract.wasm");
 
-#[cfg(any(not(feature = "testutils"), feature = "offer-wasm"))]
+#[cfg(not(all(any(test, feature = "testutils"), not(feature = "token-wasm"))))]
 pub fn create_contract(e: &Env, salt: &BytesN<32>) -> BytesN<32> {
     use soroban_sdk::Bytes;
     let bin = Bytes::from_slice(e, POOL_CONTRACT);
     e.create_contract_from_contract(bin, salt.clone())
 }
 
-#[cfg(all(feature = "testutils", not(feature = "token-wasm")))]
+#[cfg(all(any(test, feature = "testutils"), not(feature = "token-wasm")))]
 pub fn create_contract(e: &Env, salt: &BytesN<32>) -> BytesN<32> {
     use sha2::{Digest, Sha256};
     use stellar_xdr::{Hash, HashIdPreimage, HashIdPreimageContractId, Uint256, WriteXdr};

--- a/liquidity_pool_router/src/testutils.rs
+++ b/liquidity_pool_router/src/testutils.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "testutils")]
+#![cfg(any(test, feature = "testutils"))]
 use soroban_sdk::{BigInt, BytesN, Env};
 use soroban_sdk_auth::public_types::Identifier;
 

--- a/single_offer_router/Cargo.toml
+++ b/single_offer_router/Cargo.toml
@@ -15,12 +15,18 @@ testutils = ["soroban-sdk/testutils", "soroban-token-contract/testutils","soroba
 [dependencies]
 soroban-sdk = "0.0.3"
 soroban-sdk-auth = "0.0.0"
-soroban-token-contract = { version = "0.0.2", default-features = false  }
-soroban-single-offer-contract = { path = "../single_offer", version = "0.0.0", default-features = false  }
+soroban-token-contract = { version = "0.0.2", default-features = false }
+soroban-single-offer-contract = { path = "../single_offer", version = "0.0.0", default-features = false }
 ed25519-dalek = { version = "1.0.1", optional = true }
 stellar-xdr = { version = "0.0.1", features = ["next", "std"], optional = true }
 sha2 = { version = "0.10.2", optional = true }
 
 [dev_dependencies]
-soroban-single-offer-router-contract = { path = ".", default-features = false, features = ["testutils"] }
+soroban-sdk = { version = "0.0.3", features = ["testutils"] }
+soroban-sdk-auth = { version = "0.0.0", features = ["testutils"] }
+soroban-token-contract = { version = "0.0.2", default-features = false, features = ["testutils"] }
+soroban-single-offer-contract = { path = "../single_offer", version = "0.0.0", default-features = false, features = ["testutils"] }
+stellar-xdr = { version = "0.0.1", features = ["next", "std"] }
+ed25519-dalek = { version = "1.0.1" }
+sha2 = { version = "0.10.2" }
 rand = { version = "0.7.3" }

--- a/single_offer_router/src/lib.rs
+++ b/single_offer_router/src/lib.rs
@@ -1,6 +1,6 @@
 #![no_std]
 
-#[cfg(feature = "testutils")]
+#[cfg(any(test, feature = "testutils"))]
 extern crate std;
 
 mod offer_contract;

--- a/single_offer_router/src/offer_contract.rs
+++ b/single_offer_router/src/offer_contract.rs
@@ -1,16 +1,16 @@
 use soroban_sdk::{BytesN, Env};
 
-#[cfg(any(not(feature = "testutils"), feature = "offer-wasm"))]
+#[cfg(not(all(any(test, feature = "testutils"), not(feature = "token-wasm"))))]
 pub const OFFER_CONTRACT: &[u8] = include_bytes!("../../soroban_single_offer_contract.wasm");
 
-#[cfg(any(not(feature = "testutils"), feature = "offer-wasm"))]
+#[cfg(not(all(any(test, feature = "testutils"), not(feature = "token-wasm"))))]
 pub fn create_contract(e: &Env, salt: &BytesN<32>) -> BytesN<32> {
     use soroban_sdk::Bytes;
     let bin = Bytes::from_slice(e, OFFER_CONTRACT);
     e.create_contract_from_contract(bin, salt.clone())
 }
 
-#[cfg(all(feature = "testutils", not(feature = "token-wasm")))]
+#[cfg(all(any(test, feature = "testutils"), not(feature = "token-wasm")))]
 pub fn create_contract(e: &Env, salt: &BytesN<32>) -> BytesN<32> {
     use sha2::{Digest, Sha256};
     use stellar_xdr::{Hash, HashIdPreimage, HashIdPreimageContractId, Uint256, WriteXdr};

--- a/single_offer_router/src/testutils.rs
+++ b/single_offer_router/src/testutils.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "testutils")]
+#![cfg(any(test, feature = "testutils"))]
 use soroban_sdk::{BigInt, BytesN, Env};
 use soroban_sdk_auth::public_types::Identifier;
 


### PR DESCRIPTION
### What
Add ci job that checks if rust-analyzer can parse project.

### Why
A couple times now we have done things that are technically allowed in Rust but are not supported by rust-analyzer. Everytime we've walked the change back because rust-analyzer compatibility is important for developer productivity. Let's prevent these things from happening by checking if rust-analyzer can parse the project.

Same as https://github.com/stellar/rs-soroban-env/pull/371.
### Known Limitations

This relies on parsing the output of rust-analyzer analysis-status which is not stable, so it may change or break over time (https://github.com/rust-lang/rust-analyzer/issues/13115). We can remove this check if it doesn't live up to its hoped impact.