### PR TITLE
Output logs to stdout when running tests in logging example

### DIFF
--- a/logging/src/test.rs
+++ b/logging/src/test.rs
@@ -14,5 +14,7 @@ fn test() {
 
     client.hello(&symbol!("Dev"));
 
-    assert_eq!(env.logger().all(), std::vec!["Hello Symbol(Dev)"]);
+    let logs = env.logger().all();
+    assert_eq!(logs, std::vec!["Hello Symbol(Dev)"]);
+    std::println!("{}", logs.join("\n"));
 }


### PR DESCRIPTION
### What
Output logs to stdout when running tests in logging example.

### Why
To make the logs more visible to the user.