### PR TITLE
Remove extra build step from gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -11,7 +11,6 @@ tasks:
       gp open increment/src/lib.rs
       gp open increment/src/test.rs
       gp open README.md
-      make build test
       soroban invoke --id 1 --wasm target/wasm32-unknown-unknown/release/soroban_increment_contract.wasm --fn increment
 
 vscode:


### PR DESCRIPTION
### What

Remove extra build step from gitpod.

### Why

It's unnecessary because a build occurs in the prebuild, and it gets in the way of a dev from using the console on first boot.

cc @tyvdh 

### Known limitations

[TODO or N/A]
