### PR TITLE
Fix SDK revs to point to post-merge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -801,7 +801,7 @@ dependencies = [
 [[package]]
 name = "soroban-auth"
 version = "0.4.3"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=ed99657bd7ccc8e8fcadd106a663d2f5ac165c7f#ed99657bd7ccc8e8fcadd106a663d2f5ac165c7f"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=e1c3de33942f0e997680645941787102ebf61e85#e1c3de33942f0e997680645941787102ebf61e85"
 dependencies = [
  "ed25519-dalek",
  "rand 0.7.3",
@@ -948,7 +948,7 @@ dependencies = [
 [[package]]
 name = "soroban-ledger-snapshot"
 version = "0.4.3"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=ed99657bd7ccc8e8fcadd106a663d2f5ac165c7f#ed99657bd7ccc8e8fcadd106a663d2f5ac165c7f"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=e1c3de33942f0e997680645941787102ebf61e85#e1c3de33942f0e997680645941787102ebf61e85"
 dependencies = [
  "serde",
  "serde_json",
@@ -994,7 +994,7 @@ dependencies = [
 [[package]]
 name = "soroban-sdk"
 version = "0.4.3"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=ed99657bd7ccc8e8fcadd106a663d2f5ac165c7f#ed99657bd7ccc8e8fcadd106a663d2f5ac165c7f"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=e1c3de33942f0e997680645941787102ebf61e85#e1c3de33942f0e997680645941787102ebf61e85"
 dependencies = [
  "bytes-lit",
  "ed25519-dalek",
@@ -1009,7 +1009,7 @@ dependencies = [
 [[package]]
 name = "soroban-sdk-macros"
 version = "0.4.3"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=ed99657bd7ccc8e8fcadd106a663d2f5ac165c7f#ed99657bd7ccc8e8fcadd106a663d2f5ac165c7f"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=e1c3de33942f0e997680645941787102ebf61e85#e1c3de33942f0e997680645941787102ebf61e85"
 dependencies = [
  "darling",
  "itertools",
@@ -1049,7 +1049,7 @@ dependencies = [
 [[package]]
 name = "soroban-spec"
 version = "0.4.3"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=ed99657bd7ccc8e8fcadd106a663d2f5ac165c7f#ed99657bd7ccc8e8fcadd106a663d2f5ac165c7f"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=e1c3de33942f0e997680645941787102ebf61e85#e1c3de33942f0e997680645941787102ebf61e85"
 dependencies = [
  "base64",
  "darling",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,9 +42,9 @@ lto = true
 [workspace.dependencies.soroban-sdk]
 version = "0.4.2"
 git = "https://github.com/stellar/rs-soroban-sdk"
-rev = "ed99657bd7ccc8e8fcadd106a663d2f5ac165c7f"
+rev = "e1c3de33942f0e997680645941787102ebf61e85"
 
 [workspace.dependencies.soroban-auth]
 version = "0.4.2"
 git = "https://github.com/stellar/rs-soroban-sdk"
-rev = "ed99657bd7ccc8e8fcadd106a663d2f5ac165c7f"
+rev = "e1c3de33942f0e997680645941787102ebf61e85"


### PR DESCRIPTION
In https://github.com/stellar/soroban-examples/pull/195 I accidentally pointed to the pre-merge rather than post-merge revs of the SDK.

<a href="https://gitpod.io/#https://github.com/stellar/soroban-examples/pull/196"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

