### PR TITLE
Remove rlib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -808,7 +808,6 @@ dependencies = [
  "rand 0.7.3",
  "sha2 0.10.6",
  "soroban-auth",
- "soroban-liquidity-pool-contract",
  "soroban-sdk",
  "stellar-xdr",
 ]
@@ -891,7 +890,6 @@ dependencies = [
  "sha2 0.10.6",
  "soroban-auth",
  "soroban-sdk",
- "soroban-single-offer-contract",
  "stellar-xdr",
 ]
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,6 @@ all: build test
 test: build
 	cargo test
 	cargo test --features testutils
-	cargo test --features token-wasm
 
 build:
 	cargo build --target wasm32-unknown-unknown --release -p soroban-token-contract
@@ -21,7 +20,6 @@ build:
 test-optimized: build-optimized
 	cargo test
 	cargo test --features testutils
-	cargo test --features token-wasm
 
 build-optimized:
 	cargo +nightly build --target wasm32-unknown-unknown --release -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort -p soroban-token-contract

--- a/liquidity_pool/Cargo.toml
+++ b/liquidity_pool/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [lib]
-crate-type = ["cdylib", "rlib"]
+crate-type = ["cdylib"]
 
 [features]
 token-wasm = []

--- a/liquidity_pool_router/Cargo.toml
+++ b/liquidity_pool_router/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [lib]
-crate-type = ["cdylib", "rlib"]
+crate-type = ["cdylib"]
 
 [features]
 testutils = ["soroban-sdk/testutils", "soroban-auth/testutils","soroban-liquidity-pool-contract/testutils","dep:ed25519-dalek", "dep:sha2", "dep:stellar-xdr"]

--- a/liquidity_pool_router/Cargo.toml
+++ b/liquidity_pool_router/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 crate-type = ["cdylib"]
 
 [features]
-testutils = ["soroban-sdk/testutils", "soroban-auth/testutils","soroban-liquidity-pool-contract/testutils","dep:ed25519-dalek", "dep:sha2", "dep:stellar-xdr"]
+testutils = ["soroban-sdk/testutils", "soroban-auth/testutils" ,"dep:ed25519-dalek", "dep:sha2", "dep:stellar-xdr"]
 
 [dependencies]
 soroban-sdk = "0.1.0"
@@ -17,13 +17,10 @@ ed25519-dalek = { version = "1.0.1", optional = true }
 stellar-xdr = { version = "0.0.6", features = ["next", "std"], optional = true }
 sha2 = { version = "0.10.2", optional = true }
 
-[target.'cfg(not(target_family="wasm"))'.dependencies]
-soroban-liquidity-pool-contract = { path = "../liquidity_pool", version = "0.0.0", default-features = false, optional = true }
 
 [dev_dependencies]
 soroban-sdk = { version = "0.1.0", features = ["testutils"] }
 soroban-auth = { version = "0.1.0", features = ["testutils"] }
-soroban-liquidity-pool-contract = { path = "../liquidity_pool", version = "0.0.0", default-features = false, features = ["testutils"] }
 stellar-xdr = { version = "0.0.6", features = ["next", "std"] }
 ed25519-dalek = { version = "1.0.1" }
 sha2 = { version = "0.10.2" }

--- a/liquidity_pool_router/src/pool_contract.rs
+++ b/liquidity_pool_router/src/pool_contract.rs
@@ -5,32 +5,8 @@ soroban_sdk::contractimport!(
 );
 pub type LiquidityPoolClient = Client;
 
-#[cfg(not(all(any(test, feature = "testutils"), not(feature = "token-wasm"))))]
 pub fn create_contract(e: &Env, salt: &BytesN<32>) -> BytesN<32> {
     use soroban_sdk::Bytes;
     let bin = Bytes::from_slice(e, WASM);
     e.deployer().with_current_contract(salt).deploy(bin)
-}
-
-#[cfg(all(any(test, feature = "testutils"), not(feature = "token-wasm")))]
-extern crate std;
-
-#[cfg(all(any(test, feature = "testutils"), not(feature = "token-wasm")))]
-pub fn create_contract(e: &Env, salt: &BytesN<32>) -> BytesN<32> {
-    use sha2::{Digest, Sha256};
-    use stellar_xdr::{Hash, HashIdPreimage, HashIdPreimageContractId, Uint256, WriteXdr};
-
-    use std::vec::Vec;
-
-    let contract_id = Hash(e.get_current_contract().into());
-    let pre_image = HashIdPreimage::ContractIdFromContract(HashIdPreimageContractId {
-        contract_id,
-        salt: Uint256(salt.clone().into()),
-    });
-    let mut buf = Vec::new();
-    pre_image.write_xdr(&mut buf).unwrap();
-    let new_contract_id = Sha256::digest(buf).into();
-
-    soroban_liquidity_pool_contract::testutils::register_test_contract(e, &new_contract_id);
-    BytesN::from_array(e, &new_contract_id)
 }

--- a/liquidity_pool_router/src/test.rs
+++ b/liquidity_pool_router/src/test.rs
@@ -1,14 +1,13 @@
 #![cfg(test)]
 
