### PR TITLE
Update soroban-sdk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -721,7 +721,7 @@ dependencies = [
 [[package]]
 name = "soroban-sdk"
 version = "0.0.3"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=0cb632cd#0cb632cd651f380acfb852766b6487419e10665b"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=499c1013#499c10137e5e8561eb8f20fce8c8639c5991ef85"
 dependencies = [
  "bytes-lit",
  "ed25519-dalek",
@@ -733,7 +733,7 @@ dependencies = [
 [[package]]
 name = "soroban-sdk-auth"
 version = "0.0.0"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=0cb632cd#0cb632cd651f380acfb852766b6487419e10665b"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=499c1013#499c10137e5e8561eb8f20fce8c8639c5991ef85"
 dependencies = [
  "soroban-sdk",
 ]
@@ -741,7 +741,7 @@ dependencies = [
 [[package]]
 name = "soroban-sdk-macros"
 version = "0.0.3"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=0cb632cd#0cb632cd651f380acfb852766b6487419e10665b"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=499c1013#499c10137e5e8561eb8f20fce8c8639c5991ef85"
 dependencies = [
  "darling",
  "itertools",
@@ -793,7 +793,7 @@ dependencies = [
 [[package]]
 name = "soroban-spec"
 version = "0.0.1"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=0cb632cd#0cb632cd651f380acfb852766b6487419e10665b"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=499c1013#499c10137e5e8561eb8f20fce8c8639c5991ef85"
 dependencies = [
  "base64",
  "darling",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -613,7 +613,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-common"
 version = "0.0.3"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=73a944a2#73a944a28051c99acb5e4b0ef549d22a75c35bf2"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=16fcb333#16fcb333aab68cdba8711839c325b0010ef7525a"
 dependencies = [
  "soroban-env-macros",
  "soroban-wasmi",
@@ -624,7 +624,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-guest"
 version = "0.0.3"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=73a944a2#73a944a28051c99acb5e4b0ef549d22a75c35bf2"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=16fcb333#16fcb333aab68cdba8711839c325b0010ef7525a"
 dependencies = [
  "soroban-env-common",
  "static_assertions",
@@ -633,7 +633,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-host"
 version = "0.0.3"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=73a944a2#73a944a28051c99acb5e4b0ef549d22a75c35bf2"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=16fcb333#16fcb333aab68cdba8711839c325b0010ef7525a"
 dependencies = [
  "backtrace",
  "dyn-fmt",
@@ -656,7 +656,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-macros"
 version = "0.0.3"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=73a944a2#73a944a28051c99acb5e4b0ef549d22a75c35bf2"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=16fcb333#16fcb333aab68cdba8711839c325b0010ef7525a"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -710,7 +710,7 @@ dependencies = [
 [[package]]
 name = "soroban-native-sdk-macros"
 version = "0.0.1"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=73a944a2#73a944a28051c99acb5e4b0ef549d22a75c35bf2"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=16fcb333#16fcb333aab68cdba8711839c325b0010ef7525a"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -814,7 +814,7 @@ dependencies = [
 [[package]]
 name = "soroban-token-contract"
 version = "0.0.2"
-source = "git+https://github.com/stellar/soroban-token-contract?rev=94040786#940407868e89972e037f5dedeb06a8d3ace50301"
+source = "git+https://github.com/stellar/soroban-token-contract?rev=a1fb93b#a1fb93b64301520aeb99804416c5bb93aa3a2b68"
 dependencies = [
  "ed25519-dalek",
  "soroban-sdk",
@@ -864,7 +864,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "stellar-xdr"
 version = "0.0.1"
-source = "git+https://github.com/stellar/rs-stellar-xdr?rev=5b129da#5b129da05a4b0ad6b1a9e0ce0b7d80f2cc1b0e70"
+source = "git+https://github.com/stellar/rs-stellar-xdr?rev=d0fb666#d0fb66619630c64331a5e496e77fffd91219fb3b"
 dependencies = [
  "base64",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,10 +28,10 @@ lto = true
 soroban-sdk = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "499c1013" }
 soroban-sdk-auth = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "499c1013" }
 soroban-sdk-macros = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "499c1013" }
-soroban-env-common = { git = "https://github.com/stellar/rs-soroban-env", rev = "73a944a2" }
-soroban-env-guest = { git = "https://github.com/stellar/rs-soroban-env", rev = "73a944a2" }
-soroban-env-host = { git = "https://github.com/stellar/rs-soroban-env", rev = "73a944a2" }
-soroban-env-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "73a944a2" }
-soroban-native-sdk-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "73a944a2" }
-stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr", rev = "5b129da" }
-soroban-token-contract = { git = "https://github.com/stellar/soroban-token-contract", rev = "94040786" }
+soroban-env-common = { git = "https://github.com/stellar/rs-soroban-env", rev = "16fcb333" }
+soroban-env-guest = { git = "https://github.com/stellar/rs-soroban-env", rev = "16fcb333" }
+soroban-env-host = { git = "https://github.com/stellar/rs-soroban-env", rev = "16fcb333" }
+soroban-env-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "16fcb333" }
+soroban-native-sdk-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "16fcb333" }
+stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr", rev = "d0fb666" }
+soroban-token-contract = { git = "https://github.com/stellar/soroban-token-contract", rev = "a1fb93b" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,9 +25,9 @@ codegen-units = 1
 lto = true
 
 [patch.crates-io]
-soroban-sdk = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "0cb632cd" }
-soroban-sdk-auth = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "0cb632cd" }
-soroban-sdk-macros = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "0cb632cd" }
+soroban-sdk = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "499c1013" }
+soroban-sdk-auth = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "499c1013" }
+soroban-sdk-macros = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "499c1013" }
 soroban-env-common = { git = "https://github.com/stellar/rs-soroban-env", rev = "73a944a2" }
 soroban-env-guest = { git = "https://github.com/stellar/rs-soroban-env", rev = "73a944a2" }
 soroban-env-host = { git = "https://github.com/stellar/rs-soroban-env", rev = "73a944a2" }

