### PR TITLE
Use the SDK conversion from address to identifier.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -646,7 +646,7 @@ dependencies = [
 [[package]]
 name = "soroban-auth"
 version = "0.1.0"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=3992556b#3992556b840ab1659599ba7c4671ad9231129bcc"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=38f3768#38f376886fd37857b25753c0410eb5e05a31fbae"
 dependencies = [
  "ed25519-dalek",
  "rand 0.7.3",
@@ -834,7 +834,7 @@ dependencies = [
 [[package]]
 name = "soroban-sdk"
 version = "0.1.0"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=3992556b#3992556b840ab1659599ba7c4671ad9231129bcc"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=38f3768#38f376886fd37857b25753c0410eb5e05a31fbae"
 dependencies = [
  "bytes-lit",
  "ed25519-dalek",
@@ -848,7 +848,7 @@ dependencies = [
 [[package]]
 name = "soroban-sdk-macros"
 version = "0.1.0"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=3992556b#3992556b840ab1659599ba7c4671ad9231129bcc"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=38f3768#38f376886fd37857b25753c0410eb5e05a31fbae"
 dependencies = [
  "darling",
  "itertools",
@@ -898,7 +898,7 @@ dependencies = [
 [[package]]
 name = "soroban-spec"
 version = "0.1.0"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=3992556b#3992556b840ab1659599ba7c4671ad9231129bcc"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=38f3768#38f376886fd37857b25753c0410eb5e05a31fbae"
 dependencies = [
  "base64",
  "darling",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,10 +39,10 @@ codegen-units = 1
 lto = true
 
 [patch.crates-io]
-soroban-sdk = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "3992556b" }
-soroban-spec = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "3992556b" }
-soroban-auth = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "3992556b" }
-soroban-sdk-macros = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "3992556b" }
+soroban-sdk = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "38f3768" }
+soroban-spec = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "38f3768" }
+soroban-auth = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "38f3768" }
+soroban-sdk-macros = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "38f3768" }
 soroban-env-common = { git = "https://github.com/stellar/rs-soroban-env", rev = "91cf595" }
 soroban-env-guest = { git = "https://github.com/stellar/rs-soroban-env", rev = "91cf595" }
 soroban-env-host = { git = "https://github.com/stellar/rs-soroban-env", rev = "91cf595" }

--- a/timelock/src/lib.rs
+++ b/timelock/src/lib.rs
@@ -8,7 +8,7 @@
 #[cfg(feature = "testutils")]
 extern crate std;
 
-use soroban_sdk::{contractimpl, contracttype, Address, BigInt, BytesN, Env, Vec};
+use soroban_sdk::{contractimpl, contracttype, BigInt, BytesN, Env, Vec};
 
 mod token {
     soroban_sdk::contractimport!(file = "../soroban_token_spec.wasm");
@@ -83,9 +83,8 @@ impl ClaimableBalanceContract {
             panic!("contract has been already initialized");
         }
 
-        let from_id = address_to_id(env.invoker());
         // Transfer token to this contract address.
-        transfer_from_account_to_contract(&env, &token, &from_id, &amount);
+        transfer_from_account_to_contract(&env, &token, &env.invoker().into(), &amount);
         // Store all the necessary info to allow one of the claimants to claim it.
         env.data().set(
             DataKey::Balance,
@@ -110,7 +109,7 @@ impl ClaimableBalanceContract {
             panic!("time predicate is not fulfilled");
         }
 
-        let claimant_id = address_to_id(env.invoker());
+        let claimant_id = env.invoker().into();
         let claimants = &claimable_balance.claimants;
         if !claimants.contains(&claimant_id) {
             panic!("claimant is not allowed to claim this balance");
@@ -135,13 +134,6 @@ fn is_initialized(env: &Env) -> bool {
 
 fn get_contract_id(e: &Env) -> Identifier {
     Identifier::Contract(e.get_current_contract().into())
-}
-
-fn address_to_id(address: Address) -> Identifier {
-    match address {
-        Address::Account(a) => Identifier::Account(a),
-        Address::Contract(c) => Identifier::Contract(c),
-    }
 }
 
 fn transfer_from_account_to_contract(


### PR DESCRIPTION
### What

Use the SDK conversion from address to identifier.

I'm ok with postponing this if we don't want to bump the SDK revision, this is mostly to not forget about the change.

### Why

Simplifying example code

### Known limitations

N/A
