### PR TITLE
Example SIGSEGV invalid memory reference

### DIFF
--- a/increment/src/lib.rs
+++ b/increment/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-use soroban_sdk::{contractimpl, log, symbol, Env, Symbol};
+use soroban_sdk::{contractimpl, log, symbol, BytesN, Env, Symbol};
 
 const COUNTER: Symbol = symbol!("COUNTER");
 
@@ -22,6 +22,8 @@ impl IncrementContract {
 
         // Save the count.
         env.data().set(COUNTER, count);
+
+        env.data().set(count, BytesN::from_array(&env, &[0; 32]));
 
         // Return the count to the caller.
         count

--- a/increment/src/test.rs
+++ b/increment/src/test.rs
@@ -1,19 +1,28 @@
 #![cfg(test)]
 
 use super::{IncrementContract, IncrementContractClient};
-use soroban_sdk::{testutils::Logger, Env};
+use soroban_sdk::Env;
 
 extern crate std;
 
 #[test]
-fn test() {
+fn test_passes() {
     let env = Env::default();
     let contract_id = env.register_contract(None, IncrementContract);
     let client = IncrementContractClient::new(&env, &contract_id);
 
-    assert_eq!(client.increment(), 1);
-    assert_eq!(client.increment(), 2);
-    assert_eq!(client.increment(), 3);
+    for i in 0..2207 {
+        assert_eq!(client.increment(), i + 1);
+    }
+}
 
-    std::println!("{}", env.logger().all().join("\n"));
+#[test]
+fn test_stack_overflow() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, IncrementContract);
+    let client = IncrementContractClient::new(&env, &contract_id);
+
+    for i in 0..2208 {
+        assert_eq!(client.increment(), i + 1);
+    }
 }


### PR DESCRIPTION
### What
An example of when a `signal: 11, SIGSEGV: invalid memory reference` occurs.

### Why
First reported by https://discord.com/channels/897514728459468821/966788672164855829/1036512231556390932 we should understand why this is occurring.