--- a/authorization/src/lib.rs
+++ b/authorization/src/lib.rs
@@ -7,9 +7,7 @@ mod test;
 
 use soroban_sdk::{contractimpl, contracttype, BigInt, Env, IntoVal, Symbol};
 use soroban_sdk_auth::{
-    check_auth,
-    public_types::{Identifier, Signature},
-    NonceAuth,
+    check_auth, NonceAuth, {Identifier, Signature},
 };
 
 #[derive(Clone)]

--- a/authorization/src/test.rs
+++ b/authorization/src/test.rs
@@ -6,7 +6,7 @@ use rand::thread_rng;
 use soroban_sdk::testutils::ed25519::Sign;
 
 use soroban_sdk::{BytesN, Env, RawVal, Vec};
-use soroban_sdk_auth::public_types::{Ed25519Signature, SignaturePayload, SignaturePayloadV0};
+use soroban_sdk_auth::{Ed25519Signature, SignaturePayload, SignaturePayloadV0};
 
 pub fn to_ed25519(e: &Env, kp: &Keypair) -> Identifier {
     Identifier::Ed25519(kp.public.to_bytes().into_val(e))

--- a/liquidity_pool/src/lib.rs
+++ b/liquidity_pool/src/lib.rs
@@ -6,7 +6,7 @@ mod token_contract;
 
 use crate::token_contract::create_contract;
 use soroban_sdk::{contractimpl, BigInt, Bytes, BytesN, Env, IntoVal, RawVal};
-use soroban_sdk_auth::public_types::{Identifier, Signature};
+use soroban_sdk_auth::{Identifier, Signature};
 use soroban_token_contract as token;
 use token::TokenClient;
 

--- a/liquidity_pool/src/test.rs
+++ b/liquidity_pool/src/test.rs
@@ -4,7 +4,7 @@ use crate::testutils::{register_test_contract as register_liqpool, LiquidityPool
 use ed25519_dalek::Keypair;
 use rand::{thread_rng, RngCore};
 use soroban_sdk::{BigInt, BytesN, Env};
-use soroban_sdk_auth::public_types::Identifier;
+use soroban_sdk_auth::Identifier;
 use soroban_token_contract::testutils::{
     register_test_contract as register_token, to_ed25519, Token,
 };

--- a/liquidity_pool/src/testutils.rs
+++ b/liquidity_pool/src/testutils.rs
@@ -1,7 +1,7 @@
 #![cfg(any(test, feature = "testutils"))]
 
 use soroban_sdk::{BigInt, BytesN, Env};
-use soroban_sdk_auth::public_types::Identifier;
+use soroban_sdk_auth::Identifier;
 
 use crate::LiquidityPoolClient;
 

--- a/liquidity_pool_router/src/lib.rs
+++ b/liquidity_pool_router/src/lib.rs
@@ -11,8 +11,8 @@ use liquidity_pool::LiquidityPoolClient;
 use pool_contract::create_contract;
 use soroban_liquidity_pool_contract as liquidity_pool;
 use soroban_sdk::{contractimpl, contracttype, BigInt, Bytes, BytesN, Env, IntoVal, Symbol};
-use soroban_sdk_auth::public_types::{Identifier, Signature};
 use soroban_sdk_auth::{check_auth, NonceAuth};
+use soroban_sdk_auth::{Identifier, Signature};
 use soroban_token_contract as token;
 use token::TokenClient;
 

--- a/liquidity_pool_router/src/test.rs
+++ b/liquidity_pool_router/src/test.rs
@@ -8,7 +8,7 @@ use liquidity_pool::LiquidityPoolClient;
 use rand::{thread_rng, RngCore};
 use soroban_liquidity_pool_contract as liquidity_pool;
 use soroban_sdk::{BigInt, BytesN, Env};
-use soroban_sdk_auth::public_types::Identifier;
+use soroban_sdk_auth::Identifier;
 use soroban_token_contract::testutils::{
     register_test_contract as register_token, to_ed25519, Token,
 };

--- a/liquidity_pool_router/src/testutils.rs
+++ b/liquidity_pool_router/src/testutils.rs
@@ -1,7 +1,7 @@
 #![cfg(any(test, feature = "testutils"))]
 use ed25519_dalek::Keypair;
 use soroban_sdk::{testutils::ed25519::Sign, BigInt, BytesN, Env, IntoVal, RawVal, Symbol, Vec};
-use soroban_sdk_auth::public_types::{
+use soroban_sdk_auth::{
     Ed25519Signature, Identifier, Signature, SignaturePayload, SignaturePayloadV0,
 };
 

--- a/single_offer/src/lib.rs
+++ b/single_offer/src/lib.rs
@@ -8,9 +8,7 @@ pub mod testutils;
 
 use soroban_sdk::{contractimpl, contracttype, BigInt, BytesN, Env, IntoVal, Symbol};
 use soroban_sdk_auth::{
-    check_auth,
-    public_types::{Identifier, Signature},
-    NonceAuth,
+    check_auth, NonceAuth, {Identifier, Signature},
 };
 use soroban_token_contract as token;
 use token::TokenClient;

--- a/single_offer/src/test.rs
+++ b/single_offer/src/test.rs
@@ -4,7 +4,7 @@ use crate::testutils::{register_test_contract as register_single_offer, SingleOf
 use ed25519_dalek::Keypair;
 use rand::{thread_rng, RngCore};
 use soroban_sdk::{BigInt, BytesN, Env};
-use soroban_sdk_auth::public_types::Identifier;
+use soroban_sdk_auth::Identifier;
 use soroban_token_contract::testutils::{
     register_test_contract as register_token, to_ed25519, Token,
 };

--- a/single_offer/src/testutils.rs
+++ b/single_offer/src/testutils.rs
@@ -4,7 +4,7 @@ use crate::{Price, SingleOfferClient};
 use ed25519_dalek::Keypair;
 use soroban_sdk::testutils::ed25519::Sign;
 use soroban_sdk::{BigInt, BytesN, Env, IntoVal, RawVal, Symbol, Vec};
-use soroban_sdk_auth::public_types::{
+use soroban_sdk_auth::{
     Ed25519Signature, Identifier, Signature, SignaturePayload, SignaturePayloadV0,
 };
 

--- a/single_offer_router/src/lib.rs
+++ b/single_offer_router/src/lib.rs
@@ -11,9 +11,7 @@ use offer::SingleOfferClient;
 use offer_contract::create_contract;
 use soroban_sdk::{contractimpl, contracttype, BigInt, Bytes, BytesN, Env, IntoVal, Symbol};
 use soroban_sdk_auth::{
-    check_auth,
-    public_types::{Identifier, Signature},
-    NonceAuth,
+    check_auth, NonceAuth, {Identifier, Signature},
 };
 use soroban_single_offer_contract as offer;
 use soroban_token_contract as token;

--- a/single_offer_router/src/test.rs
+++ b/single_offer_router/src/test.rs
@@ -4,7 +4,7 @@ use crate::testutils::{register_test_contract as register_single_offer_router, S
 use ed25519_dalek::Keypair;
 use rand::{thread_rng, RngCore};
 use soroban_sdk::{BigInt, BytesN, Env};
-use soroban_sdk_auth::public_types::Identifier;
+use soroban_sdk_auth::Identifier;
 use soroban_token_contract::testutils::{
     register_test_contract as register_token, to_ed25519, Token,
 };

--- a/single_offer_router/src/testutils.rs
+++ b/single_offer_router/src/testutils.rs
@@ -2,7 +2,7 @@
 use ed25519_dalek::Keypair;
 use soroban_sdk::testutils::ed25519::Sign;
 use soroban_sdk::{BigInt, BytesN, Env, IntoVal, RawVal, Symbol, Vec};
-use soroban_sdk_auth::public_types::{
+use soroban_sdk_auth::{
     Ed25519Signature, Identifier, Signature, SignaturePayload, SignaturePayloadV0,
 };
 

--- a/single_offer_xfer_from/src/lib.rs
+++ b/single_offer_xfer_from/src/lib.rs
@@ -8,9 +8,7 @@ pub mod testutils;
 
 use soroban_sdk::{contractimpl, contracttype, BigInt, BytesN, Env, IntoVal, Symbol};
 use soroban_sdk_auth::{
-    check_auth,
-    public_types::{Identifier, Signature},
-    NonceAuth,
+    check_auth, NonceAuth, {Identifier, Signature},
 };
 use soroban_token_contract as token;
 use token::TokenClient;

--- a/single_offer_xfer_from/src/test.rs
+++ b/single_offer_xfer_from/src/test.rs
@@ -4,7 +4,7 @@ use crate::testutils::{register_test_contract as register_single_offer, SingleOf
 use ed25519_dalek::Keypair;
 use rand::{thread_rng, RngCore};
 use soroban_sdk::{BigInt, BytesN, Env};
-use soroban_sdk_auth::public_types::Identifier;
+use soroban_sdk_auth::Identifier;
 use soroban_token_contract::testutils::{
     register_test_contract as register_token, to_ed25519, Token,
 };

--- a/single_offer_xfer_from/src/testutils.rs
+++ b/single_offer_xfer_from/src/testutils.rs
@@ -4,7 +4,7 @@ use crate::{Price, SingleOfferXferFromClient};
 use ed25519_dalek::Keypair;
 use soroban_sdk::testutils::ed25519::Sign;
 use soroban_sdk::{BigInt, BytesN, Env, IntoVal, RawVal, Symbol, Vec};
-use soroban_sdk_auth::public_types::{
+use soroban_sdk_auth::{
     Ed25519Signature, Identifier, Signature, SignaturePayload, SignaturePayloadV0,
 };
 


### PR DESCRIPTION
### What
Update soroban-sdk, removing public_types mod from use statements of soroban_auth_sdk.

### Why
The types in the auth SDK were moved into the root of the crate.