### PR TITLE
Remove rlib crate-type from token contract

### DIFF
--- a/token/Cargo.toml
+++ b/token/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.0.6"
 edition = "2021"
 
 [lib]
-crate-type = ["cdylib", "rlib"]
+crate-type = ["cdylib"]
 
 [features]
 testutils = ["soroban-sdk/testutils", "soroban-auth/testutils", "dep:ed25519-dalek"]


### PR DESCRIPTION
### What
Remove rlib crate-type from token contract.

### Why
Related to https://github.com/stellar/soroban-docs/pull/212

### Before

Build with stable:
```
-rwxr-xr-x  1 leighmcculloch  staff  57021 Oct 31 08:28 soroban_token_contract.wasm
```
Build with nightly + wasm-opt:
```
-rw-r--r--  1 leighmcculloch  staff  24440 Oct 31 08:28 soroban_token_contract.wasm
```

### After
Build with stable:
```
-rw-r--r--  1 leighmcculloch  staff  26607 Oct 31 08:30 soroban_token_contract.wasm
```
Build with nightly + wasm-opt:
```
-rw-r--r--  1 leighmcculloch  staff  19533 Oct 31 08:29 soroban_token_contract.wasm
```