### PR TITLE
Add a default file to open on load of gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -6,7 +6,7 @@ tasks:
       cargo fetch
       make build test
     command: |
-      code increment/src/lib.rs
+      gp ports await 23000 && gp open increment/src/lib.rs
       make build test
       soroban invoke --id 1 --wasm target/wasm32-unknown-unknown/release/soroban_increment_contract.wasm --fn increment
 


### PR DESCRIPTION
### What
Add a default file to open on load of gitpod.

### Why
So that when new developers open the gitpod they are dropped into the simplest contract immediately.

### Gitpod
A prebuild of this PR on gitpod can be triggered with:
- https://gitpod.io/#prebuild/https://github.com/stellar/soroban-examples/pull/155

Open a gitpod running this PR:
- https://gitpod.io/#https://github.com/stellar/soroban-examples/pull/155