### PR TITLE
Remove rlib as a crate-type from most examples

### DIFF
--- a/auth/Cargo.toml
+++ b/auth/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [lib]
-crate-type = ["cdylib", "rlib"]
+crate-type = ["cdylib"]
 
 [features]
 testutils = ["soroban-sdk/testutils"]

--- a/auth_advanced/Cargo.toml
+++ b/auth_advanced/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [lib]
-crate-type = ["cdylib", "rlib"]
+crate-type = ["cdylib"]
 
 [features]
 testutils = ["soroban-sdk/testutils", "soroban-auth/testutils", "dep:ed25519-dalek"]

--- a/cross_contract/contract_a/Cargo.toml
+++ b/cross_contract/contract_a/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 publish = false
 
 [lib]
-crate-type = ["cdylib", "rlib"]
+crate-type = ["cdylib"]
 doctest = false
 
 [features]

--- a/cross_contract/contract_b/Cargo.toml
+++ b/cross_contract/contract_b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 publish = false
 
 [lib]
-crate-type = ["cdylib", "rlib"]
+crate-type = ["cdylib"]
 doctest = false
 
 [features]

--- a/custom_types/Cargo.toml
+++ b/custom_types/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 publish = false
 
 [lib]
-crate-type = ["cdylib", "rlib"]
+crate-type = ["cdylib"]
 doctest = false
 
 [features]

--- a/deployer/contract/Cargo.toml
+++ b/deployer/contract/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 publish = false
 
 [lib]
-crate-type = ["cdylib", "rlib"]
+crate-type = ["cdylib"]
 doctest = false
 
 [features]

--- a/deployer/deployer/Cargo.toml
+++ b/deployer/deployer/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 publish = false
 
 [lib]
-crate-type = ["cdylib", "rlib"]
+crate-type = ["cdylib"]
 doctest = false
 
 [features]

--- a/errors/Cargo.toml
+++ b/errors/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 publish = false
 
 [lib]
-crate-type = ["cdylib", "rlib"]
+crate-type = ["cdylib"]
 doctest = false
 
 [features]

--- a/events/Cargo.toml
+++ b/events/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 publish = false
 
 [lib]
-crate-type = ["cdylib", "rlib"]
+crate-type = ["cdylib"]
 doctest = false
 
 [features]

--- a/hello_world/Cargo.toml
+++ b/hello_world/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 publish = false
 
 [lib]
-crate-type = ["cdylib", "rlib"]
+crate-type = ["cdylib"]
 doctest = false
 
 [features]

--- a/increment/Cargo.toml
+++ b/increment/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 publish = false
 
 [lib]
-crate-type = ["cdylib", "rlib"]
+crate-type = ["cdylib"]
 doctest = false
 
 [features]

--- a/logging/Cargo.toml
+++ b/logging/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 publish = false
 
 [lib]
-crate-type = ["cdylib", "rlib"]
+crate-type = ["cdylib"]
 doctest = false
 
 [features]

--- a/timelock/Cargo.toml
+++ b/timelock/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 publish = false
 
 [lib]
-crate-type = ["cdylib", "rlib"]
+crate-type = ["cdylib"]
 doctest = false
 
 [features]

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 publish = false
 
 [lib]
-crate-type = ["cdylib", "rlib"]
+crate-type = ["cdylib"]
 doctest = false
 
 [features]


### PR DESCRIPTION
### What
Remove rlib as a crate-type from most examples.

### Why
It causes bloat in the .wasm and we don't need it because the rlib crate-type is only used when making a library to import into another crate.

Related to https://github.com/stellar/soroban-docs/pull/212