### PR TITLE
Make claimable balance example non-reusable.

### DIFF
--- a/timelock/src/lib.rs
+++ b/timelock/src/lib.rs
@@ -19,6 +19,7 @@ mod token {
 #[derive(Clone)]
 #[contracttype]
 pub enum DataKey {
+    Init,
     Balance,
     Nonce(Identifier),
 }
@@ -80,6 +81,9 @@ impl ClaimableBalanceContract {
         if claimants.len() > 10 {
             panic!("too many claimants");
         }
+        if is_initialized(&env) {
+            panic!("contract has been already initialized");
+        }
 
         let from_id = from.get_identifier(&env);
         // Authenticate depositor with nonce of zero, so that this may
@@ -103,12 +107,10 @@ impl ClaimableBalanceContract {
                 claimants,
             },
         );
+        env.contract_data().set(DataKey::Init, ());
     }
 
     pub fn claim(env: Env, claimant: Signature) {
-        if !is_initialized(&env) {
-            panic!("contract hasn't been initialized");
-        }
         let claimable_balance: ClaimableBalance =
             env.contract_data().get_unchecked(DataKey::Balance).unwrap();
 
@@ -145,7 +147,7 @@ impl ClaimableBalanceContract {
 }
 
 fn is_initialized(env: &Env) -> bool {
-    env.contract_data().has(DataKey::Balance)
+    env.contract_data().has(DataKey::Init)
 }
 
 fn get_contract_id(e: &Env) -> Identifier {

--- a/timelock/src/test.rs
+++ b/timelock/src/test.rs
@@ -223,7 +223,7 @@ fn test_deposit_above_allowance_not_possible() {
 }
 
 #[test]
-#[should_panic(expected = "incorrect nonce")]
+#[should_panic(expected = "contract has been already initialized")]
 fn test_double_deposit_not_possible() {
     let test = ClaimableBalanceTest::setup();
     test.approve_deposit(800);
@@ -284,7 +284,7 @@ fn test_out_of_time_bound_claim_not_possible() {
 }
 
 #[test]
-#[should_panic(expected = "contract hasn't been initialized")]
+#[should_panic(expected = "HostStorageError")]
 fn test_double_claim_not_possible() {
     let test = ClaimableBalanceTest::setup();
     test.approve_deposit(800);
@@ -306,7 +306,7 @@ fn test_double_claim_not_possible() {
 }
 
 #[test]
-#[should_panic(expected = "incorrect nonce")]
+#[should_panic(expected = "contract has been already initialized")]
 fn test_deposit_after_claim_not_possible() {
     let test = ClaimableBalanceTest::setup();
     test.approve_deposit(1000);


### PR DESCRIPTION
### What
Make claimable balance example non-reusable.

### Why

The previous implementation had an (unintentional) feature of being able to reuse the contract for multiple unique depositors. While the workaround is a bit ugly (as we need to maintain yet another ledger entry), it probably is better to have an example that has clear behavior.

### Known limitations

N/A
