### PR TITLE
Remove other contracts from timelockdependencies

### DIFF
--- a/timelock/Cargo.toml
+++ b/timelock/Cargo.toml
@@ -16,7 +16,9 @@ testutils = ["soroban-sdk/testutils", "soroban-token-contract/testutils"]
 [dependencies]
 soroban-sdk = "0.0.4"
 soroban-auth = "0.0.4"
-soroban-token-contract = { path = "../token", version = "0.0.4", default-features = false }
+
+[target.'cfg(not(target_family="wasm"))'.dependencies]
+soroban-token-contract = { path = "../token", version = "0.0.4", default-features = false, optional = true }
 
 [dev_dependencies]
 soroban-sdk = { version = "0.0.4", features = ["testutils"] }


### PR DESCRIPTION
### What
Remove other contracts from timelockdependencies.

### Why
It is not needed. The soroban-token-contract is only used in tests and in testutils and it only needs to be in the dev_dependencies section, and only in the dependencies section for non-wasm builds. It can also be marked as optional so it is only imported when testutils is in use.

C_lose stellar/rs-soroban-sdk#595