### PR TITLE
Remove target-tiny from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 /target
-/target-tiny


### PR DESCRIPTION
### What

Remove target-tiny from gitignore.

### Why

We don't build target-tiny anymore. This came up in #116 (I didn't realize target-tiny wasn't being generated anymore because it didn't show up as an untracked file) cc @leighmcculloch.

### Known limitations

N/A