### PR TITLE
Remove derive Default

### DIFF
--- a/custom_types/src/lib.rs
+++ b/custom_types/src/lib.rs
@@ -2,7 +2,7 @@
 use soroban_sdk::{contractimpl, contracttype, Env, Symbol};
 
 #[contracttype]
-#[derive(Clone, Default, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct State {
     pub count: u32,
     pub last_incr: u32,


### PR DESCRIPTION
### What
Remove `#[derive(Default)]` from custom structs in examples.

### Why
The `Default` trait's usefulness in contracts is limited because SDK types such as `Vec`, `BytesN`, etc cannot implement it. Deriving `Default` on a UDT requires all its field's types to also implement `Default`. Using it in an example sets developers up for encountering compile errors when they start adding SDK types to the UDT. The `Default` trait isn't utilized by the example in any way other than deriving it, so the derive is unnecessary.

Thanks @tomerweller for identifying this issue.

<a href="https://gitpod.io/#https://github.com/stellar/soroban-examples/pull/243"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

