### PR TITLE
Update rust-analyzer extension identifier in gitpod config

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -15,7 +15,7 @@ tasks:
 
 vscode:
   extensions:
-    - matklad.rust-analyzer
+    - rust-lang.rust-analyzer
     - vadimcn.vscode-lldb
 
 github:


### PR DESCRIPTION
### What
Update rust-analyzer extension identifier in gitpod config.

### Why
It appears to have changed.

Related conversation:
- https://discord.com/channels/816244985187008514/1037804343627362374
- https://discord.com/channels/897514728459468821/1037802210588905483