+use crate::pool_contract::LiquidityPoolClient;
 use crate::token::{self, TokenMetadata};
 
 use crate::testutils::{
     register_test_contract as register_liquidity_pool_router, LiquidityPoolRouter,
 };
-use liquidity_pool::LiquidityPoolClient;
 use rand::{thread_rng, RngCore};
 use soroban_auth::{Identifier, Signature};
-use soroban_liquidity_pool_contract as liquidity_pool;
 use soroban_sdk::{testutils::Accounts, AccountId, BigInt, BytesN, Env, IntoVal};
 
 fn generate_sorted_contract_ids() -> ([u8; 32], [u8; 32]) {

--- a/single_offer/Cargo.toml
+++ b/single_offer/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [lib]
-crate-type = ["cdylib", "rlib"]
+crate-type = ["cdylib"]
 
 [features]
 testutils = ["soroban-sdk/testutils", "soroban-auth/testutils", "dep:ed25519-dalek"]

--- a/single_offer_router/Cargo.toml
+++ b/single_offer_router/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [lib]
-crate-type = ["cdylib", "rlib"]
+crate-type = ["cdylib"]
 
 [features]
 testutils = ["soroban-sdk/testutils", "soroban-auth/testutils","soroban-single-offer-contract/testutils","dep:ed25519-dalek", "dep:sha2", "dep:stellar-xdr"]

--- a/single_offer_router/Cargo.toml
+++ b/single_offer_router/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 crate-type = ["cdylib"]
 
 [features]
-testutils = ["soroban-sdk/testutils", "soroban-auth/testutils","soroban-single-offer-contract/testutils","dep:ed25519-dalek", "dep:sha2", "dep:stellar-xdr"]
+testutils = ["soroban-sdk/testutils", "soroban-auth/testutils","dep:ed25519-dalek", "dep:sha2", "dep:stellar-xdr"]
 
 [dependencies]
 soroban-sdk = "0.1.0"
@@ -17,13 +17,9 @@ ed25519-dalek = { version = "1.0.1", optional = true }
 stellar-xdr = { version = "0.0.6", features = ["next", "std"], optional = true }
 sha2 = { version = "0.10.2", optional = true }
 
-[target.'cfg(not(target_family="wasm"))'.dependencies]
-soroban-single-offer-contract = { path = "../single_offer", version = "0.0.0", default-features = false, optional = true }
-
 [dev_dependencies]
 soroban-sdk = { version = "0.1.0", features = ["testutils"] }
 soroban-auth = { version = "0.1.0", features = ["testutils"] }
-soroban-single-offer-contract = { path = "../single_offer", version = "0.0.0", default-features = false, features = ["testutils"] }
 stellar-xdr = { version = "0.0.6", features = ["next", "std"] }
 ed25519-dalek = { version = "1.0.1" }
 sha2 = { version = "0.10.2" }

--- a/single_offer_router/src/offer_contract.rs
+++ b/single_offer_router/src/offer_contract.rs
@@ -5,32 +5,8 @@ soroban_sdk::contractimport!(
 );
 pub type SingleOfferClient = Client;
 
-#[cfg(not(all(any(test, feature = "testutils"), not(feature = "token-wasm"))))]
 pub fn create_contract(e: &Env, salt: &BytesN<32>) -> BytesN<32> {
     use soroban_sdk::Bytes;
     let bin = Bytes::from_slice(e, WASM);
     e.deployer().with_current_contract(salt).deploy(bin)
-}
-
-#[cfg(all(any(test, feature = "testutils"), not(feature = "token-wasm")))]
-extern crate std;
-
-#[cfg(all(any(test, feature = "testutils"), not(feature = "token-wasm")))]
-pub fn create_contract(e: &Env, salt: &BytesN<32>) -> BytesN<32> {
-    use sha2::{Digest, Sha256};
-    use stellar_xdr::{Hash, HashIdPreimage, HashIdPreimageContractId, Uint256, WriteXdr};
-
-    use std::vec::Vec;
-
-    let contract_id = Hash(e.get_current_contract().into());
-    let pre_image = HashIdPreimage::ContractIdFromContract(HashIdPreimageContractId {
-        contract_id,
-        salt: Uint256(salt.clone().into()),
-    });
-    let mut buf = Vec::new();
-    pre_image.write_xdr(&mut buf).unwrap();
-    let new_contract_id = Sha256::digest(buf).into();
-
-    soroban_single_offer_contract::testutils::register_test_contract(e, &new_contract_id);
-    BytesN::from_array(e, &new_contract_id)
 }

--- a/single_offer_xfer_from/Cargo.toml
+++ b/single_offer_xfer_from/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [lib]
-crate-type = ["cdylib", "rlib"]
+crate-type = ["cdylib"]
 
 [features]
 testutils = ["soroban-sdk/testutils", "soroban-auth/testutils", "dep:ed25519-dalek"]


### PR DESCRIPTION
Removes all use of rlib. The easiest way to do this was to have the router contracts always create the non-router contracts in wasm.