### PR TITLE
Shorten the errors tests

### DIFF
--- a/errors/src/lib.rs
+++ b/errors/src/lib.rs
@@ -9,14 +9,14 @@ pub enum Error {
 }
 
 const COUNTER: Symbol = symbol!("COUNTER");
-const MAX: u32 = 10;
+const MAX: u32 = 5;
 
 pub struct IncrementContract;
 
 #[contractimpl]
 impl IncrementContract {
     /// Increment increments an internal counter, and returns the value. Errors
-    /// if the value is attempted to be incremented past 10.
+    /// if the value is attempted to be incremented past 5.
     pub fn increment(env: Env) -> Result<u32, Error> {
         // Get the current count.
         let mut count: u32 = env

--- a/errors/src/test.rs
+++ b/errors/src/test.rs
@@ -16,11 +16,6 @@ fn test() {
     assert_eq!(client.try_increment(), Ok(Ok(3)));
     assert_eq!(client.try_increment(), Ok(Ok(4)));
     assert_eq!(client.try_increment(), Ok(Ok(5)));
-    assert_eq!(client.try_increment(), Ok(Ok(6)));
-    assert_eq!(client.try_increment(), Ok(Ok(7)));
-    assert_eq!(client.try_increment(), Ok(Ok(8)));
-    assert_eq!(client.try_increment(), Ok(Ok(9)));
-    assert_eq!(client.try_increment(), Ok(Ok(10)));
     assert_eq!(client.try_increment(), Err(Ok(Error::LimitReached)));
 
     std::println!("{}", env.logger().all().join("\n"));
@@ -38,10 +33,5 @@ fn test_panic() {
     assert_eq!(client.increment(), 3);
     assert_eq!(client.increment(), 4);
     assert_eq!(client.increment(), 5);
-    assert_eq!(client.increment(), 6);
-    assert_eq!(client.increment(), 7);
-    assert_eq!(client.increment(), 8);
-    assert_eq!(client.increment(), 9);
-    assert_eq!(client.increment(), 10);
     client.increment();
 }


### PR DESCRIPTION
### What
Shorten the errors tests.

### Why
So that they are easier to digest and take up less screen space in the docs.