### PR TITLE
Clean up and remove unused export features

### DIFF
--- a/liquidity_pool/Cargo.toml
+++ b/liquidity_pool/Cargo.toml
@@ -8,8 +8,6 @@ publish = false
 crate-type = ["cdylib", "rlib"]
 
 [features]
-default = ["export"]
-export = []
 token-wasm = []
 testutils = ["soroban-sdk/testutils", "soroban-token-contract/testutils", "dep:ed25519-dalek", "dep:sha2", "dep:stellar-xdr"]
 

--- a/liquidity_pool_router/Cargo.toml
+++ b/liquidity_pool_router/Cargo.toml
@@ -8,8 +8,6 @@ publish = false
 crate-type = ["cdylib", "rlib"]
 
 [features]
-default = ["export"]
-export = []
 testutils = ["soroban-sdk/testutils", "soroban-token-contract/testutils","soroban-liquidity-pool-contract/testutils","dep:ed25519-dalek", "dep:sha2", "dep:stellar-xdr"]
 
 [dependencies]

--- a/single_offer/Cargo.toml
+++ b/single_offer/Cargo.toml
@@ -8,7 +8,6 @@ publish = false
 crate-type = ["cdylib", "rlib"]
 
 [features]
-export = []
 testutils = ["soroban-sdk/testutils", "soroban-token-contract/testutils", "dep:ed25519-dalek"]
 
 [dependencies]

--- a/single_offer_router/Cargo.toml
+++ b/single_offer_router/Cargo.toml
@@ -8,8 +8,6 @@ publish = false
 crate-type = ["cdylib", "rlib"]
 
 [features]
-default = ["export"]
-export = []
 testutils = ["soroban-sdk/testutils", "soroban-token-contract/testutils","soroban-single-offer-contract/testutils","dep:ed25519-dalek", "dep:sha2", "dep:stellar-xdr"]
 
 [dependencies]

--- a/single_offer_xfer_from/Cargo.toml
+++ b/single_offer_xfer_from/Cargo.toml
@@ -8,8 +8,6 @@ publish = false
 crate-type = ["cdylib", "rlib"]
 
 [features]
-default = ["export"]
-export = []
 testutils = ["soroban-sdk/testutils", "soroban-token-contract/testutils", "dep:ed25519-dalek"]
 
 [dependencies]

--- a/token/Cargo.toml
+++ b/token/Cargo.toml
@@ -8,8 +8,6 @@ edition = "2021"
 crate-type = ["cdylib", "rlib"]
 
 [features]
-default = ["export"]
-export = []
 testutils = ["soroban-sdk/testutils", "soroban-auth/testutils", "dep:ed25519-dalek"]
 
 [dependencies]

--- a/token/src/contract.rs
+++ b/token/src/contract.rs
@@ -81,8 +81,7 @@ fn verify_and_consume_nonce(e: &Env, id: &Identifier, expected_nonce: &BigInt) {
 
 pub struct Token;
 
-#[cfg_attr(feature = "export", contractimpl)]
-#[cfg_attr(not(feature = "export"), contractimpl(export = false))]
+#[contractimpl]
 impl TokenTrait for Token {
     fn initialize(e: Env, admin: Identifier, decimal: u32, name: Bytes, symbol: Bytes) {
         if has_administrator(&e) {


### PR DESCRIPTION
### What
Clean up and remove unused export features

### Why
The `export` attribute on `contractimpl` was removed some time ago and replaced with us never importing contracts into the WASM builds of another contract. This was done after we did some exploration into how best to address the reexports of contracts and general alignment with what's the normal thing to do with Rust. Some context is here: https://github.com/stellar/rs-soroban-sdk/issues/595.