### PR TITLE
Bringing back the git rev hash to Cargo.toml of each project

### DIFF
--- a/account/Cargo.toml
+++ b/account/Cargo.toml
@@ -11,12 +11,12 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = { version = "0.7.0"}
-soroban-auth = { version = "0.7.0"}
+soroban-sdk = { version = "0.7.0", git = "https://github.com/stellar/rs-soroban-sdk", rev = "29b505cf95f2fd4fbe639fdb163b606c44920837"}
+soroban-auth = { version = "0.7.0", git = "https://github.com/stellar/rs-soroban-sdk", rev = "29b505cf95f2fd4fbe639fdb163b606c44920837"}
 
 [dev_dependencies]
-soroban-sdk = { version = "0.7.0", features = ["testutils"] }
-soroban-auth = { version = "0.7.0", features = ["testutils"] }
+soroban-sdk = { version = "0.7.0", git = "https://github.com/stellar/rs-soroban-sdk", rev = "29b505cf95f2fd4fbe639fdb163b606c44920837", features = ["testutils"] }
+soroban-auth = { version = "0.7.0", git = "https://github.com/stellar/rs-soroban-sdk", rev = "29b505cf95f2fd4fbe639fdb163b606c44920837", features = ["testutils"] }
 ed25519-dalek = { version = "1.0.1" }
 rand = { version = "0.7.3" }
 

--- a/alloc/Cargo.toml
+++ b/alloc/Cargo.toml
@@ -11,10 +11,10 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = { version = "0.7.0", features = ["alloc"] }
+soroban-sdk = { version = "0.7.0", git = "https://github.com/stellar/rs-soroban-sdk", rev = "29b505cf95f2fd4fbe639fdb163b606c44920837", features = ["alloc"] }
 
 [dev_dependencies]
-soroban-sdk = { version = "0.7.0", features = ["testutils", "alloc"] }
+soroban-sdk = { version = "0.7.0", git = "https://github.com/stellar/rs-soroban-sdk", rev = "29b505cf95f2fd4fbe639fdb163b606c44920837", features = ["testutils", "alloc"] }
 
 [profile.release]
 opt-level = "z"

--- a/atomic_multiswap/Cargo.toml
+++ b/atomic_multiswap/Cargo.toml
@@ -11,10 +11,10 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = { version = "0.7.0"}
+soroban-sdk = { version = "0.7.0", git = "https://github.com/stellar/rs-soroban-sdk", rev = "29b505cf95f2fd4fbe639fdb163b606c44920837"}
 
 [dev_dependencies]
-soroban-sdk = { version = "0.7.0", features = ["testutils"] }
+soroban-sdk = { version = "0.7.0", git = "https://github.com/stellar/rs-soroban-sdk", rev = "29b505cf95f2fd4fbe639fdb163b606c44920837", features = ["testutils"] }
 assert_unordered = "0.3.5"
 
 [profile.release]

--- a/atomic_swap/Cargo.toml
+++ b/atomic_swap/Cargo.toml
@@ -11,10 +11,10 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = { version = "0.7.0"}
+soroban-sdk = { version = "0.7.0", git = "https://github.com/stellar/rs-soroban-sdk", rev = "29b505cf95f2fd4fbe639fdb163b606c44920837"}
 
 [dev_dependencies]
-soroban-sdk = { version = "0.7.0", features = ["testutils"] }
+soroban-sdk = { version = "0.7.0", git = "https://github.com/stellar/rs-soroban-sdk", rev = "29b505cf95f2fd4fbe639fdb163b606c44920837", features = ["testutils"] }
 
 [profile.release]
 opt-level = "z"

--- a/auth/Cargo.toml
+++ b/auth/Cargo.toml
@@ -8,10 +8,10 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
-soroban-sdk = { version = "0.7.0"}
+soroban-sdk = { version = "0.7.0", git = "https://github.com/stellar/rs-soroban-sdk", rev = "29b505cf95f2fd4fbe639fdb163b606c44920837"}
 
 [dev_dependencies]
-soroban-sdk = { version = "0.7.0", features = ["testutils"] }
+soroban-sdk = { version = "0.7.0", git = "https://github.com/stellar/rs-soroban-sdk", rev = "29b505cf95f2fd4fbe639fdb163b606c44920837", features = ["testutils"] }
 
 [profile.release]
 opt-level = "z"

