### PR TITLE
Rewrite the auth example to be based on the increment example

### DIFF
--- a/auth/src/lib.rs
+++ b/auth/src/lib.rs
@@ -14,7 +14,8 @@ impl IncrementContract {
     pub fn increment(env: Env) -> u32 {
         // Construct a key for the data being stored. Use an enum to set the
         // contract up well for adding other types of data to be stored.
-        let key = DataKey::Counter(env.invoker());
+        let invoker = env.invoker();
+        let key = DataKey::Counter(invoker);
 
         // Get the current count for the invoker.
         let mut count: u32 = env

--- a/auth/src/lib.rs
+++ b/auth/src/lib.rs
@@ -1,52 +1,37 @@
 #![no_std]
-
-mod test;
-
-use soroban_sdk::{contractimpl, contracttype, Address, BigInt, Env};
+use soroban_sdk::{contractimpl, contracttype, Address, Env};
 
 #[contracttype]
 pub enum DataKey {
-    SavedNum(Address),
-    Admin,
+    Counter(Address),
 }
 
-pub struct ExampleContract;
+pub struct IncrementContract;
 
 #[contractimpl]
-impl ExampleContract {
-    /// Set the admin Address.
-    ///
-    /// May be called only once unauthenticated, and
-    /// then only by current admin.
-    pub fn set_admin(env: Env, new_admin: Address) {
-        let admin = Self::admin(&env);
-        if let Some(admin) = admin {
-            assert_eq!(env.invoker(), admin);
-        }
-        env.data().set(DataKey::Admin, new_admin);
-    }
+impl IncrementContract {
+    /// Increment increments a counter for the invoker, and returns the value.
+    pub fn increment(env: Env) -> u32 {
+        // Construct a key for the data being stored. Use an enum to set the
+        // contract up well for adding other types of data to be stored.
+        let key = DataKey::Counter(env.invoker());
 
-    /// Set the number for an authenticated address.
-    pub fn set_num(env: Env, num: BigInt) {
-        let addr = env.invoker();
-        env.data().set(DataKey::SavedNum(addr), num);
-    }
+        // Get the current count for the invoker.
+        let mut count: u32 = env
+            .data()
+            .get(&key)
+            .unwrap_or(Ok(0)) // If no value set, assume 0.
+            .unwrap(); // Panic if the value of COUNTER is not u32.
 
-    /// Get the number for an Address.
-    pub fn num(env: Env, addr: Address) -> Option<BigInt> {
-        env.data().get(DataKey::SavedNum(addr)).map(Result::unwrap)
-    }
+        // Increment the count.
+        count += 1;
 
-    /// Overwrite any number for an Address.
-    /// Callable only by admin.
-    pub fn overwrite(env: Env, addr: Address, num: BigInt) {
-        let admin = Self::admin(&env);
-        assert_eq!(Some(env.invoker()), admin);
+        // Save the count.
+        env.data().set(&key, count);
 
-        env.data().set(DataKey::SavedNum(addr), num);
-    }
-
-    fn admin(env: &Env) -> Option<Address> {
-        env.data().get(DataKey::Admin).map(Result::unwrap)
+        // Return the count to the caller.
+        count
     }
 }
+
+mod test;

--- a/auth/src/test.rs
+++ b/auth/src/test.rs
@@ -2,33 +2,19 @@
 
 use super::*;
 
-use soroban_sdk::{testutils::Accounts, Address, Env};
+use soroban_sdk::{testutils::Accounts, Env};
 
 #[test]
 fn test() {
     let env = Env::default();
-    let contract_id = env.register_contract(None, ExampleContract);
-    let client = ExampleContractClient::new(&env, contract_id);
+    let contract_id = env.register_contract(None, IncrementContract);
+    let client = IncrementContractClient::new(&env, &contract_id);
 
-    // Initialize contract by setting the admin.
-    let admin = env.accounts().generate();
-    let admin_address = &Address::Account(admin.clone());
-    client.set_admin(admin_address);
+    let user_1 = env.accounts().generate();
+    let user_2 = env.accounts().generate();
 
-    // Check if user 1 has a num, it doesn't yet.
-    let user1 = env.accounts().generate();
-    let user1_address = &Address::Account(user1.clone());
-    assert_eq!(client.num(user1_address), None);
-
-    // Have user 1 set a num for themselves.
-    let five = BigInt::from_u32(&env, 5);
-    client.with_source_account(&user1).set_num(&five);
-    assert_eq!(client.num(user1_address), Some(five));
-
-    // Have admin overwrite user 1's num.
-    let ten = BigInt::from_u32(&env, 10);
-    client
-        .with_source_account(&admin)
-        .overwrite(user1_address, &ten);
-    assert_eq!(client.num(user1_address), Some(ten));
+    assert_eq!(client.with_source_account(&user_1).increment(), 1);
+    assert_eq!(client.with_source_account(&user_1).increment(), 2);
+    assert_eq!(client.with_source_account(&user_2).increment(), 1);
+    assert_eq!(client.with_source_account(&user_1).increment(), 3);
 }


### PR DESCRIPTION
### What
Rewrite the auth example to be based on the increment example

### Why
So that all the smaller examples are similar and tell a story for how to add a feature to a contract. This was a suggestion from @tomerweller. I've tried it on a few examples and it seems to work pretty well I think.