### PR TITLE
Remove macro_use and extern crate uses that are unnecessary

### DIFF
--- a/liquidity_pool_router/src/lib.rs
+++ b/liquidity_pool_router/src/lib.rs
@@ -1,8 +1,5 @@
 #![no_std]
 
-#[cfg(any(test, feature = "testutils"))]
-extern crate std;
-
 mod pool_contract;
 mod test;
 pub mod testutils;

--- a/liquidity_pool_router/src/pool_contract.rs
+++ b/liquidity_pool_router/src/pool_contract.rs
@@ -13,6 +13,9 @@ pub fn create_contract(e: &Env, salt: &BytesN<32>) -> BytesN<32> {
 }
 
 #[cfg(all(any(test, feature = "testutils"), not(feature = "token-wasm")))]
+extern crate std;
+
+#[cfg(all(any(test, feature = "testutils"), not(feature = "token-wasm")))]
 pub fn create_contract(e: &Env, salt: &BytesN<32>) -> BytesN<32> {
     use sha2::{Digest, Sha256};
     use stellar_xdr::{Hash, HashIdPreimage, HashIdPreimageContractId, Uint256, WriteXdr};

--- a/single_offer/src/lib.rs
+++ b/single_offer/src/lib.rs
@@ -1,8 +1,5 @@
 #![no_std]
 
-#[cfg(feature = "testutils")]
-extern crate std;
-
 mod test;
 pub mod testutils;
 

--- a/single_offer_router/src/lib.rs
+++ b/single_offer_router/src/lib.rs
@@ -1,8 +1,5 @@
 #![no_std]
 
-#[cfg(any(test, feature = "testutils"))]
-extern crate std;
-
 mod offer_contract;
 mod test;
 pub mod testutils;

--- a/single_offer_router/src/offer_contract.rs
+++ b/single_offer_router/src/offer_contract.rs
@@ -13,6 +13,9 @@ pub fn create_contract(e: &Env, salt: &BytesN<32>) -> BytesN<32> {
 }
 
 #[cfg(all(any(test, feature = "testutils"), not(feature = "token-wasm")))]
+extern crate std;
+
+#[cfg(all(any(test, feature = "testutils"), not(feature = "token-wasm")))]
 pub fn create_contract(e: &Env, salt: &BytesN<32>) -> BytesN<32> {
     use sha2::{Digest, Sha256};
     use stellar_xdr::{Hash, HashIdPreimage, HashIdPreimageContractId, Uint256, WriteXdr};

--- a/single_offer_xfer_from/src/lib.rs
+++ b/single_offer_xfer_from/src/lib.rs
@@ -1,8 +1,5 @@
 #![no_std]
 
-#[cfg(feature = "testutils")]
-extern crate std;
-
 mod test;
 pub mod testutils;
 

--- a/timelock/src/lib.rs
+++ b/timelock/src/lib.rs
@@ -5,8 +5,6 @@
 //! account(s) claim it before or after provided time point.
 //! For simplicity, the contract only supports invoker-based auth.
 #![no_std]
-#[cfg(feature = "testutils")]
-extern crate std;
 
 use soroban_sdk::{contractimpl, contracttype, BigInt, BytesN, Env, Vec};
 

--- a/token/src/lib.rs
+++ b/token/src/lib.rs
@@ -1,9 +1,5 @@
 #![no_std]
 
-#[cfg(any(test, feature = "testutils"))]
-#[macro_use]
-extern crate std;
-
 mod admin;
 mod allowance;
 mod balance;

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -2,8 +2,6 @@
 //! complex auth scheme with multiple signers that authorize payments in immediate
 //! or delayed (async) fashion.
 #![no_std]
-#[cfg(feature = "testutils")]
-extern crate std;
 
 use soroban_auth::{verify, Identifier, Signature};
 use soroban_sdk::{


### PR DESCRIPTION
### What
Remove macro_use and extern crate uses that are unnecessary, and move some uses into a smaller scope.

### Why
For the most part we don't need to import the std crate into our examples. We import it in a few places even though we have no use for it.