### PR TITLE
Remove other contracts from single_offer_router dependencies

### DIFF
--- a/single_offer_router/Cargo.toml
+++ b/single_offer_router/Cargo.toml
@@ -15,11 +15,13 @@ testutils = ["soroban-sdk/testutils", "soroban-token-contract/testutils","soroba
 [dependencies]
 soroban-sdk = "0.0.4"
 soroban-auth = "0.0.4"
-soroban-token-contract = { path = "../token", version = "0.0.4", default-features = false }
-soroban-single-offer-contract = { path = "../single_offer", version = "0.0.0", default-features = false }
 ed25519-dalek = { version = "1.0.1", optional = true }
 stellar-xdr = { version = "0.0.2", features = ["next", "std"], optional = true }
 sha2 = { version = "0.10.2", optional = true }
+
+[target.'cfg(not(target_family="wasm"))'.dependencies]
+soroban-token-contract = { path = "../token", version = "0.0.4", default-features = false, optional = true }
+soroban-single-offer-contract = { path = "../single_offer", version = "0.0.0", default-features = false, optional = true }
 
 [dev_dependencies]
 soroban-sdk = { version = "0.0.4", features = ["testutils"] }

--- a/single_offer_router/src/lib.rs
+++ b/single_offer_router/src/lib.rs
@@ -6,16 +6,15 @@ extern crate std;
 mod offer_contract;
 mod test;
 pub mod testutils;
+mod token_contract;
 
-use offer::SingleOfferClient;
-use offer_contract::create_contract;
+use offer_contract::{create_contract, SingleOfferClient};
+use token_contract::TokenClient;
+
 use soroban_auth::{
     check_auth, {Identifier, Signature},
 };
 use soroban_sdk::{contractimpl, contracttype, BigInt, Bytes, BytesN, Env, IntoVal, Symbol};
-use soroban_single_offer_contract as offer;
-use soroban_token_contract as token;
-use token::TokenClient;
 
 #[derive(Clone)]
 #[contracttype]

--- a/single_offer_router/src/offer_contract.rs
+++ b/single_offer_router/src/offer_contract.rs
@@ -1,12 +1,12 @@
 use soroban_sdk::{BytesN, Env};
 
-#[cfg(not(all(any(test, feature = "testutils"), not(feature = "token-wasm"))))]
-pub const OFFER_CONTRACT: &[u8] = include_bytes!("../../soroban_single_offer_contract.wasm");
+soroban_sdk::contractimport!(file = "../soroban_single_offer_contract.wasm");
+pub type SingleOfferClient = ContractClient;
 
 #[cfg(not(all(any(test, feature = "testutils"), not(feature = "token-wasm"))))]
 pub fn create_contract(e: &Env, salt: &BytesN<32>) -> BytesN<32> {
     use soroban_sdk::Bytes;
-    let bin = Bytes::from_slice(e, OFFER_CONTRACT);
+    let bin = Bytes::from_slice(e, WASM);
     e.deployer().from_current_contract(salt).deploy(bin)
 }
 

--- a/single_offer_router/src/token_contract.rs
+++ b/single_offer_router/src/token_contract.rs
@@ -1,0 +1,2 @@
+soroban_sdk::contractimport!(file = "../soroban_token_contract.wasm");
+pub type TokenClient = ContractClient;


### PR DESCRIPTION
### What
Remove other contracts from single_offer_router dependencies.

### Why
They aren't needed. The other contracts shouldn't be imported outside of testing because soon the SDK functionality for controlling if an imported contract is exported or not will disappear. They also don't need to be imported outside of tests, because the contractimport! macro can generate clients from the wasm files.

C_lose stellar/rs-soroban-sdk#595