--- a/cross_contract/contract_a/Cargo.toml
+++ b/cross_contract/contract_a/Cargo.toml
@@ -11,10 +11,10 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = { version = "0.7.0" }
+soroban-sdk = { version = "0.7.0", git = "https://github.com/stellar/rs-soroban-sdk", rev = "29b505cf95f2fd4fbe639fdb163b606c44920837" }
 
 [dev_dependencies]
-soroban-sdk = { version = "0.7.0", features = ["testutils"] }
+soroban-sdk = { version = "0.7.0", git = "https://github.com/stellar/rs-soroban-sdk", rev = "29b505cf95f2fd4fbe639fdb163b606c44920837", features = ["testutils"] }
 
 [profile.release]
 opt-level = "z"

--- a/cross_contract/contract_b/Cargo.toml
+++ b/cross_contract/contract_b/Cargo.toml
@@ -11,10 +11,10 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = { version = "0.7.0" }
+soroban-sdk = { version = "0.7.0", git = "https://github.com/stellar/rs-soroban-sdk", rev = "29b505cf95f2fd4fbe639fdb163b606c44920837" }
 
 [dev_dependencies]
-soroban-sdk = { version = "0.7.0", features = ["testutils"] }
+soroban-sdk = { version = "0.7.0", git = "https://github.com/stellar/rs-soroban-sdk", rev = "29b505cf95f2fd4fbe639fdb163b606c44920837", features = ["testutils"] }
 
 [profile.release]
 opt-level = "z"

--- a/custom_types/Cargo.toml
+++ b/custom_types/Cargo.toml
@@ -11,10 +11,10 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = { version = "0.7.0"}
+soroban-sdk = { version = "0.7.0", git = "https://github.com/stellar/rs-soroban-sdk", rev = "29b505cf95f2fd4fbe639fdb163b606c44920837"}
 
 [dev_dependencies]
-soroban-sdk = { version = "0.7.0", features = ["testutils"] }
+soroban-sdk = { version = "0.7.0", git = "https://github.com/stellar/rs-soroban-sdk", rev = "29b505cf95f2fd4fbe639fdb163b606c44920837", features = ["testutils"] }
 
 [profile.release]
 opt-level = "z"

--- a/deployer/contract/Cargo.toml
+++ b/deployer/contract/Cargo.toml
@@ -11,10 +11,10 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = { version = "0.7.0"}
+soroban-sdk = { version = "0.7.0", git = "https://github.com/stellar/rs-soroban-sdk", rev = "29b505cf95f2fd4fbe639fdb163b606c44920837"}
 
 [dev_dependencies]
-soroban-sdk = { version = "0.7.0", features = ["testutils"] }
+soroban-sdk = { version = "0.7.0", git = "https://github.com/stellar/rs-soroban-sdk", rev = "29b505cf95f2fd4fbe639fdb163b606c44920837", features = ["testutils"] }
 
 [profile.release]
 opt-level = "z"

--- a/deployer/deployer/Cargo.toml
+++ b/deployer/deployer/Cargo.toml
@@ -11,10 +11,10 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = { version = "0.7.0"}
+soroban-sdk = { version = "0.7.0", git = "https://github.com/stellar/rs-soroban-sdk", rev = "29b505cf95f2fd4fbe639fdb163b606c44920837"}
 
 [dev_dependencies]
-soroban-sdk = { version = "0.7.0", features = ["testutils"] }
+soroban-sdk = { version = "0.7.0", git = "https://github.com/stellar/rs-soroban-sdk", rev = "29b505cf95f2fd4fbe639fdb163b606c44920837", features = ["testutils"] }
 
 [profile.release]
 opt-level = "z"

--- a/errors/Cargo.toml
+++ b/errors/Cargo.toml
@@ -11,10 +11,10 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = { version = "0.7.0"}
+soroban-sdk = { version = "0.7.0", git = "https://github.com/stellar/rs-soroban-sdk", rev = "29b505cf95f2fd4fbe639fdb163b606c44920837"}
 
 [dev_dependencies]
