### PR TITLE
Fixing the dependencies between some of the examples

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -866,6 +866,7 @@ name = "soroban-atomic-multiswap-contract"
 version = "0.0.0"
 dependencies = [
  "assert_unordered",
+ "soroban-atomic-swap-contract",
  "soroban-sdk",
 ]
 
@@ -903,6 +904,7 @@ dependencies = [
 name = "soroban-cross-contract-b-contract"
 version = "0.0.0"
 dependencies = [
+ "soroban-cross-contract-a-contract",
  "soroban-sdk",
 ]
 
@@ -1033,6 +1035,7 @@ version = "0.0.0"
 dependencies = [
  "num-integer",
  "soroban-sdk",
+ "soroban-token-contract",
 ]
 
 [[package]]

--- a/atomic_multiswap/Cargo.toml
+++ b/atomic_multiswap/Cargo.toml
@@ -11,6 +11,7 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
+soroban-atomic-swap-contract = { path = "../atomic_swap" }
 soroban-sdk = { workspace = true }
 
 [dev_dependencies]

--- a/cross_contract/contract_b/Cargo.toml
+++ b/cross_contract/contract_b/Cargo.toml
@@ -11,6 +11,7 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
+soroban-cross-contract-a-contract = { path = "../contract_a" }
 soroban-sdk = { workspace = true }
 
 [dev_dependencies]

--- a/liquidity_pool/Cargo.toml
+++ b/liquidity_pool/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
+soroban-token-contract = { path = "../token" }
 soroban-sdk = { workspace = true }
 num-integer = { version = "0.1.45", default-features = false, features = ["i128"] }
 

--- a/logging/Cargo.toml
+++ b/logging/Cargo.toml
@@ -14,10 +14,10 @@ doctest = false
 testutils = ["soroban-sdk/testutils"]
 
 [dependencies]
-soroban-sdk = { workspace = true }
+soroban-sdk = "0.7.0"
 
 [dev_dependencies]
-soroban-sdk = { workspace = true, features = ["testutils"] }
+soroban-sdk = { version = "0.7.0", features = ["testutils"] }
 
 [profile.release]
 opt-level = "z"

--- a/logging/Cargo.toml
+++ b/logging/Cargo.toml
@@ -14,21 +14,7 @@ doctest = false
 testutils = ["soroban-sdk/testutils"]
 
 [dependencies]
-soroban-sdk = "0.7.0"
+soroban-sdk = { workspace = true }
 
 [dev_dependencies]
-soroban-sdk = { version = "0.7.0", features = ["testutils"] }
-
-[profile.release]
-opt-level = "z"
-overflow-checks = true
-debug = 0
-strip = "symbols"
-debug-assertions = false
-panic = "abort"
-codegen-units = 1
-lto = true
-
-[profile.release-with-logs]
-inherits = "release"
-debug-assertions = true
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/logging/Cargo.toml
+++ b/logging/Cargo.toml
@@ -18,3 +18,17 @@ soroban-sdk = { workspace = true }
 
 [dev_dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }
+
+[profile.release]
+opt-level = "z"
+overflow-checks = true
+debug = 0
+strip = "symbols"
+debug-assertions = false
+panic = "abort"
+codegen-units = 1
+lto = true
+
+[profile.release-with-logs]
+inherits = "release"
+debug-assertions = true


### PR DESCRIPTION
### What

Some examples have dependencies between them which was not specified in Cargo.toml files.

### Why

The first time the wasms were build from the root directory of `soroban-examples`, there would be errors because of the dependencies. Adding the dependencies explicitly fixes this issue. 

Command run to test the fix:
```
cargo build --target wasm32-unknown-unknown --release
```
