### PR TITLE
Use zero nonces

### DIFF
--- a/liquidity_pool/src/lib.rs
+++ b/liquidity_pool/src/lib.rs
@@ -103,7 +103,7 @@ fn burn_shares(e: &Env, amount: BigInt) {
 
     TokenClient::new(&e, share_contract_id).burn(
         &Signature::Contract,
-        &BigInt::from_u32(&e, 0),
+        &BigInt::zero(&e),
         &get_contract_id(e),
         &amount,
     );
@@ -116,7 +116,7 @@ fn mint_shares(e: &Env, to: Identifier, amount: BigInt) {
 
     TokenClient::new(&e, share_contract_id).mint(
         &Signature::Contract,
-        &BigInt::from_u32(&e, 0),
+        &BigInt::zero(&e),
         &to,
         &amount,
     );
@@ -125,12 +125,7 @@ fn mint_shares(e: &Env, to: Identifier, amount: BigInt) {
 }
 
 fn transfer(e: &Env, contract_id: BytesN<32>, to: Identifier, amount: BigInt) {
-    TokenClient::new(&e, contract_id).xfer(
-        &Signature::Contract,
-        &BigInt::from_u32(&e, 0),
-        &to,
-        &amount,
-    );
+    TokenClient::new(&e, contract_id).xfer(&Signature::Contract, &BigInt::zero(&e), &to, &amount);
 }
 
 fn transfer_a(e: &Env, to: Identifier, amount: BigInt) {
@@ -201,9 +196,9 @@ impl LiquidityPoolTrait for LiquidityPool {
         put_token_a(&e, token_a);
         put_token_b(&e, token_b);
         put_token_share(&e, share_contract_id.try_into().unwrap());
-        put_total_shares(&e, BigInt::from_u32(&e, 0));
-        put_reserve_a(&e, BigInt::from_u32(&e, 0));
-        put_reserve_b(&e, BigInt::from_u32(&e, 0));
+        put_total_shares(&e, BigInt::zero(&e));
+        put_reserve_a(&e, BigInt::zero(&e));
+        put_reserve_b(&e, BigInt::zero(&e));
     }
 
     fn share_id(e: Env) -> BytesN<32> {
@@ -215,7 +210,7 @@ impl LiquidityPoolTrait for LiquidityPool {
         let (balance_a, balance_b) = (get_balance_a(&e), get_balance_b(&e));
         let total_shares = get_total_shares(&e);
 
-        let zero = BigInt::from_u32(&e, 0);
+        let zero = BigInt::zero(&e);
         let new_total_shares = if reserve_a > zero.clone() && reserve_b > zero {
             let shares_a = (balance_a.clone() * total_shares.clone()) / reserve_a;
             let shares_b = (balance_b.clone() * total_shares.clone()) / reserve_b;
@@ -237,7 +232,7 @@ impl LiquidityPoolTrait for LiquidityPool {
         // deducting the fee, scaled up by 1000 to avoid fractions
         let residue_numerator = BigInt::from_u32(&e, 997);
         let residue_denominator = BigInt::from_u32(&e, 1000);
-        let zero = BigInt::from_u32(&e, 0);
+        let zero = BigInt::zero(&e);
 
         let new_invariant_factor = |balance: BigInt, reserve: BigInt, out: BigInt| {
             let delta = balance - reserve.clone() - out;

--- a/liquidity_pool/src/test.rs
+++ b/liquidity_pool/src/test.rs
@@ -87,29 +87,25 @@ fn test() {
     assert_eq!(token2.balance(&pool_id), BigInt::from_u32(&e, 100));
     liqpool.deposit(&user1_id);
     assert_eq!(token_share.balance(&user1_id), BigInt::from_u32(&e, 100));
-    assert_eq!(token_share.balance(&pool_id), BigInt::from_u32(&e, 0));
+    assert_eq!(token_share.balance(&pool_id), BigInt::zero(&e));
 
     token1.xfer(&user1, &pool_id, &BigInt::from_u32(&e, 100));
     assert_eq!(token1.balance(&user1_id), BigInt::from_u32(&e, 800));
     assert_eq!(token1.balance(&pool_id), BigInt::from_u32(&e, 200));
-    liqpool.swap(
-        &user1_id,
-        &BigInt::from_u32(&e, 0),
-        &BigInt::from_u32(&e, 49),
-    );
+    liqpool.swap(&user1_id, &BigInt::zero(&e), &BigInt::from_u32(&e, 49));
     assert_eq!(token1.balance(&user1_id), BigInt::from_u32(&e, 800));
     assert_eq!(token1.balance(&pool_id), BigInt::from_u32(&e, 200));
     assert_eq!(token2.balance(&user1_id), BigInt::from_u32(&e, 949));
     assert_eq!(token2.balance(&pool_id), BigInt::from_u32(&e, 51));
 
     token_share.xfer(&user1, &pool_id, &BigInt::from_u32(&e, 100));
-    assert_eq!(token_share.balance(&user1_id), BigInt::from_u32(&e, 0));
+    assert_eq!(token_share.balance(&user1_id), BigInt::zero(&e));
     assert_eq!(token_share.balance(&pool_id), BigInt::from_u32(&e, 100));
     liqpool.withdraw(&user1_id);
     assert_eq!(token1.balance(&user1_id), BigInt::from_u32(&e, 1000));
     assert_eq!(token2.balance(&user1_id), BigInt::from_u32(&e, 1000));
-    assert_eq!(token_share.balance(&user1_id), BigInt::from_u32(&e, 0));
-    assert_eq!(token1.balance(&pool_id), BigInt::from_u32(&e, 0));
-    assert_eq!(token2.balance(&pool_id), BigInt::from_u32(&e, 0));
-    assert_eq!(token_share.balance(&pool_id), BigInt::from_u32(&e, 0));
+    assert_eq!(token_share.balance(&user1_id), BigInt::zero(&e));
+    assert_eq!(token1.balance(&pool_id), BigInt::zero(&e));
+    assert_eq!(token2.balance(&pool_id), BigInt::zero(&e));
+    assert_eq!(token_share.balance(&pool_id), BigInt::zero(&e));
 }

--- a/liquidity_pool_router/src/lib.rs
+++ b/liquidity_pool_router/src/lib.rs
@@ -23,10 +23,6 @@ pub enum DataKey {
     Nonce(Identifier),
 }
 
-fn get_contract_id(e: &Env) -> Identifier {
-    Identifier::Contract(e.get_current_contract().into())
-}
-
 fn get_pool_id(e: &Env, salt: &BytesN<32>) -> BytesN<32> {
     e.contract_data()
         .get_unchecked(DataKey::Pool(salt.clone()))
@@ -202,20 +198,18 @@ impl LiquidityPoolRouterTrait for LiquidityPoolRouter {
         let amounts = get_deposit_amounts(desired_a, min_a, desired_b, min_b, reserves);
 
         let client_a = TokenClient::new(&e, token_a);
-        let nonce_a = client_a.nonce(&get_contract_id(&e));
         client_a.xfer_from(
             &Signature::Contract,
-            &nonce_a,
+            &BigInt::zero(&e),
             &to_id,
             &Identifier::Contract(pool_id.clone()),
             &amounts.0,
         );
 
         let client_b = TokenClient::new(&e, token_b);
-        let nonce_b = client_b.nonce(&get_contract_id(&e));
         client_b.xfer_from(
             &Signature::Contract,
-            &nonce_b,
+            &BigInt::zero(&e),
             &to_id,
             &Identifier::Contract(pool_id.clone()),
             &amounts.1,
@@ -266,10 +260,9 @@ impl LiquidityPoolRouterTrait for LiquidityPoolRouter {
         }
 
         let client = TokenClient::new(&e, &sell);
-        let nonce = client.nonce(&get_contract_id(&e));
         client.xfer_from(
             &Signature::Contract,
-            &nonce,
+            &BigInt::zero(&e),
             &to_id,
             &Identifier::Contract(pool_id.clone()),
             &xfer_amount,
@@ -323,10 +316,9 @@ impl LiquidityPoolRouterTrait for LiquidityPoolRouter {
         let share_token = pool_client.share_id();
 
         let client = TokenClient::new(&e, &share_token);
-        let nonce = client.nonce(&get_contract_id(&e));
         client.xfer_from(
             &Signature::Contract,
-            &nonce,
+            &BigInt::zero(&e),
             &to_id,
             &Identifier::Contract(pool_id.clone()),
             &share_amount,

--- a/liquidity_pool_router/src/lib.rs
+++ b/liquidity_pool_router/src/lib.rs
@@ -271,11 +271,11 @@ impl LiquidityPoolRouterTrait for LiquidityPoolRouter {
         let out_a: BigInt;
         let out_b: BigInt;
         if sell == token_a {
-            out_a = BigInt::from_u32(&e, 0);
+            out_a = BigInt::zero(&e);
             out_b = out;
         } else {
             out_a = out;
-            out_b = BigInt::from_u32(&e, 0);
+            out_b = BigInt::zero(&e);
         }
 
         LiquidityPoolClient::new(&e, &pool_id).swap(&to_id, &out_a, &out_b)

--- a/liquidity_pool_router/src/test.rs
+++ b/liquidity_pool_router/src/test.rs
@@ -94,7 +94,7 @@ fn test() {
     assert_eq!(token2.balance(&user1_id), BigInt::from_u32(&e, 900));
     assert_eq!(token2.balance(&pool_id), BigInt::from_u32(&e, 100));
     assert_eq!(token_share.balance(&user1_id), BigInt::from_u32(&e, 100));
-    assert_eq!(token_share.balance(&pool_id), BigInt::from_u32(&e, 0));
+    assert_eq!(token_share.balance(&pool_id), BigInt::zero(&e));
 
     token1.approve(&user1, &router_id, &BigInt::from_u32(&e, 100));
 
@@ -122,8 +122,8 @@ fn test() {
     );
     assert_eq!(token1.balance(&user1_id), BigInt::from_u32(&e, 1000));
     assert_eq!(token2.balance(&user1_id), BigInt::from_u32(&e, 1000));
-    assert_eq!(token_share.balance(&user1_id), BigInt::from_u32(&e, 0));
-    assert_eq!(token1.balance(&pool_id), BigInt::from_u32(&e, 0));
-    assert_eq!(token2.balance(&pool_id), BigInt::from_u32(&e, 0));
-    assert_eq!(token_share.balance(&pool_id), BigInt::from_u32(&e, 0));
+    assert_eq!(token_share.balance(&user1_id), BigInt::zero(&e));
+    assert_eq!(token1.balance(&pool_id), BigInt::zero(&e));
+    assert_eq!(token2.balance(&pool_id), BigInt::zero(&e));
+    assert_eq!(token_share.balance(&pool_id), BigInt::zero(&e));
 }

--- a/single_offer/src/lib.rs
+++ b/single_offer/src/lib.rs
@@ -70,8 +70,7 @@ fn load_price(e: &Env) -> Price {
 
 fn transfer(e: &Env, contract_id: BytesN<32>, to: Identifier, amount: BigInt) {
     let client = TokenClient::new(&e, contract_id);
-    let nonce = client.nonce(&get_contract_id(&e));
-    client.xfer(&Signature::Contract, &nonce, &to, &amount);
+    client.xfer(&Signature::Contract, &BigInt::zero(&e), &to, &amount);
 }
 
 fn transfer_sell(e: &Env, to: Identifier, amount: BigInt) {

--- a/single_offer/src/test.rs
+++ b/single_offer/src/test.rs
@@ -81,7 +81,7 @@ fn test() {
     assert_eq!(token1.balance(&offer_id), BigInt::from_u32(&e, 80));
     assert_eq!(token2.balance(&user1_id), BigInt::from_u32(&e, 10));
     assert_eq!(token2.balance(&user2_id), BigInt::from_u32(&e, 990));
-    assert_eq!(token2.balance(&offer_id), BigInt::from_u32(&e, 0));
+    assert_eq!(token2.balance(&offer_id), BigInt::zero(&e));
 
     // Withdraw 70 token1 from offer
     offer.withdraw(&user1, &BigInt::from_u32(&e, 70));
@@ -90,7 +90,7 @@ fn test() {
     assert_eq!(token1.balance(&offer_id), BigInt::from_u32(&e, 10));
     assert_eq!(token2.balance(&user1_id), BigInt::from_u32(&e, 10));
     assert_eq!(token2.balance(&user2_id), BigInt::from_u32(&e, 990));
-    assert_eq!(token2.balance(&offer_id), BigInt::from_u32(&e, 0));
+    assert_eq!(token2.balance(&offer_id), BigInt::zero(&e));
 
     // The price here is 1 A = 1 B
     offer.updt_price(&user1, 1, 1);
@@ -105,5 +105,5 @@ fn test() {
     assert_eq!(token1.balance(&offer_id), BigInt::from_u32(&e, 00));
     assert_eq!(token2.balance(&user1_id), BigInt::from_u32(&e, 20));
     assert_eq!(token2.balance(&user2_id), BigInt::from_u32(&e, 980));
-    assert_eq!(token2.balance(&offer_id), BigInt::from_u32(&e, 0));
+    assert_eq!(token2.balance(&offer_id), BigInt::zero(&e));
 }

--- a/single_offer_router/src/lib.rs
+++ b/single_offer_router/src/lib.rs
@@ -24,10 +24,6 @@ pub enum DataKey {
     Nonce(Identifier),
 }
 
-fn get_contract_id(e: &Env) -> Identifier {
-    Identifier::Contract(e.get_current_contract().into())
-}
-
 fn get_offer(e: &Env, salt: &BytesN<32>) -> BytesN<32> {
     e.contract_data()
         .get_unchecked(DataKey::Offer(salt.clone()))
@@ -181,11 +177,10 @@ impl SingleOfferRouterTrait for SingleOfferRouter {
         let buy = offer_client.get_buy();
 
         let token_client = TokenClient::new(&e, &buy);
-        let nonce = token_client.nonce(&get_contract_id(&e));
 
         token_client.xfer_from(
             &Signature::Contract,
-            &nonce,
+            &BigInt::zero(&e),
             &to_id,
             &Identifier::Contract(offer.clone()),
             &amount,

--- a/single_offer_xfer_from/src/lib.rs
+++ b/single_offer_xfer_from/src/lib.rs
@@ -32,10 +32,6 @@ pub struct Price {
     pub d: u32,
 }
 
-fn get_contract_id(e: &Env) -> Identifier {
-    Identifier::Contract(e.get_current_contract().into())
-}
-
 fn get_sell_token(e: &Env) -> BytesN<32> {
     e.contract_data().get_unchecked(DataKey::SellToken).unwrap()
 }
@@ -68,8 +64,7 @@ fn transfer_from(
     amount: &BigInt,
 ) {
     let client = TokenClient::new(&e, &contract_id);
-    let nonce = client.nonce(&get_contract_id(&e));
-    client.xfer_from(&Signature::Contract, &nonce, &from, &to, &amount)
+    client.xfer_from(&Signature::Contract, &BigInt::zero(&e), &from, &to, &amount)
 }
 
 fn transfer_sell(e: &Env, from: &Identifier, to: &Identifier, amount: &BigInt) {

--- a/single_offer_xfer_from/src/test.rs
+++ b/single_offer_xfer_from/src/test.rs
@@ -83,8 +83,8 @@ fn test() {
 
     // Trade 10 token2 for 10 token1
     offer.trade(&user2, &BigInt::from_u32(&e, 10), &BigInt::from_u32(&e, 10));
-    assert_eq!(token1.balance(&user1_id), BigInt::from_u32(&e, 0));
+    assert_eq!(token1.balance(&user1_id), BigInt::zero(&e));
     assert_eq!(token1.balance(&user2_id), BigInt::from_u32(&e, 30));
     assert_eq!(token2.balance(&user1_id), BigInt::from_u32(&e, 20));
-    assert_eq!(token2.balance(&user2_id), BigInt::from_u32(&e, 0));
+    assert_eq!(token2.balance(&user2_id), BigInt::zero(&e));
 }


### PR DESCRIPTION
1. Pass zero nonces when using `Signature::Contract`. `check_auth` expects the nonce to be [zero](https://github.com/stellar/rs-soroban-sdk/blob/6d129bf6a9250d54d67ee851ea027d4a4f892673/soroban-auth/src/lib.rs#L128) for `Signature::Contract` because it isn't used, so we can avoid the cross contract `nonce` call and pass in zero directly.
2. Use `BigInt::zero` instead of `BigInt::from_u32(&e, 0)`.