### PR TITLE
Update rust deps to use latest released

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -858,8 +858,8 @@ dependencies = [
 
 [[package]]
 name = "soroban-auth"
-version = "0.6.0"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=9947607e2f9bf733cbfd264d92560b75308f0294#9947607e2f9bf733cbfd264d92560b75308f0294"
+version = "0.7.0"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=8abd3353c728f09ee1c8a2544f67a853e915afc2#8abd3353c728f09ee1c8a2544f67a853e915afc2"
 dependencies = [
  "soroban-env-host",
  "soroban-sdk",
@@ -909,8 +909,8 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-common"
-version = "0.0.14"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=75b21696b0636bd145b7acb47a6fed4621b05978#75b21696b0636bd145b7acb47a6fed4621b05978"
+version = "0.0.15"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=cf83838ae8a07a00224f0a5a3500eb7969bac7cf#cf83838ae8a07a00224f0a5a3500eb7969bac7cf"
 dependencies = [
  "crate-git-revision",
  "ethnum",
@@ -923,8 +923,8 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-guest"
-version = "0.0.14"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=75b21696b0636bd145b7acb47a6fed4621b05978#75b21696b0636bd145b7acb47a6fed4621b05978"
+version = "0.0.15"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=cf83838ae8a07a00224f0a5a3500eb7969bac7cf#cf83838ae8a07a00224f0a5a3500eb7969bac7cf"
 dependencies = [
  "soroban-env-common",
  "static_assertions",
@@ -932,8 +932,8 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-host"
-version = "0.0.14"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=75b21696b0636bd145b7acb47a6fed4621b05978#75b21696b0636bd145b7acb47a6fed4621b05978"
+version = "0.0.15"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=cf83838ae8a07a00224f0a5a3500eb7969bac7cf#cf83838ae8a07a00224f0a5a3500eb7969bac7cf"
 dependencies = [
  "backtrace",
  "curve25519-dalek",
@@ -954,8 +954,8 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-macros"
-version = "0.0.14"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=75b21696b0636bd145b7acb47a6fed4621b05978#75b21696b0636bd145b7acb47a6fed4621b05978"
+version = "0.0.15"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=cf83838ae8a07a00224f0a5a3500eb7969bac7cf#cf83838ae8a07a00224f0a5a3500eb7969bac7cf"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -997,8 +997,8 @@ dependencies = [
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "0.6.0"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=9947607e2f9bf733cbfd264d92560b75308f0294#9947607e2f9bf733cbfd264d92560b75308f0294"
+version = "0.7.0"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=8abd3353c728f09ee1c8a2544f67a853e915afc2#8abd3353c728f09ee1c8a2544f67a853e915afc2"
 dependencies = [
  "serde",
  "serde_json",
@@ -1023,8 +1023,8 @@ dependencies = [
 
 [[package]]
 name = "soroban-native-sdk-macros"
-version = "0.0.14"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=75b21696b0636bd145b7acb47a6fed4621b05978#75b21696b0636bd145b7acb47a6fed4621b05978"
+version = "0.0.15"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=cf83838ae8a07a00224f0a5a3500eb7969bac7cf#cf83838ae8a07a00224f0a5a3500eb7969bac7cf"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1034,8 +1034,8 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "0.6.0"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=9947607e2f9bf733cbfd264d92560b75308f0294#9947607e2f9bf733cbfd264d92560b75308f0294"
+version = "0.7.0"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=8abd3353c728f09ee1c8a2544f67a853e915afc2#8abd3353c728f09ee1c8a2544f67a853e915afc2"
 dependencies = [
  "bytes-lit",
  "ed25519-dalek",
@@ -1049,8 +1049,8 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "0.6.0"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=9947607e2f9bf733cbfd264d92560b75308f0294#9947607e2f9bf733cbfd264d92560b75308f0294"
+version = "0.7.0"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=8abd3353c728f09ee1c8a2544f67a853e915afc2#8abd3353c728f09ee1c8a2544f67a853e915afc2"
 dependencies = [
  "darling",
  "itertools",
@@ -1072,8 +1072,8 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec"
-version = "0.6.0"
-source = "git+https://github.com/stellar/rs-soroban-sdk?rev=9947607e2f9bf733cbfd264d92560b75308f0294#9947607e2f9bf733cbfd264d92560b75308f0294"
+version = "0.7.0"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=8abd3353c728f09ee1c8a2544f67a853e915afc2#8abd3353c728f09ee1c8a2544f67a853e915afc2"
 dependencies = [
  "base64",
  "darling",
@@ -1150,8 +1150,8 @@ dependencies = [
 
 [[package]]
 name = "stellar-xdr"
-version = "0.0.14"
-source = "git+https://github.com/stellar/rs-stellar-xdr?rev=07aff1190dc3f97b889d31b2bfb77098e7db55ce#07aff1190dc3f97b889d31b2bfb77098e7db55ce"
+version = "0.0.15"
+source = "git+https://github.com/stellar/rs-stellar-xdr?rev=4655b635c698bb3bbc628bdba456df627c42ee3a#4655b635c698bb3bbc628bdba456df627c42ee3a"
 dependencies = [
  "base64",
  "crate-git-revision",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,14 +38,14 @@ codegen-units = 1
 lto = true
 
 [workspace.dependencies.soroban-sdk]
-version = "0.6.0"
+version = "0.7.0"
 git = "https://github.com/stellar/rs-soroban-sdk"
-rev = "9947607e2f9bf733cbfd264d92560b75308f0294"
+rev = "8abd3353c728f09ee1c8a2544f67a853e915afc2"
 
 [workspace.dependencies.soroban-auth]
-version = "0.6.0"
+version = "0.7.0"
 git = "https://github.com/stellar/rs-soroban-sdk"
-rev = "9947607e2f9bf733cbfd264d92560b75308f0294"
+rev = "8abd3353c728f09ee1c8a2544f67a853e915afc2"
 
 # [patch."https://github.com/stellar/rs-soroban-sdk"]
 # soroban-sdk = { path = "../rs-soroban-sdk/soroban-sdk" }


### PR DESCRIPTION
### What

Update the rust deps to the newly released sdk version.

### Why

So it compiles with the newly released sdk version.

### Known limitations

[TODO or N/A]
