### PR TITLE
Update soroban-cli in gitpod to v0.3.3

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,7 +1,7 @@
 FROM gitpod/workspace-full:2022-11-09-13-54-49
 
 RUN mkdir -p ~/.local/bin
-RUN curl -L -o ~/.local/bin/soroban https://github.com/stellar/soroban-tools/releases/download/v0.3.1/soroban-cli-0.3.1-x86_64-unknown-linux-gnu
+RUN curl -L -o ~/.local/bin/soroban https://github.com/stellar/soroban-tools/releases/download/v0.3.3/soroban-cli-0.3.3-x86_64-unknown-linux-gnu
 RUN chmod +x ~/.local/bin/soroban
 RUN curl -L https://github.com/mozilla/sccache/releases/download/v0.3.0/sccache-v0.3.0-x86_64-unknown-linux-musl.tar.gz | tar xz --strip-components 1 -C ~/.local/bin sccache-v0.3.0-x86_64-unknown-linux-musl/sccache
 RUN chmod +x ~/.local/bin/sccache


### PR DESCRIPTION
### What
Update soroban-cli in gitpod to v0.3.3.

### Why
To get the new version of soroban-cli that is built against an older version of glibc.

<a href="https://gitpod.io/#https://github.com/stellar/soroban-examples/pull/182"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