-soroban-sdk = { version = "0.7.0", features = ["testutils"] }
+soroban-sdk = { version = "0.7.0", git = "https://github.com/stellar/rs-soroban-sdk", rev = "29b505cf95f2fd4fbe639fdb163b606c44920837", features = ["testutils"] }
 
 [profile.release]
 opt-level = "z"

--- a/events/Cargo.toml
+++ b/events/Cargo.toml
@@ -11,10 +11,10 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = { version = "0.7.0"}
+soroban-sdk = { version = "0.7.0", git = "https://github.com/stellar/rs-soroban-sdk", rev = "29b505cf95f2fd4fbe639fdb163b606c44920837"}
 
 [dev_dependencies]
-soroban-sdk = { version = "0.7.0", features = ["testutils"] }
+soroban-sdk = { version = "0.7.0", git = "https://github.com/stellar/rs-soroban-sdk", rev = "29b505cf95f2fd4fbe639fdb163b606c44920837", features = ["testutils"] }
 
 [profile.release]
 opt-level = "z"

--- a/hello_world/Cargo.toml
+++ b/hello_world/Cargo.toml
@@ -11,10 +11,10 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = { version = "0.7.0"}
+soroban-sdk = { version = "0.7.0", git = "https://github.com/stellar/rs-soroban-sdk", rev = "29b505cf95f2fd4fbe639fdb163b606c44920837"}
 
 [dev_dependencies]
-soroban-sdk = { version = "0.7.0", features = ["testutils"] }
+soroban-sdk = { version = "0.7.0", git = "https://github.com/stellar/rs-soroban-sdk", rev = "29b505cf95f2fd4fbe639fdb163b606c44920837", features = ["testutils"] }
 
 [profile.release]
 opt-level = "z"

--- a/increment/Cargo.toml
+++ b/increment/Cargo.toml
@@ -11,10 +11,10 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = { version = "0.7.0"}
+soroban-sdk = { version = "0.7.0", git = "https://github.com/stellar/rs-soroban-sdk", rev = "29b505cf95f2fd4fbe639fdb163b606c44920837"}
 
 [dev_dependencies]
-soroban-sdk = { version = "0.7.0", features = ["testutils"] }
+soroban-sdk = { version = "0.7.0", git = "https://github.com/stellar/rs-soroban-sdk", rev = "29b505cf95f2fd4fbe639fdb163b606c44920837", features = ["testutils"] }
 
 [profile.release]
 opt-level = "z"

--- a/liquidity_pool/Cargo.toml
+++ b/liquidity_pool/Cargo.toml
@@ -8,11 +8,11 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
-soroban-sdk = { version = "0.7.0"}
+soroban-sdk = { version = "0.7.0", git = "https://github.com/stellar/rs-soroban-sdk", rev = "29b505cf95f2fd4fbe639fdb163b606c44920837"}
 num-integer = { version = "0.1.45", default-features = false, features = ["i128"] }
 
 [dev_dependencies]
-soroban-sdk = { version = "0.7.0", features = ["testutils"] }
+soroban-sdk = { version = "0.7.0", git = "https://github.com/stellar/rs-soroban-sdk", rev = "29b505cf95f2fd4fbe639fdb163b606c44920837", features = ["testutils"] }
 
 [profile.release]
 opt-level = "z"

--- a/logging/Cargo.toml
+++ b/logging/Cargo.toml
@@ -14,10 +14,10 @@ doctest = false
 testutils = ["soroban-sdk/testutils"]
 
 [dependencies]
-soroban-sdk = { version = "0.7.0"}
+soroban-sdk = { version = "0.7.0", git = "https://github.com/stellar/rs-soroban-sdk", rev = "29b505cf95f2fd4fbe639fdb163b606c44920837"}
 
 [dev_dependencies]
-soroban-sdk = { version = "0.7.0", features = ["testutils"] }
+soroban-sdk = { version = "0.7.0", git = "https://github.com/stellar/rs-soroban-sdk", rev = "29b505cf95f2fd4fbe639fdb163b606c44920837", features = ["testutils"] }
 
 [profile.release]
 opt-level = "z"

