### PR TITLE
Remove optimization makefile targets

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,7 +12,7 @@ jobs:
 
   complete:
     if: always()
-    needs: [fmt, rust-analyzer-compat, build-and-test, build-and-test-optimized]
+    needs: [fmt, rust-analyzer-compat, build-and-test]
     runs-on: ubuntu-latest
     steps:
     - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
@@ -47,22 +47,5 @@ jobs:
     - run: rustup update
     - run: rustup target add ${{ matrix.sys.target }}
     - run: make test
-      env:
-        CARGO_BUILD_TARGET: ${{ matrix.sys.target }}
-
-  build-and-test-optimized:
-    strategy:
-      matrix:
-        sys:
-        - os: ubuntu-latest
-          target: x86_64-unknown-linux-gnu
-    runs-on: ${{ matrix.sys.os }}
-    steps:
-    - uses: actions/checkout@v3
-    - uses: stellar/actions/rust-cache@main
-    - run: rustup update nightly
-    - run: rustup component add rust-src --toolchain nightly-${{ matrix.sys.target }}
-    - run: rustup target add ${{ matrix.sys.target }}
-    - run: make test-optimized
       env:
         CARGO_BUILD_TARGET: ${{ matrix.sys.target }}

--- a/Makefile
+++ b/Makefile
@@ -16,21 +16,6 @@ build:
 			ls -l "$$i"; \
 		done
 
-test-optimized: build-optimized
-	cargo test
-	cargo test --features testutils
-
-build-optimized:
-	cargo +nightly build --target wasm32-unknown-unknown --release -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort -p soroban-token-contract
-	cargo +nightly build --target wasm32-unknown-unknown --release -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort -p soroban-cross-contract-a-contract
-	cargo +nightly build --target wasm32-unknown-unknown --release -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort -p soroban-atomic-swap-contract
-	cargo +nightly build --target wasm32-unknown-unknown --release -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort
-	cd target/wasm32-unknown-unknown/release/ && \
-		for i in *.wasm ; do \
-			wasm-opt -Oz -c -mvp "$$i" -o "$$i.tmp" && mv "$$i.tmp" "$$i"; \
-			ls -l "$$i"; \
-		done
-
 watch:
 	cargo watch --clear --watch-when-idle --shell '$(MAKE)'
 


### PR DESCRIPTION
### What
Remove optimization makefile targets.

### Why
We aren't encouraging or promoting this optimization method anymore, because it relies on nightly which is an unstable release of Rust, and we have achieved similar optimizations in the SDK using the unwrap_optimized function.

<a href="https://gitpod.io/#https://github.com/stellar/soroban-examples/pull/215"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

