### PR TITLE
Remove cargo-hack

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -46,7 +46,6 @@ jobs:
     - uses: stellar/actions/rust-cache@main
     - run: rustup update
     - run: rustup target add ${{ matrix.sys.target }}
-    - run: cargo install --target-dir ~/.cargo/target --locked --version 0.5.16 cargo-hack
     - run: make test
       env:
         CARGO_BUILD_TARGET: ${{ matrix.sys.target }}
@@ -64,7 +63,6 @@ jobs:
     - run: rustup update nightly
     - run: rustup component add rust-src --toolchain nightly-${{ matrix.sys.target }}
     - run: rustup target add ${{ matrix.sys.target }}
-    - run: cargo install --target-dir ~/.cargo/target --locked --version 0.5.16 cargo-hack
     - run: make test-optimized
       env:
         CARGO_BUILD_TARGET: ${{ matrix.sys.target }}

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -4,7 +4,6 @@ RUN mkdir -p ~/.local/bin
 RUN curl -L https://github.com/stellar/soroban-cli/releases/download/v0.1.2/soroban-cli-0.1.2-x86_64-unknown-linux-gnu.tar.gz | tar xz -C ~/.local/bin soroban
 RUN curl -L https://github.com/mozilla/sccache/releases/download/v0.3.0/sccache-v0.3.0-x86_64-unknown-linux-musl.tar.gz | tar xz --strip-components 1 -C ~/.local/bin sccache-v0.3.0-x86_64-unknown-linux-musl/sccache
 RUN chmod +x ~/.local/bin/sccache
-RUN curl -L https://github.com/taiki-e/cargo-hack/releases/download/v0.5.21/cargo-hack-x86_64-unknown-linux-gnu.tar.gz | tar xz -C ~/.local/bin cargo-hack
 RUN curl -L https://github.com/watchexec/cargo-watch/releases/download/v8.1.2/cargo-watch-v8.1.2-x86_64-unknown-linux-gnu.tar.xz | tar xJ --strip-components 1 -C ~/.local/bin cargo-watch-v8.1.2-x86_64-unknown-linux-gnu/cargo-watch
 
 ENV RUSTC_WRAPPER=sccache

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ build-optimized:
 	cargo +nightly build --target wasm32-unknown-unknown --release -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort -p soroban-liquidity-pool-contract
 	cargo +nightly build --target wasm32-unknown-unknown --release -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort -p soroban-single-offer-contract
 	cargo +nightly build --target wasm32-unknown-unknown --release -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort -p soroban-cross-contract-a-contract
-	cargo +nightly hack build --target wasm32-unknown-unknown --release -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort
+	cargo +nightly build --target wasm32-unknown-unknown --release -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort
 	cd target/wasm32-unknown-unknown/release/ && \
 		for i in *.wasm ; do \
 			wasm-opt -Oz "$$i" -o "$$i.tmp" && mv "$$i.tmp" "$$i"; \

--- a/Makefile
+++ b/Makefile
@@ -3,25 +3,31 @@ default: build
 all: build test
 
 test: build
-	cargo hack --feature-powerset test
+	cargo test
+	cargo test --features testutils
+	cargo test --features token-wasm
 
 build:
 	cargo build --target wasm32-unknown-unknown --release -p soroban-token-contract
 	cargo build --target wasm32-unknown-unknown --release -p soroban-liquidity-pool-contract
 	cargo build --target wasm32-unknown-unknown --release -p soroban-single-offer-contract
-	cargo hack build --target wasm32-unknown-unknown --release
+	cargo build --target wasm32-unknown-unknown --release -p soroban-cross-contract-a-contract
+	cargo build --target wasm32-unknown-unknown --release
 	cd target/wasm32-unknown-unknown/release/ && \
 		for i in *.wasm ; do \
 			ls -l "$$i"; \
 		done
 
 test-optimized: build-optimized
-	cargo hack --feature-powerset test
+	cargo test
+	cargo test --features testutils
+	cargo test --features token-wasm
 
 build-optimized:
 	cargo +nightly build --target wasm32-unknown-unknown --release -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort -p soroban-token-contract
 	cargo +nightly build --target wasm32-unknown-unknown --release -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort -p soroban-liquidity-pool-contract
 	cargo +nightly build --target wasm32-unknown-unknown --release -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort -p soroban-single-offer-contract
+	cargo +nightly build --target wasm32-unknown-unknown --release -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort -p soroban-cross-contract-a-contract
 	cargo +nightly hack build --target wasm32-unknown-unknown --release -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort
 	cd target/wasm32-unknown-unknown/release/ && \
 		for i in *.wasm ; do \

--- a/auth/Cargo.toml
+++ b/auth/Cargo.toml
@@ -7,9 +7,6 @@ publish = false
 [lib]
 crate-type = ["cdylib", "rlib"]
 
