### PR TITLE
Update the examples to reflect the contract deployment changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -834,8 +834,7 @@ dependencies = [
 [[package]]
 name = "soroban-auth"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9218b5b9e66c664000e87750ad8199cd7e94b37afb592b079183cc9619aaba9e"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=8e3d9642#8e3d9642118ee593669e56adbc51a235fa699d3b"
 dependencies = [
  "ed25519-dalek",
  "rand 0.7.3",
@@ -846,8 +845,6 @@ dependencies = [
 name = "soroban-auth-advanced-contract"
 version = "0.0.0"
 dependencies = [
- "ed25519-dalek",
- "rand 0.7.3",
  "soroban-auth",
  "soroban-sdk",
 ]
@@ -897,20 +894,18 @@ dependencies = [
 [[package]]
 name = "soroban-env-common"
 version = "0.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d85c804501b0f703626c19de336ed559f1a9f12c261777e4e6e066696afe40aa"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=f5d64c9c#f5d64c9c2e52d8162eceebbda204a2252b956559"
 dependencies = [
  "soroban-env-macros",
  "soroban-wasmi",
  "static_assertions",
- "stellar-xdr 0.0.7",
+ "stellar-xdr",
 ]
 
 [[package]]
 name = "soroban-env-guest"
 version = "0.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e315e428ca52c33798e21b969cc59c06724303466ae36865a1c30e221753b95c"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=f5d64c9c#f5d64c9c2e52d8162eceebbda204a2252b956559"
 dependencies = [
  "soroban-env-common",
  "static_assertions",
@@ -919,10 +914,10 @@ dependencies = [
 [[package]]
 name = "soroban-env-host"
 version = "0.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8905e033f3b1c5e756a5cadd184e7e8cc449ec6dd16a5a5dd0017b86c8a1d99"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=f5d64c9c#f5d64c9c2e52d8162eceebbda204a2252b956559"
 dependencies = [
  "backtrace",
+ "curve25519-dalek",
  "dyn-fmt",
  "ed25519-dalek",
  "hex",
@@ -943,13 +938,12 @@ dependencies = [
 [[package]]
 name = "soroban-env-macros"
 version = "0.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63b23eda217f8fc531ed46ecc25020512942d51ed437b6075022f77fee5f847"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=f5d64c9c#f5d64c9c2e52d8162eceebbda204a2252b956559"
 dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "stellar-xdr 0.0.7",
+ "stellar-xdr",
  "syn",
 ]
 
@@ -985,24 +979,16 @@ dependencies = [
 name = "soroban-liquidity-pool-contract"
 version = "0.0.0"
 dependencies = [
- "ed25519-dalek",
- "rand 0.7.3",
- "sha2 0.10.6",
  "soroban-auth",
  "soroban-sdk",
- "stellar-xdr 0.0.6",
 ]
 
 [[package]]
 name = "soroban-liquidity-pool-router-contract"
 version = "0.0.0"
 dependencies = [
- "ed25519-dalek",
- "rand 0.7.3",
- "sha2 0.10.6",
  "soroban-auth",
  "soroban-sdk",
- "stellar-xdr 0.0.6",
 ]
 
 [[package]]
@@ -1015,8 +1001,7 @@ dependencies = [
 [[package]]
 name = "soroban-native-sdk-macros"
 version = "0.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd4a4ccc67b7f8a049fc7b65f7fe015c9fc518b993ae7b58f26c70a0fd8afe64"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=f5d64c9c#f5d64c9c2e52d8162eceebbda204a2252b956559"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1027,8 +1012,7 @@ dependencies = [
 [[package]]
 name = "soroban-sdk"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "541d2e344e84c26342b086b761679c88fd88987fe86a1f0fa60a7bf70dbcc9c4"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=8e3d9642#8e3d9642118ee593669e56adbc51a235fa699d3b"
 dependencies = [
  "bytes-lit",
  "ed25519-dalek",
@@ -1042,8 +1026,7 @@ dependencies = [
 [[package]]
 name = "soroban-sdk-macros"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cd2b3180bd1b45b24290f5ed3f36784ef4ac88a33275bd970238c56778efef8"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=8e3d9642#8e3d9642118ee593669e56adbc51a235fa699d3b"
 dependencies = [
  "darling",
  "itertools",
@@ -1052,7 +1035,7 @@ dependencies = [
  "sha2 0.10.6",
  "soroban-env-common",
  "soroban-spec",
- "stellar-xdr 0.0.7",
+ "stellar-xdr",
  "syn",
 ]
 
@@ -1060,19 +1043,14 @@ dependencies = [
 name = "soroban-single-offer-contract"
 version = "0.0.0"
 dependencies = [
- "ed25519-dalek",
- "rand 0.7.3",
  "soroban-auth",
  "soroban-sdk",
- "stellar-xdr 0.0.6",
 ]
 
 [[package]]
 name = "soroban-single-offer-contract-xfer-from"
 version = "0.0.0"
 dependencies = [
- "ed25519-dalek",
- "rand 0.7.3",
  "soroban-auth",
  "soroban-sdk",
 ]
@@ -1081,19 +1059,14 @@ dependencies = [
 name = "soroban-single-offer-router-contract"
 version = "0.0.0"
 dependencies = [
- "ed25519-dalek",
- "rand 0.7.3",
- "sha2 0.10.6",
  "soroban-auth",
  "soroban-sdk",
- "stellar-xdr 0.0.6",
 ]
 
 [[package]]
 name = "soroban-spec"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05fa8fffbfe5023a4be81695442a70f770ee954ab82a8e7a8077674882859817"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=8e3d9642#8e3d9642118ee593669e56adbc51a235fa699d3b"
 dependencies = [
  "base64",
  "darling",
@@ -1105,8 +1078,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sha2 0.10.6",
- "soroban-env-host",
- "stellar-xdr 0.0.7",
+ "stellar-xdr",
  "syn",
  "thiserror",
  "wasmparser",
@@ -1116,7 +1088,6 @@ dependencies = [
 name = "soroban-timelock-contract"
 version = "0.0.0"
 dependencies = [
- "rand 0.8.5",
  "soroban-auth",
  "soroban-sdk",
 ]
@@ -1126,7 +1097,6 @@ name = "soroban-token-contract"
 version = "0.0.6"
 dependencies = [
  "ed25519-dalek",
- "num-bigint",
  "rand 0.7.3",
  "soroban-auth",
  "soroban-sdk",
@@ -1145,8 +1115,7 @@ dependencies = [
 [[package]]
 name = "soroban-wasmi"
 version = "0.16.0-soroban1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40812f1c94fb5cf57ba4cda81f9d17d18bac1dde377967d7ed907b6974627bf8"
+source = "git+https://github.com/stellar/wasmi?rev=d1ec0036#d1ec0036a002a14227b0b09117f0dc6182ae19e4"
 dependencies = [
  "soroban-wasmi_core",
  "spin",
@@ -1156,8 +1125,7 @@ dependencies = [
 [[package]]
 name = "soroban-wasmi_core"
 version = "0.16.0-soroban1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "468b788f0b3d4080a25243d3f452fb8413c31104bdf7612242b506d1229dfe85"
+source = "git+https://github.com/stellar/wasmi?rev=d1ec0036#d1ec0036a002a14227b0b09117f0dc6182ae19e4"
 dependencies = [
  "downcast-rs",
  "libm",
@@ -1181,8 +1149,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "stellar-strkey"
 version = "0.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbdc24a977b92cac2028693957b8e07ffb9249a0767a548391246c9fb964a439"
+source = "git+https://github.com/stellar/rs-stellar-strkey?rev=5e582a8b#5e582a8b48f85443df60dc78e2e98959862400d6"
 dependencies = [
  "base32",
  "thiserror",
@@ -1190,15 +1157,8 @@ dependencies = [
 
 [[package]]
 name = "stellar-xdr"
-version = "0.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcc8646f7ff2122e5d1f82ea754cedd883f30996056a5a92fd9d557db0d2a3b7"
-
-[[package]]
-name = "stellar-xdr"
 version = "0.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9295054553418f5d14d9099070acab34e8befab65aae102a3bae79b9cdf76ac0"
+source = "git+https://github.com/stellar/rs-stellar-xdr?rev=5fd7c7d4#5fd7c7d44d66452209a951be89c0c3602ab9f302"
 dependencies = [
  "base64",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,15 +38,12 @@ panic = "abort"
 codegen-units = 1
 lto = true
 
-# [patch.crates-io]
-# soroban-sdk = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "3ec51a3d" }
-# soroban-spec = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "3ec51a3d" }
-# soroban-auth = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "3ec51a3d" }
-# soroban-sdk-macros = { git = "https://github.com/stellar/rs-soroban-sdk", rev = "3ec51a3d" }
-# soroban-env-common = { git = "https://github.com/stellar/rs-soroban-env", rev = "c04c2332" }
-# soroban-env-guest = { git = "https://github.com/stellar/rs-soroban-env", rev = "c04c2332" }
-# soroban-env-host = { git = "https://github.com/stellar/rs-soroban-env", rev = "c04c2332" }
-# soroban-env-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "c04c2332" }
-# soroban-native-sdk-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "c04c2332" }
-# stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr", rev = "e88f9fa7" }
-# wasmi = { package = "soroban-wasmi", git = "https://github.com/stellar/wasmi", rev = "d1ec0036" }
+[workspace.dependencies.soroban-sdk]
+version = "0.2.1"
+git = "https://github.com/stellar/rs-soroban-sdk"
+rev = "8e3d9642"
+
+[workspace.dependencies.soroban-auth]
+version = "0.2.1"
+git = "https://github.com/stellar/rs-soroban-sdk"
+rev = "8e3d9642"

--- a/auth/Cargo.toml
+++ b/auth/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
-soroban-sdk = "0.2.1"
+soroban-sdk = { workspace = true }
 
 [dev_dependencies]
-soroban-sdk = { version = "0.2.1", features = ["testutils"] }
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/auth_advanced/Cargo.toml
+++ b/auth_advanced/Cargo.toml
@@ -8,12 +8,9 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
-soroban-sdk = "0.2.1"
-soroban-auth = "0.2.1"
-ed25519-dalek = { version = "1.0.1", optional = true }
+soroban-sdk = { workspace = true }
+soroban-auth = { workspace = true }
 
 [dev_dependencies]
-soroban-sdk = { version = "0.2.1", features = ["testutils"] }
-soroban-auth = { version = "0.2.1", features = ["testutils"] }
-ed25519-dalek = { version = "1.0.1" }
-rand = { version = "0.7.3" }
+soroban-sdk = { workspace = true, features = ["testutils"] }
+soroban-auth = { workspace = true, features = ["testutils"] }

--- a/cross_contract/contract_a/Cargo.toml
+++ b/cross_contract/contract_a/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = "0.2.1"
+soroban-sdk = { workspace = true }
 
 [dev_dependencies]
-soroban-sdk = { version = "0.2.1", features = ["testutils"] }
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/cross_contract/contract_b/Cargo.toml
+++ b/cross_contract/contract_b/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = "0.2.1"
+soroban-sdk = { workspace = true }
 
 [dev_dependencies]
-soroban-sdk = { version = "0.2.1", features = ["testutils"] }
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/cross_contract/contract_b/src/test.rs
+++ b/cross_contract/contract_b/src/test.rs
@@ -8,7 +8,7 @@ fn test() {
     let env = Env::default();
 
     // Register contract A using the imported WASM.
-    let contract_a_id = env.register_contract_wasm(None, contract_a::WASM);
+    let contract_a_id = env.register_contract_wasm(contract_a::WASM);
 
     // Register contract B defined in this crate.
     let contract_b_id = env.register_contract(None, ContractB);

--- a/custom_types/Cargo.toml
+++ b/custom_types/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = "0.2.1"
+soroban-sdk = { workspace = true }
 
 [dev_dependencies]
-soroban-sdk = { version = "0.2.1", features = ["testutils"] }
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/deployer/contract/Cargo.toml
+++ b/deployer/contract/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = "0.2.1"
+soroban-sdk = { workspace = true }
 
 [dev_dependencies]
-soroban-sdk = { version = "0.2.1", features = ["testutils"] }
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/deployer/deployer/Cargo.toml
+++ b/deployer/deployer/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = "0.2.1"
+soroban-sdk = { workspace = true }
 
 [dev_dependencies]
-soroban-sdk = { version = "0.2.1", features = ["testutils"] }
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/deployer/deployer/src/lib.rs
+++ b/deployer/deployer/src/lib.rs
@@ -12,12 +12,12 @@ impl Deployer {
     pub fn deploy(
         env: Env,
         salt: Bytes,
-        wasm: Bytes,
+        wasm_hash: BytesN<32>,
         init_fn: Symbol,
         init_args: Vec<RawVal>,
     ) -> (BytesN<32>, RawVal) {
-        // Deploy the wasm.
-        let id = env.deployer().with_current_contract(salt).deploy(wasm);
+        // Deploy the contract using the installed WASM code with given hash.
+        let id = env.deployer().with_current_contract(salt).deploy(wasm_hash);
         // Invoke the init function with the given arguments.
         let res: RawVal = env.invoke_contract(&id, &init_fn, init_args);
         // Return the contract ID of the deployed contract and the result of

--- a/deployer/deployer/src/test.rs
+++ b/deployer/deployer/src/test.rs
@@ -15,9 +15,11 @@ fn test() {
     let env = Env::default();
     let client = DeployerClient::new(&env, &env.register_contract(None, Deployer));
 
-    // Deploy contract using deployer, and include an init function to call.
-    let salt = Bytes::from_array(&env, &[0; 32]);
+    // Install the WASM code to be deployed from the deployer contract.
     let wasm_hash = env.install_contract_wasm(contract::WASM);
+    
+    // Deploy contract using deployer, and include an init function to call.
+    let salt = Bytes::from_array(&env, &[0; 32]);    
     let init_fn = symbol!("init");
     let init_fn_args = (5u32,).into_val(&env);
     let (contract_id, init_result) = client.deploy(&salt, &wasm_hash, &init_fn, &init_fn_args);

--- a/deployer/deployer/src/test.rs
+++ b/deployer/deployer/src/test.rs
@@ -1,7 +1,7 @@
 #![cfg(test)]
 
 use crate::{Deployer, DeployerClient};
-use soroban_sdk::{bytesn, symbol, Bytes, BytesN, Env, IntoVal};
+use soroban_sdk::{symbol, Bytes, Env, IntoVal};
 
 // The contract that will be deployed by the deployer contract.
 mod contract {
@@ -13,20 +13,14 @@ mod contract {
 #[test]
 fn test() {
     let env = Env::default();
-    let deployer_id = BytesN::from_array(&env, &[0; 32]);
-    env.register_contract(&deployer_id, Deployer);
-    let client = DeployerClient::new(&env, &deployer_id);
+    let client = DeployerClient::new(&env, &env.register_contract(None, Deployer));
 
     // Deploy contract using deployer, and include an init function to call.
     let salt = Bytes::from_array(&env, &[0; 32]);
-    let wasm: Bytes = contract::WASM.into_val(&env);
+    let wasm_hash = env.install_contract_wasm(contract::WASM);
     let init_fn = symbol!("init");
     let init_fn_args = (5u32,).into_val(&env);
-    let (contract_id, init_result) = client.deploy(&salt, &wasm, &init_fn, &init_fn_args);
-    assert_eq!(
-        contract_id,
-        bytesn!(&env, 0xead19f55aec09bfcb555e09f230149ba7f72744a5fd639804ce1e934e8fe9c5d)
-    );
+    let (contract_id, init_result) = client.deploy(&salt, &wasm_hash, &init_fn, &init_fn_args);
     assert!(init_result.is_void());
 
     // Invoke contract to check that it is initialized.

--- a/deployer/deployer/src/test.rs
+++ b/deployer/deployer/src/test.rs
@@ -17,9 +17,9 @@ fn test() {
 
     // Install the WASM code to be deployed from the deployer contract.
     let wasm_hash = env.install_contract_wasm(contract::WASM);
-    
+
     // Deploy contract using deployer, and include an init function to call.
-    let salt = Bytes::from_array(&env, &[0; 32]);    
+    let salt = Bytes::from_array(&env, &[0; 32]);
     let init_fn = symbol!("init");
     let init_fn_args = (5u32,).into_val(&env);
     let (contract_id, init_result) = client.deploy(&salt, &wasm_hash, &init_fn, &init_fn_args);

--- a/errors/Cargo.toml
+++ b/errors/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = "0.2.1"
+soroban-sdk = { workspace = true }
 
 [dev_dependencies]
-soroban-sdk = { version = "0.2.1", features = ["testutils"] }
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/events/Cargo.toml
+++ b/events/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = "0.2.1"
+soroban-sdk = { workspace = true }
 
 [dev_dependencies]
-soroban-sdk = { version = "0.2.1", features = ["testutils"] }
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/hello_world/Cargo.toml
+++ b/hello_world/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = "0.2.1"
+soroban-sdk = { workspace = true }
 
 [dev_dependencies]
-soroban-sdk = { version = "0.2.1", features = ["testutils"] }
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/increment/Cargo.toml
+++ b/increment/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = "0.2.1"
+soroban-sdk = { workspace = true }
 
 [dev_dependencies]
-soroban-sdk = { version = "0.2.1", features = ["testutils"] }
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/liquidity_pool/Cargo.toml
+++ b/liquidity_pool/Cargo.toml
@@ -9,18 +9,11 @@ crate-type = ["cdylib"]
 
 [features]
 token-wasm = []
-testutils = ["soroban-sdk/testutils", "dep:ed25519-dalek", "dep:sha2", "dep:stellar-xdr"]
+testutils = ["soroban-sdk/testutils"]
 
 [dependencies]
-soroban-sdk = "0.2.1"
-soroban-auth = "0.2.1"
-stellar-xdr = { version = "0.0.6", features = ["next", "std"], optional = true }
-ed25519-dalek = { version = "1.0.1", optional = true }
-sha2 = { version = "0.10.2", optional = true }
+soroban-sdk = { workspace = true }
+soroban-auth = { workspace = true }
 
 [dev_dependencies]
-soroban-sdk = { version = "0.2.1", features = ["testutils"] }
-stellar-xdr = { version = "0.0.6", features = ["next", "std"] }
-ed25519-dalek = { version = "1.0.1" }
-sha2 = { version = "0.10.2" }
-rand = { version = "0.7.3" }
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/liquidity_pool/src/test.rs
+++ b/liquidity_pool/src/test.rs
@@ -1,34 +1,13 @@
 #![cfg(test)]
+extern crate std;
 
 use crate::testutils::{register_test_contract as register_liqpool, LiquidityPool};
 use crate::token::{self, TokenMetadata};
-use rand::{thread_rng, RngCore};
 use soroban_sdk::{testutils::Accounts, AccountId, BigInt, BytesN, Env, IntoVal};
 use token::{Identifier, Signature};
 
-fn generate_contract_id() -> [u8; 32] {
-    let mut id: [u8; 32] = Default::default();
-    thread_rng().fill_bytes(&mut id);
-    id
-}
-
-fn generate_sorted_contract_ids() -> ([u8; 32], [u8; 32]) {
-    let a = generate_contract_id();
-    let b = generate_contract_id();
-    if a < b {
-        (a, b)
-    } else if a == b {
-        generate_sorted_contract_ids()
-    } else {
-        (b, a)
-    }
-}
-
-fn create_token_contract(e: &Env, id: &[u8; 32], admin: &AccountId) -> token::Client {
-    let contract_id = BytesN::from_array(e, &id);
-    e.register_contract_token(&contract_id);
-
-    let token = token::Client::new(e, id);
+fn create_token_contract(e: &Env, admin: &AccountId) -> token::Client {
+    let token = token::Client::new(e, e.register_contract_token());
     // decimals, name, symbol don't matter in tests
     token.init(
         &Identifier::Account(admin.clone()),
@@ -41,32 +20,29 @@ fn create_token_contract(e: &Env, id: &[u8; 32], admin: &AccountId) -> token::Cl
     token
 }
 
-fn create_liqpool_contract(
-    e: &Env,
-    token_a: &[u8; 32],
-    token_b: &[u8; 32],
-) -> ([u8; 32], LiquidityPool) {
-    let id = generate_contract_id();
-    register_liqpool(&e, &id);
-    let liqpool = LiquidityPool::new(e, &id);
+fn create_liqpool_contract(e: &Env, token_a: &BytesN<32>, token_b: &BytesN<32>) -> LiquidityPool {
+    let liqpool = LiquidityPool::new(e, &register_liqpool(&e));
     liqpool.initialize(token_a, token_b);
-    (id, liqpool)
+    liqpool
 }
 
 #[test]
 fn test() {
     let e: Env = Default::default();
 
-    let admin1 = e.accounts().generate();
-    let admin2 = e.accounts().generate();
+    let mut admin1 = e.accounts().generate();
+    let mut admin2 = e.accounts().generate();
+
+    let mut token1 = create_token_contract(&e, &admin1);
+    let mut token2 = create_token_contract(&e, &admin2);
+    if &token2.contract_id < &token1.contract_id {
+        std::mem::swap(&mut token1, &mut token2);
+        std::mem::swap(&mut admin1, &mut admin2);
+    }
     let user1 = e.accounts().generate();
     let user1_id = Identifier::Account(user1.clone());
-
-    let (contract1, contract2) = generate_sorted_contract_ids();
-    let token1 = create_token_contract(&e, &contract1, &admin1);
-    let token2 = create_token_contract(&e, &contract2, &admin2);
-    let (contract_pool, liqpool) = create_liqpool_contract(&e, &contract1, &contract2);
-    let pool_id = Identifier::Contract(BytesN::from_array(&e, &contract_pool));
+    let liqpool = create_liqpool_contract(&e, &token1.contract_id, &token2.contract_id);
+    let pool_id = Identifier::Contract(liqpool.contract_id.clone());
     let contract_share: [u8; 32] = liqpool.share_id().into();
     let token_share = token::Client::new(&e, &contract_share);
 

--- a/liquidity_pool/src/testutils.rs
+++ b/liquidity_pool/src/testutils.rs
@@ -4,14 +4,13 @@ use soroban_sdk::{BigInt, BytesN, Env};
 
 use crate::{token::Identifier, LiquidityPoolClient};
 
-pub fn register_test_contract(e: &Env, contract_id: &[u8; 32]) {
-    let contract_id = BytesN::from_array(e, contract_id);
-    e.register_contract(&contract_id, crate::LiquidityPool {});
+pub fn register_test_contract(e: &Env) -> BytesN<32> {
+    e.register_contract(None, crate::LiquidityPool {})
 }
 
 pub struct LiquidityPool {
     env: Env,
-    contract_id: BytesN<32>,
+    pub contract_id: BytesN<32>,
 }
 
 impl LiquidityPool {
@@ -19,17 +18,15 @@ impl LiquidityPool {
         LiquidityPoolClient::new(&self.env, &self.contract_id)
     }
 
-    pub fn new(env: &Env, contract_id: &[u8; 32]) -> Self {
+    pub fn new(env: &Env, contract_id: &BytesN<32>) -> Self {
         Self {
             env: env.clone(),
-            contract_id: BytesN::from_array(env, contract_id),
+            contract_id: contract_id.clone(),
         }
     }
 
-    pub fn initialize(&self, token_a: &[u8; 32], token_b: &[u8; 32]) {
-        let token_a = BytesN::from_array(&self.env, token_a);
-        let token_b = BytesN::from_array(&self.env, token_b);
-        self.client().initialize(&token_a, &token_b)
+    pub fn initialize(&self, token_a: &BytesN<32>, token_b: &BytesN<32>) {
+        self.client().initialize(token_a, token_b)
     }
 
     pub fn share_id(&self) -> BytesN<32> {

--- a/liquidity_pool_router/Cargo.toml
+++ b/liquidity_pool_router/Cargo.toml
@@ -8,19 +8,11 @@ publish = false
 crate-type = ["cdylib"]
 
 [features]
-testutils = ["soroban-sdk/testutils" ,"dep:ed25519-dalek", "dep:sha2", "dep:stellar-xdr"]
+testutils = ["soroban-sdk/testutils"]
 
 [dependencies]
-soroban-sdk = "0.2.1"
-soroban-auth = "0.2.1"
-ed25519-dalek = { version = "1.0.1", optional = true }
-stellar-xdr = { version = "0.0.6", features = ["next", "std"], optional = true }
-sha2 = { version = "0.10.2", optional = true }
-
+soroban-sdk = { workspace = true }
+soroban-auth = { workspace = true }
 
 [dev_dependencies]
-soroban-sdk = { version = "0.2.1", features = ["testutils"] }
-stellar-xdr = { version = "0.0.6", features = ["next", "std"] }
-ed25519-dalek = { version = "1.0.1" }
-sha2 = { version = "0.10.2" }
-rand = { version = "0.7.3" }
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/liquidity_pool_router/src/lib.rs
+++ b/liquidity_pool_router/src/lib.rs
@@ -4,8 +4,7 @@ mod pool_contract;
 mod test;
 pub mod testutils;
 
-use pool_contract::{create_contract, LiquidityPoolClient};
-
+use pool_contract::LiquidityPoolClient;
 use soroban_sdk::{contractimpl, contracttype, BigInt, Bytes, BytesN, Env};
 use token::{Identifier, Signature};
 
@@ -34,6 +33,7 @@ fn has_pool(e: &Env, salt: &BytesN<32>) -> bool {
 pub trait LiquidityPoolRouterTrait {
     fn sf_deposit(
         e: Env,
+        liqiudity_pool_wasm_hash: BytesN<32>,
         token_a: BytesN<32>,
         token_b: BytesN<32>,
         desired_a: BigInt,
@@ -111,6 +111,7 @@ struct LiquidityPoolRouter;
 impl LiquidityPoolRouterTrait for LiquidityPoolRouter {
     fn sf_deposit(
         e: Env,
+        liquidity_pool_wasm_hash: BytesN<32>,
         token_a: BytesN<32>,
         token_b: BytesN<32>,
         desired_a: BigInt,
@@ -120,7 +121,10 @@ impl LiquidityPoolRouterTrait for LiquidityPoolRouter {
     ) {
         let salt = pool_salt(&e, &token_a, &token_b);
         if !has_pool(&e, &salt) {
-            let pool_contract_id = create_contract(&e, &salt);
+            let pool_contract_id = e
+                .deployer()
+                .with_current_contract(salt.clone())
+                .deploy(liquidity_pool_wasm_hash);
 
             put_pool(&e, &salt, &pool_contract_id);
 

--- a/liquidity_pool_router/src/pool_contract.rs
+++ b/liquidity_pool_router/src/pool_contract.rs
@@ -1,12 +1,4 @@
-use soroban_sdk::{BytesN, Env};
-
 soroban_sdk::contractimport!(
     file = "../target/wasm32-unknown-unknown/release/soroban_liquidity_pool_contract.wasm"
 );
 pub type LiquidityPoolClient = Client;
-
-pub fn create_contract(e: &Env, salt: &BytesN<32>) -> BytesN<32> {
-    use soroban_sdk::Bytes;
-    let bin = Bytes::from_slice(e, WASM);
-    e.deployer().with_current_contract(salt).deploy(bin)
-}

--- a/liquidity_pool_router/src/testutils.rs
+++ b/liquidity_pool_router/src/testutils.rs
@@ -3,14 +3,13 @@ use soroban_sdk::{AccountId, BigInt, BytesN, Env};
 
 use crate::LiquidityPoolRouterClient;
 
-pub fn register_test_contract(e: &Env, contract_id: &[u8; 32]) {
-    let contract_id = BytesN::from_array(e, contract_id);
-    e.register_contract(&contract_id, crate::LiquidityPoolRouter {});
+pub fn register_test_contract(e: &Env) -> BytesN<32> {
+    e.register_contract(None, crate::LiquidityPoolRouter {})
 }
 
 pub struct LiquidityPoolRouter {
     env: Env,
-    contract_id: BytesN<32>,
+    pub contract_id: BytesN<32>,
 }
 
 impl LiquidityPoolRouter {
@@ -18,72 +17,67 @@ impl LiquidityPoolRouter {
         LiquidityPoolRouterClient::new(&self.env, &self.contract_id)
     }
 
-    pub fn new(env: &Env, contract_id: &[u8; 32]) -> Self {
+    pub fn new(env: &Env, contract_id: &BytesN<32>) -> Self {
         Self {
             env: env.clone(),
-            contract_id: BytesN::from_array(env, contract_id),
+            contract_id: contract_id.clone(),
         }
     }
 
     pub fn sf_deposit(
         &self,
+        liquidity_pool_wasm_hash: &BytesN<32>,
         to: &AccountId,
-        token_a: &[u8; 32],
-        token_b: &[u8; 32],
+        token_a: &BytesN<32>,
+        token_b: &BytesN<32>,
         desired_a: &BigInt,
         min_a: &BigInt,
         desired_b: &BigInt,
         min_b: &BigInt,
     ) {
-        let token_a = BytesN::from_array(&self.env, token_a);
-        let token_b = BytesN::from_array(&self.env, token_b);
-
-        self.client()
-            .with_source_account(&to)
-            .sf_deposit(&token_a, &token_b, &desired_a, &min_a, &desired_b, &min_b)
+        self.client().with_source_account(&to).sf_deposit(
+            liquidity_pool_wasm_hash,
+            token_a,
+            token_b,
+            &desired_a,
+            &min_a,
+            &desired_b,
+            &min_b,
+        )
     }
 
     pub fn swap_out(
         &self,
         to: &AccountId,
-        sell: &[u8; 32],
-        buy: &[u8; 32],
+        sell: &BytesN<32>,
+        buy: &BytesN<32>,
         out: &BigInt,
         in_max: &BigInt,
     ) {
-        let sell = BytesN::from_array(&self.env, sell);
-        let buy = BytesN::from_array(&self.env, buy);
-
         self.client()
             .with_source_account(&to)
-            .swap_out(&sell, &buy, &out, &in_max)
+            .swap_out(sell, buy, &out, &in_max)
     }
 
     pub fn sf_withdrw(
         &self,
         to: &AccountId,
-        token_a: &[u8; 32],
-        token_b: &[u8; 32],
+        token_a: &BytesN<32>,
+        token_b: &BytesN<32>,
         share_amount: &BigInt,
         min_a: &BigInt,
         min_b: &BigInt,
     ) {
-        let token_a = BytesN::from_array(&self.env, token_a);
-        let token_b = BytesN::from_array(&self.env, token_b);
-
         self.client().with_source_account(&to).sf_withdrw(
-            &token_a,
-            &token_b,
+            token_a,
+            token_b,
             &share_amount,
             &min_a,
             &min_b,
         )
     }
 
-    pub fn get_pool(&self, token_a: &[u8; 32], token_b: &[u8; 32]) -> BytesN<32> {
-        let token_a = BytesN::from_array(&self.env, token_a);
-        let token_b = BytesN::from_array(&self.env, token_b);
-
-        self.client().get_pool(&token_a, &token_b)
+    pub fn get_pool(&self, token_a: &BytesN<32>, token_b: &BytesN<32>) -> BytesN<32> {
+        self.client().get_pool(token_a, token_b)
     }
 }

--- a/logging/Cargo.toml
+++ b/logging/Cargo.toml
@@ -14,7 +14,7 @@ doctest = false
 testutils = ["soroban-sdk/testutils"]
 
 [dependencies]
-soroban-sdk = "0.2.1"
+soroban-sdk = { workspace = true }
 
 [dev_dependencies]
-soroban-sdk = { version = "0.2.1", features = ["testutils"] }
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/single_offer/Cargo.toml
+++ b/single_offer/Cargo.toml
@@ -8,15 +8,11 @@ publish = false
 crate-type = ["cdylib"]
 
 [features]
-testutils = ["soroban-sdk/testutils", "dep:ed25519-dalek"]
+testutils = ["soroban-sdk/testutils"]
 
 [dependencies]
-soroban-sdk = "0.2.1"
-soroban-auth = "0.2.1"
-ed25519-dalek = { version = "1.0.1", optional = true }
+soroban-sdk = { workspace = true }
+soroban-auth = { workspace = true }
 
 [dev_dependencies]
-soroban-sdk = { version = "0.2.1", features = ["testutils"] }
-stellar-xdr = { version = "0.0.6" }
-ed25519-dalek = { version = "1.0.1" }
-rand = { version = "0.7.3" }
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/single_offer/src/test.rs
+++ b/single_offer/src/test.rs
@@ -2,18 +2,10 @@
 
 use crate::testutils::{register_test_contract as register_single_offer, SingleOffer};
 use crate::token::{self, Identifier, Signature, TokenMetadata};
-use rand::{thread_rng, RngCore};
 use soroban_sdk::{testutils::Accounts, AccountId, BigInt, BytesN, Env, IntoVal};
 
-fn generate_contract_id() -> [u8; 32] {
-    let mut id: [u8; 32] = Default::default();
-    thread_rng().fill_bytes(&mut id);
-    id
-}
-
-fn create_token_contract(e: &Env, admin: &AccountId) -> ([u8; 32], token::Client) {
-    let id = e.register_contract_token(None);
-    let token = token::Client::new(e, &id);
+fn create_token_contract(e: &Env, admin: &AccountId) -> token::Client {
+    let token = token::Client::new(e, &e.register_contract_token());
     // decimals, name, symbol don't matter in tests
     token.init(
         &Identifier::Account(admin.clone()),
@@ -23,22 +15,20 @@ fn create_token_contract(e: &Env, admin: &AccountId) -> ([u8; 32], token::Client
             decimals: 7,
         },
     );
-    (id.into(), token)
+    token
 }
 
 fn create_single_offer_contract(
     e: &Env,
     admin: &AccountId,
-    token_a: &[u8; 32],
-    token_b: &[u8; 32],
+    token_a: &BytesN<32>,
+    token_b: &BytesN<32>,
     n: u32,
     d: u32,
-) -> ([u8; 32], SingleOffer) {
-    let id = generate_contract_id();
-    register_single_offer(&e, &id);
-    let single_offer = SingleOffer::new(e, &id);
+) -> SingleOffer {
+    let single_offer = SingleOffer::new(e, &register_single_offer(&e));
     single_offer.initialize(&Identifier::Account(admin.clone()), token_a, token_b, n, d);
-    (id, single_offer)
+    single_offer
 }
 
 #[test]
@@ -51,13 +41,13 @@ fn test() {
     let user1_id = Identifier::Account(user1.clone());
     let user2_id = Identifier::Account(user2.clone());
 
-    let (contract1, token1) = create_token_contract(&e, &admin1);
-    let (contract2, token2) = create_token_contract(&e, &admin2);
+    let token1 = create_token_contract(&e, &admin1);
+    let token2 = create_token_contract(&e, &admin2);
 
     // The price here is 1 A == .5 B
-    let (contract_offer, offer) =
-        create_single_offer_contract(&e, &user1, &contract1, &contract2, 1, 2);
-    let offer_id = Identifier::Contract(BytesN::from_array(&e, &contract_offer));
+    let offer =
+        create_single_offer_contract(&e, &user1, &token1.contract_id, &token2.contract_id, 1, 2);
+    let offer_id = Identifier::Contract(offer.contract_id.clone());
 
     token1.with_source_account(&admin1).mint(
         &Signature::Invoker,

--- a/single_offer/src/testutils.rs
+++ b/single_offer/src/testutils.rs
@@ -4,14 +4,13 @@ use crate::{token::Identifier, Price, SingleOfferClient};
 
 use soroban_sdk::{AccountId, BigInt, BytesN, Env};
 
-pub fn register_test_contract(e: &Env, contract_id: &[u8; 32]) {
-    let contract_id = BytesN::from_array(e, contract_id);
-    e.register_contract(&contract_id, crate::SingleOffer {});
+pub fn register_test_contract(e: &Env) -> BytesN<32> {
+    e.register_contract(None, crate::SingleOffer {})
 }
 
 pub struct SingleOffer {
     env: Env,
-    contract_id: BytesN<32>,
+    pub contract_id: BytesN<32>,
 }
 
 impl SingleOffer {
@@ -19,24 +18,22 @@ impl SingleOffer {
         SingleOfferClient::new(&self.env, &self.contract_id)
     }
 
-    pub fn new(env: &Env, contract_id: &[u8; 32]) -> Self {
+    pub fn new(env: &Env, contract_id: &BytesN<32>) -> Self {
         Self {
             env: env.clone(),
-            contract_id: BytesN::from_array(env, contract_id),
+            contract_id: contract_id.clone(),
         }
     }
 
     pub fn initialize(
         &self,
         admin: &Identifier,
-        token_a: &[u8; 32],
-        token_b: &[u8; 32],
+        token_a: &BytesN<32>,
+        token_b: &BytesN<32>,
         n: u32,
         d: u32,
     ) {
-        let token_a = BytesN::from_array(&self.env, token_a);
-        let token_b = BytesN::from_array(&self.env, token_b);
-        self.client().initialize(&admin, &token_a, &token_b, &n, &d);
+        self.client().initialize(&admin, token_a, token_b, &n, &d);
     }
 
     pub fn trade(&self, to: &Identifier, min: &BigInt) {

--- a/single_offer_router/Cargo.toml
+++ b/single_offer_router/Cargo.toml
@@ -8,18 +8,11 @@ publish = false
 crate-type = ["cdylib"]
 
 [features]
-testutils = ["soroban-sdk/testutils","dep:ed25519-dalek", "dep:sha2", "dep:stellar-xdr"]
+testutils = ["soroban-sdk/testutils"]
 
 [dependencies]
-soroban-sdk = "0.2.1"
-soroban-auth = "0.2.1"
-ed25519-dalek = { version = "1.0.1", optional = true }
-stellar-xdr = { version = "0.0.6", features = ["next", "std"], optional = true }
-sha2 = { version = "0.10.2", optional = true }
+soroban-sdk = { workspace = true }
+soroban-auth = { workspace = true }
 
 [dev_dependencies]
-soroban-sdk = { version = "0.2.1", features = ["testutils"] }
-stellar-xdr = { version = "0.0.6", features = ["next", "std"] }
-ed25519-dalek = { version = "1.0.1" }
-sha2 = { version = "0.10.2" }
-rand = { version = "0.7.3" }
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/single_offer_router/src/lib.rs
+++ b/single_offer_router/src/lib.rs
@@ -4,7 +4,7 @@ mod offer_contract;
 mod test;
 pub mod testutils;
 
-use offer_contract::{create_contract, SingleOfferClient};
+use offer_contract::SingleOfferClient;
 use token::{Identifier, Signature};
 
 use soroban_sdk::{contractimpl, contracttype, serde::Serialize, BigInt, Bytes, BytesN, Env};
@@ -39,6 +39,7 @@ pub trait SingleOfferRouterTrait {
     // Creates an offer contract and stores the address in a map
     fn init(
         e: Env,
+        offer_wasm_hash: BytesN<32>,
         admin: Identifier,
         sell_token: BytesN<32>,
         buy_token: BytesN<32>,
@@ -86,6 +87,7 @@ struct SingleOfferRouter;
 impl SingleOfferRouterTrait for SingleOfferRouter {
     fn init(
         e: Env,
+        offer_wasm_hash: BytesN<32>,
         admin: Identifier,
         sell_token: BytesN<32>,
         buy_token: BytesN<32>,
@@ -98,7 +100,10 @@ impl SingleOfferRouterTrait for SingleOfferRouter {
             panic!("contract already exists");
         }
 
-        let offer_contract_id = create_contract(&e, &offer_key);
+        let offer_contract_id = e
+            .deployer()
+            .with_current_contract(offer_key.clone())
+            .deploy(offer_wasm_hash);
 
         put_offer(&e, &offer_key, &offer_contract_id);
 

--- a/single_offer_router/src/offer_contract.rs
+++ b/single_offer_router/src/offer_contract.rs
@@ -1,12 +1,4 @@
-use soroban_sdk::{BytesN, Env};
-
 soroban_sdk::contractimport!(
     file = "../target/wasm32-unknown-unknown/release/soroban_single_offer_contract.wasm"
 );
 pub type SingleOfferClient = Client;
-
-pub fn create_contract(e: &Env, salt: &BytesN<32>) -> BytesN<32> {
-    use soroban_sdk::Bytes;
-    let bin = Bytes::from_slice(e, WASM);
-    e.deployer().with_current_contract(salt).deploy(bin)
-}

--- a/single_offer_router/src/testutils.rs
+++ b/single_offer_router/src/testutils.rs
@@ -3,14 +3,13 @@ use soroban_sdk::{AccountId, BigInt, BytesN, Env};
 
 use crate::{token::Identifier, SingleOfferRouterClient};
 
-pub fn register_test_contract(e: &Env, contract_id: &[u8; 32]) {
-    let contract_id = BytesN::from_array(e, contract_id);
-    e.register_contract(&contract_id, crate::SingleOfferRouter {});
+pub fn register_test_contract(e: &Env) -> BytesN<32> {
+    e.register_contract(None, crate::SingleOfferRouter {})
 }
 
 pub struct SingleOfferRouter {
     env: Env,
-    contract_id: BytesN<32>,
+    pub contract_id: BytesN<32>,
 }
 
 impl SingleOfferRouter {
@@ -18,34 +17,38 @@ impl SingleOfferRouter {
         SingleOfferRouterClient::new(&self.env, &self.contract_id)
     }
 
-    pub fn new(env: &Env, contract_id: &[u8; 32]) -> Self {
+    pub fn new(env: &Env, contract_id: &BytesN<32>) -> Self {
         Self {
             env: env.clone(),
-            contract_id: BytesN::from_array(env, contract_id),
+            contract_id: contract_id.clone(),
         }
     }
 
-    pub fn init(&self, admin: &Identifier, token_a: &[u8; 32], token_b: &[u8; 32], n: u32, d: u32) {
-        let token_a = BytesN::from_array(&self.env, token_a);
-        let token_b = BytesN::from_array(&self.env, token_b);
-        self.client().init(&admin, &token_a, &token_b, &n, &d)
+    pub fn init(
+        &self,
+        offer_wasm_hash: &BytesN<32>,
+        admin: &Identifier,
+        token_a: &BytesN<32>,
+        token_b: &BytesN<32>,
+        n: u32,
+        d: u32,
+    ) {
+        self.client()
+            .init(offer_wasm_hash, admin, token_a, token_b, &n, &d)
     }
 
-    pub fn safe_trade(&self, to: &AccountId, offer: &[u8; 32], amount: &BigInt, min: &BigInt) {
-        let offer_addr = BytesN::from_array(&self.env, offer);
+    pub fn safe_trade(&self, to: &AccountId, offer: &BytesN<32>, amount: &BigInt, min: &BigInt) {
         self.client()
             .with_source_account(&to)
-            .safe_trade(&offer_addr, &amount, &min)
+            .safe_trade(offer, &amount, &min)
     }
 
     pub fn get_offer(
         &self,
         admin: &Identifier,
-        token_a: &[u8; 32],
-        token_b: &[u8; 32],
+        token_a: &BytesN<32>,
+        token_b: &BytesN<32>,
     ) -> BytesN<32> {
-        let token_a = BytesN::from_array(&self.env, token_a);
-        let token_b = BytesN::from_array(&self.env, token_b);
-        self.client().get_offer(&admin, &token_a, &token_b)
+        self.client().get_offer(admin, token_a, token_b)
     }
 }

--- a/single_offer_xfer_from/Cargo.toml
+++ b/single_offer_xfer_from/Cargo.toml
@@ -8,14 +8,11 @@ publish = false
 crate-type = ["cdylib"]
 
 [features]
-testutils = ["soroban-sdk/testutils", "dep:ed25519-dalek"]
+testutils = ["soroban-sdk/testutils"]
 
 [dependencies]
-soroban-sdk = "0.2.1"
-soroban-auth = "0.2.1"
-ed25519-dalek = { version = "1.0.1", optional = true }
+soroban-sdk = { workspace = true }
+soroban-auth = { workspace = true }
 
 [dev_dependencies]
-soroban-sdk = { version = "0.2.1", features = ["testutils"] }
-ed25519-dalek = { version = "1.0.1" }
-rand = { version = "0.7.3" }
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/single_offer_xfer_from/src/test.rs
+++ b/single_offer_xfer_from/src/test.rs
@@ -2,17 +2,10 @@
 
 use crate::testutils::{register_test_contract as register_single_offer, SingleOfferXferFrom};
 use crate::token::{self, Identifier, Signature, TokenMetadata};
-use rand::{thread_rng, RngCore};
 use soroban_sdk::{testutils::Accounts, AccountId, BigInt, BytesN, Env, IntoVal};
 
-fn generate_contract_id() -> [u8; 32] {
-    let mut id: [u8; 32] = Default::default();
-    thread_rng().fill_bytes(&mut id);
-    id
-}
-
-fn create_token_contract(e: &Env, admin: &AccountId) -> ([u8; 32], token::Client) {
-    let id = e.register_contract_token(None);
+fn create_token_contract(e: &Env, admin: &AccountId) -> token::Client {
+    let id = e.register_contract_token();
     let token = token::Client::new(e, &id);
     // decimals, name, symbol don't matter in tests
     token.init(
@@ -23,22 +16,20 @@ fn create_token_contract(e: &Env, admin: &AccountId) -> ([u8; 32], token::Client
             decimals: 7,
         },
     );
-    (id.into(), token)
+    token
 }
 
 fn create_single_offer_contract(
     e: &Env,
     admin: &AccountId,
-    token_a: &[u8; 32],
-    token_b: &[u8; 32],
+    token_a: &BytesN<32>,
+    token_b: &BytesN<32>,
     n: u32,
     d: u32,
-) -> ([u8; 32], SingleOfferXferFrom) {
-    let id = generate_contract_id();
-    register_single_offer(&e, &id);
-    let single_offer = SingleOfferXferFrom::new(e, &id);
+) -> SingleOfferXferFrom {
+    let single_offer = SingleOfferXferFrom::new(e, &register_single_offer(&e));
     single_offer.initialize(&Identifier::Account(admin.clone()), token_a, token_b, n, d);
-    (id, single_offer)
+    single_offer
 }
 
 #[test]
@@ -52,13 +43,13 @@ fn test() {
     let user1_id = Identifier::Account(user1.clone());
     let user2_id = Identifier::Account(user2.clone());
 
-    let (contract1, token1) = create_token_contract(&e, &admin1);
-    let (contract2, token2) = create_token_contract(&e, &admin2);
+    let token1 = create_token_contract(&e, &admin1);
+    let token2 = create_token_contract(&e, &admin2);
 
     // The price here is 1 A == .5 B and the admin in user1
-    let (contract_offer, offer) =
-        create_single_offer_contract(&e, &user1, &contract1, &contract2, 1, 2);
-    let offer_id = Identifier::Contract(BytesN::from_array(&e, &contract_offer));
+    let offer =
+        create_single_offer_contract(&e, &user1, &token1.contract_id, &token2.contract_id, 1, 2);
+    let offer_id = Identifier::Contract(offer.contract_id.clone());
 
     // mint tokens that will be traded
     token1.with_source_account(&admin1).mint(

--- a/single_offer_xfer_from/src/testutils.rs
+++ b/single_offer_xfer_from/src/testutils.rs
@@ -3,14 +3,13 @@
 use crate::{token::Identifier, Price, SingleOfferXferFromClient};
 use soroban_sdk::{AccountId, BigInt, BytesN, Env};
 
-pub fn register_test_contract(e: &Env, contract_id: &[u8; 32]) {
-    let contract_id = BytesN::from_array(e, contract_id);
-    e.register_contract(&contract_id, crate::SingleOfferXferFrom {});
+pub fn register_test_contract(e: &Env) -> BytesN<32> {
+    e.register_contract(None, crate::SingleOfferXferFrom {})
 }
 
 pub struct SingleOfferXferFrom {
     env: Env,
-    contract_id: BytesN<32>,
+    pub contract_id: BytesN<32>,
 }
 
 impl SingleOfferXferFrom {
@@ -18,25 +17,22 @@ impl SingleOfferXferFrom {
         SingleOfferXferFromClient::new(&self.env, &self.contract_id)
     }
 
-    pub fn new(env: &Env, contract_id: &[u8; 32]) -> Self {
+    pub fn new(env: &Env, contract_id: &BytesN<32>) -> Self {
         Self {
             env: env.clone(),
-            contract_id: BytesN::from_array(env, contract_id),
+            contract_id: contract_id.clone(),
         }
     }
 
     pub fn initialize(
         &self,
         admin: &Identifier,
-        token_a: &[u8; 32],
-        token_b: &[u8; 32],
+        token_a: &BytesN<32>,
+        token_b: &BytesN<32>,
         n: u32,
         d: u32,
     ) {
-        let token_a = BytesN::from_array(&self.env, token_a);
-        let token_b = BytesN::from_array(&self.env, token_b);
-
-        self.client().initialize(&admin, &token_a, &token_b, &n, &d)
+        self.client().initialize(admin, token_a, token_b, &n, &d)
     }
 
     pub fn trade(&self, to: &AccountId, amount_to_sell: &BigInt, min: &BigInt) {

--- a/timelock/Cargo.toml
+++ b/timelock/Cargo.toml
@@ -11,9 +11,8 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = "0.2.1"
-soroban-auth = "0.2.1"
+soroban-sdk = { workspace = true }
+soroban-auth = { workspace = true }
 
 [dev_dependencies]
-soroban-sdk = { version = "0.2.1", features = ["testutils"] }
-rand = { version = "0.8.5" }
+soroban-sdk = { workspace = true, features = ["testutils"]  }

--- a/timelock/src/test.rs
+++ b/timelock/src/test.rs
@@ -1,19 +1,12 @@
 #![cfg(test)]
 
 use super::*;
-use rand::{thread_rng, RngCore};
 use soroban_sdk::testutils::{Accounts, Ledger, LedgerInfo};
 use soroban_sdk::{vec, AccountId, Env, IntoVal};
 use token::{Client as TokenClient, TokenMetadata};
 
-fn generate_contract_id() -> [u8; 32] {
-    let mut id: [u8; 32] = Default::default();
-    thread_rng().fill_bytes(&mut id);
-    id
-}
-
 fn create_token_contract(e: &Env, admin: &AccountId) -> (BytesN<32>, TokenClient) {
-    let id = e.register_contract_token(None);
+    let id = e.register_contract_token();
     let token = TokenClient::new(e, &id);
     // decimals, name, symbol don't matter in tests
     token.init(
@@ -28,10 +21,7 @@ fn create_token_contract(e: &Env, admin: &AccountId) -> (BytesN<32>, TokenClient
 }
 
 fn create_claimable_balance_contract(e: &Env) -> ClaimableBalanceContractClient {
-    let contract_id = BytesN::from_array(e, &generate_contract_id());
-    e.register_contract(&contract_id, ClaimableBalanceContract {});
-
-    ClaimableBalanceContractClient::new(e, contract_id)
+    ClaimableBalanceContractClient::new(e, e.register_contract(None, ClaimableBalanceContract {}))
 }
 
 struct ClaimableBalanceTest {

--- a/token/Cargo.toml
+++ b/token/Cargo.toml
@@ -8,16 +8,12 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [features]
-testutils = ["soroban-sdk/testutils", "soroban-auth/testutils", "dep:ed25519-dalek"]
+testutils = ["soroban-sdk/testutils", "soroban-auth/testutils"]
 
 [dependencies]
-ed25519-dalek = { version = "1.0.1", optional = true }
-num-bigint = { version = "0.4", optional = true }
-soroban-sdk = { version = "0.2.1" }
-soroban-auth = { version = "0.2.1" }
+soroban-sdk = { workspace = true }
+soroban-auth = { workspace = true }
 
 [dev-dependencies]
-soroban-sdk = { version = "0.2.1", features = ["testutils"] }
-soroban-auth = { version = "0.2.1", features = ["testutils"] }
 ed25519-dalek = { version = "1.0.1" }
 rand = { version = "0.7.3" }

--- a/token/src/test.rs
+++ b/token/src/test.rs
@@ -5,13 +5,7 @@ use crate::TokenClient;
 use ed25519_dalek::Keypair;
 use rand::{thread_rng, RngCore};
 use soroban_auth::{Ed25519Signature, Signature};
-use soroban_sdk::{BigInt, BytesN, Env, IntoVal};
-
-fn generate_contract_id() -> [u8; 32] {
-    let mut id: [u8; 32] = Default::default();
-    thread_rng().fill_bytes(&mut id);
-    id
-}
+use soroban_sdk::{BigInt, Env, IntoVal};
 
 fn generate_keypair() -> Keypair {
     Keypair::generate(&mut thread_rng())
@@ -20,8 +14,7 @@ fn generate_keypair() -> Keypair {
 #[test]
 fn test() {
     let e: Env = Default::default();
-    let contract_id = generate_contract_id();
-    register_token(&e, &contract_id);
+    let contract_id = register_token(&e);
     let token = Token::new(&e, &contract_id);
 
     let admin1 = generate_keypair();
@@ -83,8 +76,7 @@ fn test() {
 #[should_panic(expected = "insufficient balance")]
 fn xfer_insufficient_balance() {
     let e: Env = Default::default();
-    let contract_id = generate_contract_id();
-    register_token(&e, &contract_id);
+    let contract_id = register_token(&e);
     let token = Token::new(&e, &contract_id);
 
     let admin1 = generate_keypair();
@@ -107,8 +99,7 @@ fn xfer_insufficient_balance() {
 #[should_panic(expected = "can't receive when frozen")]
 fn xfer_receive_frozen() {
     let e: Env = Default::default();
-    let contract_id = generate_contract_id();
-    register_token(&e, &contract_id);
+    let contract_id = register_token(&e);
     let token = Token::new(&e, &contract_id);
 
     let admin1 = generate_keypair();
@@ -132,8 +123,7 @@ fn xfer_receive_frozen() {
 #[should_panic(expected = "can't spend when frozen")]
 fn xfer_spend_frozen() {
     let e: Env = Default::default();
-    let contract_id = generate_contract_id();
-    register_token(&e, &contract_id);
+    let contract_id = register_token(&e);
     let token = Token::new(&e, &contract_id);
 
     let admin1 = generate_keypair();
@@ -157,8 +147,7 @@ fn xfer_spend_frozen() {
 #[should_panic(expected = "insufficient allowance")]
 fn xfer_from_insufficient_allowance() {
     let e: Env = Default::default();
-    let contract_id = generate_contract_id();
-    register_token(&e, &contract_id);
+    let contract_id = register_token(&e);
     let token = Token::new(&e, &contract_id);
 
     let admin1 = generate_keypair();
@@ -190,8 +179,7 @@ fn xfer_from_insufficient_allowance() {
 #[should_panic(expected = "already initialized")]
 fn initialize_already_initialized() {
     let e: Env = Default::default();
-    let contract_id = generate_contract_id();
-    register_token(&e, &contract_id);
+    let contract_id = register_token(&e);
     let token = Token::new(&e, &contract_id);
 
     let admin1 = generate_keypair();
@@ -205,8 +193,7 @@ fn initialize_already_initialized() {
 #[should_panic] // TODO: Add expected
 fn set_admin_bad_signature() {
     let e: Env = Default::default();
-    let contract_id = generate_contract_id();
-    register_token(&e, &contract_id);
+    let contract_id = register_token(&e);
     let token = Token::new(&e, &contract_id);
 
     let admin1 = generate_keypair();
@@ -224,9 +211,7 @@ fn set_admin_bad_signature() {
         signature: signature.into_val(&e),
     });
 
-    let contract_id_bin = BytesN::from_array(&e, &contract_id);
-
-    let client = TokenClient::new(&e, &contract_id_bin);
+    let client = TokenClient::new(&e, &contract_id);
     let nonce = client.nonce(&admin1_id);
     client.set_admin(&auth, &nonce, &admin2_id);
 }
@@ -235,8 +220,7 @@ fn set_admin_bad_signature() {
 #[should_panic(expected = "Decimal must fit in a u8")]
 fn decimal_is_over_max() {
     let e = Default::default();
-    let contract_id = generate_contract_id();
-    register_token(&e, &contract_id);
+    let contract_id = register_token(&e);
     let token = Token::new(&e, &contract_id);
 
     let admin1 = generate_keypair();

--- a/token/src/testutils.rs
+++ b/token/src/testutils.rs
@@ -6,9 +6,8 @@ use soroban_auth::{Ed25519Signature, Identifier, Signature, SignaturePayload, Si
 use soroban_sdk::testutils::ed25519::Sign;
 use soroban_sdk::{symbol, BigInt, Bytes, BytesN, Env, IntoVal};
 
-pub fn register_test_contract(e: &Env, contract_id: &[u8; 32]) {
-    let contract_id = BytesN::from_array(e, contract_id);
-    e.register_contract(&contract_id, crate::contract::Token {});
+pub fn register_test_contract(e: &Env) -> BytesN<32> {
+    e.register_contract(None, crate::contract::Token {})
 }
 
 pub fn to_ed25519(e: &Env, kp: &Keypair) -> Identifier {
@@ -21,10 +20,10 @@ pub struct Token {
 }
 
 impl Token {
-    pub fn new(env: &Env, contract_id: &[u8; 32]) -> Self {
+    pub fn new(env: &Env, contract_id: &BytesN<32>) -> Self {
         Self {
             env: env.clone(),
-            contract_id: BytesN::from_array(env, contract_id),
+            contract_id: contract_id.clone(),
         }
     }
 

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -11,11 +11,11 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = "0.2.1"
-soroban-auth = "0.2.1"
+soroban-sdk = { workspace = true }
+soroban-auth = { workspace = true }
 
 [dev_dependencies]
-soroban-sdk = { version = "0.2.1", features = ["testutils"] }
-soroban-auth = { version = "0.2.1", features = ["testutils"] }
+soroban-sdk = { workspace = true, features = ["testutils"] }
+soroban-auth = { workspace = true, features = ["testutils"] }
 rand = { version = "0.7.3" }
 ed25519-dalek = { version = "1.0.1" }

--- a/wallet/src/test.rs
+++ b/wallet/src/test.rs
@@ -25,7 +25,7 @@ fn generate_id() -> [u8; 32] {
 // test only for the sake of the test setup simplicity. There are no limitations
 // on types of identifiers used in any contexts here.
 fn create_token_contract(e: &Env, admin: &AccountId) -> (BytesN<32>, TokenClient) {
-    let id = e.register_contract_token(None);
+    let id = e.register_contract_token();
     let token = TokenClient::new(e, &id);
     // decimals, name, symbol don't matter in tests
     token.init(
@@ -40,10 +40,7 @@ fn create_token_contract(e: &Env, admin: &AccountId) -> (BytesN<32>, TokenClient
 }
 
 fn create_wallet_contract(e: &Env) -> WalletContractClient {
-    let contract_id = BytesN::from_array(e, &generate_id());
-    e.register_contract(&contract_id, WalletContract {});
-
-    WalletContractClient::new(e, contract_id)
+    WalletContractClient::new(e, e.register_contract(None, WalletContract {}))
 }
 
 fn sign_args(


### PR DESCRIPTION
### What

Update the SDK revision and change the examples to deploy the contracts using the WASM hash, as well as tests to not use contract ids.

### Why

Support the SDK changes.

### Known limitations

N/A
