### PR TITLE
Fix tests so they compile when running cargo test inside the module directory

### DIFF
--- a/liquidity_pool/Cargo.toml
+++ b/liquidity_pool/Cargo.toml
@@ -18,3 +18,4 @@ num-integer = { version = "0.1.45", default-features = false, features = ["i128"
 
 [dev_dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }
+soroban-auth = { workspace = true, features = ["testutils"] }

--- a/liquidity_pool_router/Cargo.toml
+++ b/liquidity_pool_router/Cargo.toml
@@ -16,3 +16,4 @@ soroban-auth = { workspace = true }
 
 [dev_dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }
+soroban-auth = { workspace = true, features = ["testutils"] }

--- a/single_offer/Cargo.toml
+++ b/single_offer/Cargo.toml
@@ -16,3 +16,4 @@ soroban-auth = { workspace = true }
 
 [dev_dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }
+soroban-auth = { workspace = true, features = ["testutils"] }

--- a/single_offer_router/Cargo.toml
+++ b/single_offer_router/Cargo.toml
@@ -16,3 +16,4 @@ soroban-auth = { workspace = true }
 
 [dev_dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }
+soroban-auth = { workspace = true, features = ["testutils"] }

--- a/single_offer_xfer_from/Cargo.toml
+++ b/single_offer_xfer_from/Cargo.toml
@@ -16,3 +16,4 @@ soroban-auth = { workspace = true }
 
 [dev_dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }
+soroban-auth = { workspace = true, features = ["testutils"] }

--- a/timelock/Cargo.toml
+++ b/timelock/Cargo.toml
@@ -19,3 +19,4 @@ soroban-auth = { workspace = true }
 
 [dev_dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"]  }
+soroban-auth = { workspace = true, features = ["testutils"]  }

--- a/token/Cargo.toml
+++ b/token/Cargo.toml
@@ -17,3 +17,5 @@ soroban-auth = { workspace = true }
 [dev-dependencies]
 ed25519-dalek = { version = "1.0.1" }
 rand = { version = "0.7.3" }
+soroban-sdk = { workspace = true, features = ["testutils"] }
+soroban-auth = { workspace = true, features = ["testutils"] }


### PR DESCRIPTION
@jeesunikim and @marta-lokhova discovered that `cargo test` fails with a compilation error in some modules when it's run inside the modules directory (as opposed to from the root directory). This fixes the issue. 

It's still a little unclear why the tests still compile and run when run together. My theory is that since one of the other tests has `soroban-auth = { workspace = true, features = ["testutils"] }` under dev_dependencies, the others pick it up. I confirmed this by removing all but the timelock example from the root toml and the compilation error returned.


<a href="https://gitpod.io/#https://github.com/stellar/soroban-examples/pull/194"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