-[features]
-testutils = ["soroban-sdk/testutils"]
-
 [dependencies]
 soroban-sdk = "0.1.0"
 

--- a/auth_advanced/Cargo.toml
+++ b/auth_advanced/Cargo.toml
@@ -7,9 +7,6 @@ publish = false
 [lib]
 crate-type = ["cdylib", "rlib"]
 
-[features]
-testutils = ["soroban-sdk/testutils", "soroban-auth/testutils", "dep:ed25519-dalek"]
-
 [dependencies]
 soroban-sdk = "0.1.0"
 soroban-auth = "0.1.0"

--- a/cross_contract/contract_a/Cargo.toml
+++ b/cross_contract/contract_a/Cargo.toml
@@ -10,9 +10,6 @@ publish = false
 crate-type = ["cdylib", "rlib"]
 doctest = false
 
-[features]
-testutils = ["soroban-sdk/testutils"]
-
 [dependencies]
 soroban-sdk = "0.1.0"
 

--- a/cross_contract/contract_b/Cargo.toml
+++ b/cross_contract/contract_b/Cargo.toml
@@ -10,9 +10,6 @@ publish = false
 crate-type = ["cdylib", "rlib"]
 doctest = false
 
-[features]
-testutils = ["soroban-sdk/testutils"]
-
 [dependencies]
 soroban-sdk = "0.1.0"
 

--- a/custom_types/Cargo.toml
+++ b/custom_types/Cargo.toml
@@ -10,9 +10,6 @@ publish = false
 crate-type = ["cdylib", "rlib"]
 doctest = false
 
-[features]
-testutils = ["soroban-sdk/testutils"]
-
 [dependencies]
 soroban-sdk = "0.1.0"
 

--- a/deployer/contract/Cargo.toml
+++ b/deployer/contract/Cargo.toml
@@ -10,9 +10,6 @@ publish = false
 crate-type = ["cdylib", "rlib"]
 doctest = false
 
-[features]
-testutils = ["soroban-sdk/testutils"]
-
 [dependencies]
 soroban-sdk = "0.1.0"
 

--- a/deployer/deployer/Cargo.toml
+++ b/deployer/deployer/Cargo.toml
@@ -10,9 +10,6 @@ publish = false
 crate-type = ["cdylib", "rlib"]
 doctest = false
 
-[features]
-testutils = ["soroban-sdk/testutils"]
-
 [dependencies]
 soroban-sdk = "0.1.0"
 

--- a/errors/Cargo.toml
+++ b/errors/Cargo.toml
@@ -10,9 +10,6 @@ publish = false
 crate-type = ["cdylib", "rlib"]
 doctest = false
 
-[features]
-testutils = ["soroban-sdk/testutils"]
-
 [dependencies]
 soroban-sdk = "0.1.0"
 

--- a/events/Cargo.toml
+++ b/events/Cargo.toml
@@ -10,9 +10,6 @@ publish = false
 crate-type = ["cdylib", "rlib"]
 doctest = false
 
-[features]
-testutils = ["soroban-sdk/testutils"]
-
 [dependencies]
 soroban-sdk = "0.1.0"
 

--- a/hello_world/Cargo.toml
+++ b/hello_world/Cargo.toml
@@ -10,9 +10,6 @@ publish = false
 crate-type = ["cdylib", "rlib"]
 doctest = false
 
-[features]
-testutils = ["soroban-sdk/testutils"]
-
 [dependencies]
 soroban-sdk = "0.1.0"
 

--- a/increment/Cargo.toml
+++ b/increment/Cargo.toml
@@ -10,9 +10,6 @@ publish = false
 crate-type = ["cdylib", "rlib"]
 doctest = false
 
-[features]
-testutils = ["soroban-sdk/testutils"]
-
 [dependencies]
 soroban-sdk = "0.1.0"
 

--- a/timelock/Cargo.toml
+++ b/timelock/Cargo.toml
@@ -10,9 +10,6 @@ publish = false
 crate-type = ["cdylib", "rlib"]
 doctest = false
 
-[features]
-testutils = ["soroban-sdk/testutils"]
-
 [dependencies]
 soroban-sdk = "0.1.0"
 soroban-auth = "0.1.0"

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -10,9 +10,6 @@ publish = false
 crate-type = ["cdylib", "rlib"]
 doctest = false
 
-[features]
-testutils = ["soroban-sdk/testutils"]
-
 [dependencies]
 soroban-sdk = "0.1.0"
 soroban-auth = "0.1.0"


### PR DESCRIPTION
### What
Remove cargo-hack. Remove unused features. Replace cargo-hack powerset usages with explicitly specifying the features to enable in test runs.

### Why
@tyvdh  made the point that it complicates the examples, and encourages developers new to Rust to think they need cargo-hack when they probably don't.