--- a/simple_account/Cargo.toml
+++ b/simple_account/Cargo.toml
@@ -11,12 +11,12 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = { version = "0.7.0"}
-soroban-auth = { version = "0.7.0"}
+soroban-sdk = { version = "0.7.0", git = "https://github.com/stellar/rs-soroban-sdk", rev = "29b505cf95f2fd4fbe639fdb163b606c44920837"}
+soroban-auth = { version = "0.7.0", git = "https://github.com/stellar/rs-soroban-sdk", rev = "29b505cf95f2fd4fbe639fdb163b606c44920837"}
 
 [dev_dependencies]
-soroban-sdk = { version = "0.7.0", features = ["testutils"] }
-soroban-auth = { version = "0.7.0", features = ["testutils"] }
+soroban-sdk = { version = "0.7.0", git = "https://github.com/stellar/rs-soroban-sdk", rev = "29b505cf95f2fd4fbe639fdb163b606c44920837", features = ["testutils"] }
+soroban-auth = { version = "0.7.0", git = "https://github.com/stellar/rs-soroban-sdk", rev = "29b505cf95f2fd4fbe639fdb163b606c44920837", features = ["testutils"] }
 ed25519-dalek = { version = "1.0.1" }
 rand = { version = "0.7.3" }
 

--- a/single_offer/Cargo.toml
+++ b/single_offer/Cargo.toml
@@ -8,10 +8,10 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
-soroban-sdk = { version = "0.7.0"}
+soroban-sdk = { version = "0.7.0", git = "https://github.com/stellar/rs-soroban-sdk", rev = "29b505cf95f2fd4fbe639fdb163b606c44920837"}
 
 [dev_dependencies]
-soroban-sdk = { version = "0.7.0", features = ["testutils"] }
+soroban-sdk = { version = "0.7.0", git = "https://github.com/stellar/rs-soroban-sdk", rev = "29b505cf95f2fd4fbe639fdb163b606c44920837", features = ["testutils"] }
 
 [profile.release]
 opt-level = "z"

--- a/timelock/Cargo.toml
+++ b/timelock/Cargo.toml
@@ -11,10 +11,10 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = { version = "0.7.0"}
+soroban-sdk = { version = "0.7.0", git = "https://github.com/stellar/rs-soroban-sdk", rev = "29b505cf95f2fd4fbe639fdb163b606c44920837"}
 
 [dev_dependencies]
-soroban-sdk = { version = "0.7.0", features = ["testutils"] }
+soroban-sdk = { version = "0.7.0", git = "https://github.com/stellar/rs-soroban-sdk", rev = "29b505cf95f2fd4fbe639fdb163b606c44920837", features = ["testutils"] }
 
 [profile.release]
 opt-level = "z"

--- a/token/Cargo.toml
+++ b/token/Cargo.toml
@@ -8,10 +8,10 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-soroban-sdk = { version = "0.7.0"}
+soroban-sdk = { version = "0.7.0", git = "https://github.com/stellar/rs-soroban-sdk", rev = "29b505cf95f2fd4fbe639fdb163b606c44920837"}
 
 [dev_dependencies]
-soroban-sdk = { version = "0.7.0", features = ["testutils"] }
+soroban-sdk = { version = "0.7.0", git = "https://github.com/stellar/rs-soroban-sdk", rev = "29b505cf95f2fd4fbe639fdb163b606c44920837", features = ["testutils"] }
 
 [profile.release]
 opt-level = "z"


### PR DESCRIPTION
### What

Bringing back the git rev hash to Cargo.toml of each project

### Why

This was unintentionally removed with [PR 232](https://github.com/stellar/soroban-examples/pull/232) when moving away from workspace (with each example being a member project) to individual sub directory projects without top level workspace.

### Scripts used
1. Search and replace
```
find . -maxdepth 3 -type f -name Cargo.toml | xargs sed -i'' -e 's/version = "0.7.0"/version = "0.7.0", git = "https:\/\/github.com\/stellar\/rs-soroban-sdk", rev = "29b505cf95f2fd4fbe639fdb163b606c44920837"/g'
```

2. Add to git
```
find . -maxdepth 3 -type f -name Cargo.toml | xargs git add 
```

3. Clean up backup from sed command
```
git clean -f -x *
```

4. Commit and push,
```
git commit -m "Bringing back the git rev hash to Cargo.toml of each project"
git push
```