### PR TITLE
Remove other contracts from liquidity_pool_router dependencies

### DIFF
--- a/liquidity_pool_router/Cargo.toml
+++ b/liquidity_pool_router/Cargo.toml
@@ -15,11 +15,13 @@ testutils = ["soroban-sdk/testutils", "soroban-token-contract/testutils","soroba
 [dependencies]
 soroban-sdk = "0.0.4"
 soroban-auth = "0.0.4"
-soroban-token-contract = { path = "../token", version = "0.0.4", default-features = false }
-soroban-liquidity-pool-contract = { path = "../liquidity_pool", version = "0.0.0", default-features = false }
 ed25519-dalek = { version = "1.0.1", optional = true }
 stellar-xdr = { version = "0.0.2", features = ["next", "std"], optional = true }
 sha2 = { version = "0.10.2", optional = true }
+
+[target.'cfg(not(target_family="wasm"))'.dependencies]
+soroban-token-contract = { path = "../token", version = "0.0.4", default-features = false, optional = true }
+soroban-liquidity-pool-contract = { path = "../liquidity_pool", version = "0.0.0", default-features = false, optional = true }
 
 [dev_dependencies]
 soroban-sdk = { version = "0.0.4", features = ["testutils"] }

--- a/liquidity_pool_router/src/lib.rs
+++ b/liquidity_pool_router/src/lib.rs
@@ -9,10 +9,11 @@ pub mod testutils;
 mod token_contract;
 
 use pool_contract::{create_contract, LiquidityPoolClient};
+use token_contract::TokenClient;
+
 use soroban_auth::check_auth;
 use soroban_auth::{Identifier, Signature};
 use soroban_sdk::{contractimpl, contracttype, BigInt, Bytes, BytesN, Env, IntoVal, Symbol};
-use token_contract::TokenClient;
 
 #[derive(Clone)]
 #[contracttype]

--- a/liquidity_pool_router/src/lib.rs
+++ b/liquidity_pool_router/src/lib.rs
@@ -6,15 +6,13 @@ extern crate std;
 mod pool_contract;
 mod test;
 pub mod testutils;
+mod token_contract;
 
-use liquidity_pool::LiquidityPoolClient;
-use pool_contract::create_contract;
+use pool_contract::{create_contract, LiquidityPoolClient};
 use soroban_auth::check_auth;
 use soroban_auth::{Identifier, Signature};
-use soroban_liquidity_pool_contract as liquidity_pool;
 use soroban_sdk::{contractimpl, contracttype, BigInt, Bytes, BytesN, Env, IntoVal, Symbol};
-use soroban_token_contract as token;
-use token::TokenClient;
+use token_contract::TokenClient;
 
 #[derive(Clone)]
 #[contracttype]

--- a/liquidity_pool_router/src/pool_contract.rs
+++ b/liquidity_pool_router/src/pool_contract.rs
@@ -1,12 +1,12 @@
 use soroban_sdk::{BytesN, Env};
 
-#[cfg(not(all(any(test, feature = "testutils"), not(feature = "token-wasm"))))]
-pub const POOL_CONTRACT: &[u8] = include_bytes!("../../soroban_liquidity_pool_contract.wasm");
+soroban_sdk::contractimport!(file = "../soroban_liquidity_pool_contract.wasm");
+pub type LiquidityPoolClient = ContractClient;
 
 #[cfg(not(all(any(test, feature = "testutils"), not(feature = "token-wasm"))))]
 pub fn create_contract(e: &Env, salt: &BytesN<32>) -> BytesN<32> {
     use soroban_sdk::Bytes;
-    let bin = Bytes::from_slice(e, POOL_CONTRACT);
+    let bin = Bytes::from_slice(e, WASM);
     e.deployer().from_current_contract(salt).deploy(bin)
 }
 

--- a/liquidity_pool_router/src/token_contract.rs
+++ b/liquidity_pool_router/src/token_contract.rs
@@ -1,0 +1,2 @@
+soroban_sdk::contractimport!(file = "../soroban_token_contract.wasm");
+pub type TokenClient = ContractClient;

--- a/timelock/Cargo.toml
+++ b/timelock/Cargo.toml
@@ -16,7 +16,9 @@ testutils = ["soroban-sdk/testutils", "soroban-token-contract/testutils"]
 [dependencies]
 soroban-sdk = "0.0.4"
 soroban-auth = "0.0.4"
-soroban-token-contract = { path = "../token", version = "0.0.4", default-features = false }
+
+[target.'cfg(not(target_family="wasm"))'.dependencies]
+soroban-token-contract = { path = "../token", version = "0.0.4", default-features = false, optional = true }
 
 [dev_dependencies]
 soroban-sdk = { version = "0.0.4", features = ["testutils"] }


### PR DESCRIPTION
### What
Remove other contracts from liquidity_pool_router dependencies.

### Why
They aren't needed. The other contracts shouldn't be imported outside of testing because soon the SDK functionality for controlling if an imported contract is exported or not will disappear. They also don't need to be imported outside of tests, because the contractimport! macro can generate clients from the wasm files.

C_lose https://github.com/stellar/rs-soroban-sdk/issues/595