### PR TITLE
Use client `.address()` method directly to get contract address.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -859,7 +859,7 @@ dependencies = [
 [[package]]
 name = "soroban-auth"
 version = "0.6.0"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=754c43bd87fe3fd69773ab5e3dc9cbe5a4852c37#754c43bd87fe3fd69773ab5e3dc9cbe5a4852c37"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=7a2d3c4acc816f0b4214b3ca09d2e1aef8a33259#7a2d3c4acc816f0b4214b3ca09d2e1aef8a33259"
 dependencies = [
  "soroban-sdk",
 ]
@@ -997,7 +997,7 @@ dependencies = [
 [[package]]
 name = "soroban-ledger-snapshot"
 version = "0.6.0"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=754c43bd87fe3fd69773ab5e3dc9cbe5a4852c37#754c43bd87fe3fd69773ab5e3dc9cbe5a4852c37"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=7a2d3c4acc816f0b4214b3ca09d2e1aef8a33259#7a2d3c4acc816f0b4214b3ca09d2e1aef8a33259"
 dependencies = [
  "serde",
  "serde_json",
@@ -1034,7 +1034,7 @@ dependencies = [
 [[package]]
 name = "soroban-sdk"
 version = "0.6.0"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=754c43bd87fe3fd69773ab5e3dc9cbe5a4852c37#754c43bd87fe3fd69773ab5e3dc9cbe5a4852c37"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=7a2d3c4acc816f0b4214b3ca09d2e1aef8a33259#7a2d3c4acc816f0b4214b3ca09d2e1aef8a33259"
 dependencies = [
  "bytes-lit",
  "ed25519-dalek",
@@ -1049,7 +1049,7 @@ dependencies = [
 [[package]]
 name = "soroban-sdk-macros"
 version = "0.6.0"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=754c43bd87fe3fd69773ab5e3dc9cbe5a4852c37#754c43bd87fe3fd69773ab5e3dc9cbe5a4852c37"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=7a2d3c4acc816f0b4214b3ca09d2e1aef8a33259#7a2d3c4acc816f0b4214b3ca09d2e1aef8a33259"
 dependencies = [
  "darling",
  "itertools",
@@ -1072,7 +1072,7 @@ dependencies = [
 [[package]]
 name = "soroban-spec"
 version = "0.6.0"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=754c43bd87fe3fd69773ab5e3dc9cbe5a4852c37#754c43bd87fe3fd69773ab5e3dc9cbe5a4852c37"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=7a2d3c4acc816f0b4214b3ca09d2e1aef8a33259#7a2d3c4acc816f0b4214b3ca09d2e1aef8a33259"
 dependencies = [
  "base64",
  "darling",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,9 +40,13 @@ lto = true
 [workspace.dependencies.soroban-sdk]
 version = "0.6.0"
 git = "https://github.com/stellar/rs-soroban-sdk"
-rev = "754c43bd87fe3fd69773ab5e3dc9cbe5a4852c37"
+rev = "7a2d3c4acc816f0b4214b3ca09d2e1aef8a33259"
 
 [workspace.dependencies.soroban-auth]
 version = "0.6.0"
 git = "https://github.com/stellar/rs-soroban-sdk"
-rev = "754c43bd87fe3fd69773ab5e3dc9cbe5a4852c37"
+rev = "7a2d3c4acc816f0b4214b3ca09d2e1aef8a33259"
+
+# [patch."https://github.com/stellar/rs-soroban-sdk"]
+# soroban-sdk = { path = "../rs-soroban-sdk/soroban-sdk" }
+# soroban-auth = { path = "../rs-soroban-sdk/soroban-auth" }

--- a/account/src/test.rs
+++ b/account/src/test.rs
@@ -5,7 +5,7 @@ use ed25519_dalek::Keypair;
 use ed25519_dalek::Signer;
 use rand::thread_rng;
 use soroban_auth::AuthorizationContext;
-use soroban_sdk::{testutils::BytesN as _, vec, Address, BytesN, Env, IntoVal, Symbol};
+use soroban_sdk::{testutils::BytesN as _, vec, BytesN, Env, IntoVal, Symbol};
 
 use crate::AccError;
 use crate::{AccountContract, AccountContractClient, Signature};
@@ -75,14 +75,13 @@ fn test_token_auth() {
         .unwrap()
         .unwrap();
 
-    let account_address = Address::from_contract_id(&env, &account_contract.contract_id);
     // Add a spend limit of 1000 per 1 signer.
     account_contract.add_limit(&token, &1000);
     // Verify that this call needs to be authorized.
     assert_eq!(
         env.recorded_top_authorizations(),
         std::vec![(
-            account_address.clone(),
+            account_contract.address(),
             account_contract.contract_id.clone(),
             Symbol::short("add_limit"),
             (token.clone(), 1000_i128).into_val(&env),

--- a/liquidity_pool/src/test.rs
+++ b/liquidity_pool/src/test.rs
@@ -48,8 +48,6 @@ fn test() {
         &token2.contract_id,
     );
 
-    let pool_address = Address::from_contract_id(&e, &liqpool.contract_id);
-
     let contract_share: [u8; 32] = liqpool.share_id().into();
     let token_share = token::Client::new(&e, &contract_share);
 
@@ -71,11 +69,11 @@ fn test() {
     );
 
     assert_eq!(token_share.balance(&user1), 100);
-    assert_eq!(token_share.balance(&pool_address), 0);
+    assert_eq!(token_share.balance(&liqpool.address()), 0);
     assert_eq!(token1.balance(&user1), 900);
-    assert_eq!(token1.balance(&pool_address), 100);
+    assert_eq!(token1.balance(&liqpool.address()), 100);
     assert_eq!(token2.balance(&user1), 900);
-    assert_eq!(token2.balance(&pool_address), 100);
+    assert_eq!(token2.balance(&liqpool.address()), 100);
 
     liqpool.swap(&user1, &false, &49, &100);
     assert_eq!(
@@ -89,9 +87,9 @@ fn test() {
     );
 
     assert_eq!(token1.balance(&user1), 803);
-    assert_eq!(token1.balance(&pool_address), 197);
+    assert_eq!(token1.balance(&liqpool.address()), 197);
     assert_eq!(token2.balance(&user1), 949);
-    assert_eq!(token2.balance(&pool_address), 51);
+    assert_eq!(token2.balance(&liqpool.address()), 51);
 
     liqpool.withdraw(&user1, &100, &197, &51);
     assert_eq!(
@@ -107,7 +105,7 @@ fn test() {
     assert_eq!(token1.balance(&user1), 1000);
     assert_eq!(token2.balance(&user1), 1000);
     assert_eq!(token_share.balance(&user1), 0);
-    assert_eq!(token1.balance(&pool_address), 0);
-    assert_eq!(token2.balance(&pool_address), 0);
-    assert_eq!(token_share.balance(&pool_address), 0);
+    assert_eq!(token1.balance(&liqpool.address()), 0);
+    assert_eq!(token2.balance(&liqpool.address()), 0);
+    assert_eq!(token_share.balance(&liqpool.address()), 0);
 }

--- a/single_offer/src/test.rs
+++ b/single_offer/src/test.rs
@@ -58,13 +58,11 @@ fn test() {
         1,
         2,
     );
-    let offer_address = Address::from_contract_id(&e, &offer.contract_id);
-
     // Give some sell_token to seller and buy_token to buyer.
     sell_token.mint(&token_admin, &seller, &1000);
     buy_token.mint(&token_admin, &buyer, &1000);
     // Deposit 100 sell_token from seller into offer.
-    sell_token.xfer(&seller, &offer_address, &100);
+    sell_token.xfer(&seller, &offer.address(), &100);
 
     // Try trading 20 buy_token for at least 11 sell_token - that wouldn't
     // succeed because the offer price would result in 10 sell_token.
@@ -84,10 +82,10 @@ fn test() {
 
     assert_eq!(sell_token.balance(&seller), 900);
     assert_eq!(sell_token.balance(&buyer), 10);
-    assert_eq!(sell_token.balance(&offer_address), 90);
+    assert_eq!(sell_token.balance(&offer.address()), 90);
     assert_eq!(buy_token.balance(&seller), 20);
     assert_eq!(buy_token.balance(&buyer), 980);
-    assert_eq!(buy_token.balance(&offer_address), 0);
+    assert_eq!(buy_token.balance(&offer.address()), 0);
 
     // Withdraw 70 sell_token from offer.
     offer.withdraw(&sell_token.contract_id, &70);
@@ -103,7 +101,7 @@ fn test() {
     );
 
     assert_eq!(sell_token.balance(&seller), 970);
-    assert_eq!(sell_token.balance(&offer_address), 20);
+    assert_eq!(sell_token.balance(&offer.address()), 20);
 
     // The price here is 1 sell_token = 1 buy_token.
     offer.updt_price(&1, &1);
@@ -122,8 +120,8 @@ fn test() {
     offer.trade(&buyer, &10_i128, &9_i128);
     assert_eq!(sell_token.balance(&seller), 970);
     assert_eq!(sell_token.balance(&buyer), 20);
-    assert_eq!(sell_token.balance(&offer_address), 10);
+    assert_eq!(sell_token.balance(&offer.address()), 10);
     assert_eq!(buy_token.balance(&seller), 30);
     assert_eq!(buy_token.balance(&buyer), 970);
-    assert_eq!(buy_token.balance(&offer_address), 0);
+    assert_eq!(buy_token.balance(&offer.address()), 0);
 }

--- a/timelock/src/test.rs
+++ b/timelock/src/test.rs
@@ -26,7 +26,6 @@ struct ClaimableBalanceTest {
     claim_addresses: [Address; 3],
     token: TokenClient,
     contract: ClaimableBalanceContractClient,
-    contract_address: Address,
 }
 
 impl ClaimableBalanceTest {
@@ -54,14 +53,12 @@ impl ClaimableBalanceTest {
         token.mint(&token_admin, &deposit_address, &1000);
 
         let contract = create_claimable_balance_contract(&env);
-        let contract_address = Address::from_contract_id(&env, &contract.contract_id);
         ClaimableBalanceTest {
             env,
             deposit_address,
             claim_addresses,
             token,
             contract,
-            contract_address,
         }
     }
 }
@@ -109,7 +106,7 @@ fn test_deposit_and_claim() {
     );
 
     assert_eq!(test.token.balance(&test.deposit_address), 200);
-    assert_eq!(test.token.balance(&test.contract_address), 800);
+    assert_eq!(test.token.balance(&test.contract.address()), 800);
     assert_eq!(test.token.balance(&test.claim_addresses[1]), 0);
 
     test.contract.claim(&test.claim_addresses[1]);
@@ -124,7 +121,7 @@ fn test_deposit_and_claim() {
     );
 
     assert_eq!(test.token.balance(&test.deposit_address), 200);
-    assert_eq!(test.token.balance(&test.contract_address), 0);
+    assert_eq!(test.token.balance(&test.contract.address()), 0);
     assert_eq!(test.token.balance(&test.claim_addresses[1]), 800);
 }
 


### PR DESCRIPTION
### What

Use client `.address()` method directly to get contract address.

### Why

Slightly better UX 

### Known limitations

N/A
