### PR TITLE
Open readme and files on boot in gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -6,7 +6,11 @@ tasks:
       cargo fetch
       make build test
     command: |
-      gp ports await 23000 && gp open increment/src/lib.rs
+      gp ports await 23000
+      gp open README.md
+      gp open increment/src/lib.rs
+      gp open increment/src/test.rs
+      gp open README.md
       make build test
       soroban invoke --id 1 --wasm target/wasm32-unknown-unknown/release/soroban_increment_contract.wasm --fn increment
 


### PR DESCRIPTION
### What
Open readme and files on boot in gitpod

### Why
@rice2000 pointed out that it isn't very intuitive where to go. The readme has a link to the examples tutorials.

### Gitpod
A prebuild of this PR on gitpod can be triggered with:
- https://gitpod.io/#prebuild/https://github.com/stellar/soroban-examples/pull/158

Open a gitpod running this PR:
- https://gitpod.io/#https://github.com/stellar/soroban-examples/pull/158