### PR TITLE
Make fmt target modify files

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,8 +24,8 @@ jobs:
     - uses: actions/checkout@v3
     - run: rustup update
     - run: |
-      shopt -s globstar
-      rustfmt **/*.rs
+        shopt -s globstar
+        rustfmt **/*.rs
 
   rust-analyzer-compat:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - run: rustup update
-    - run: make fmt
+    - run: rustfmt **/*.rs
 
   rust-analyzer-compat:
     runs-on: ubuntu-latest
@@ -32,7 +32,9 @@ jobs:
     - run: rustup update
     - run: rustup +nightly component add rust-analyzer
     - name: Check if rust-analyzer encounters any errors parsing project
-      run: rustup run nightly rust-analyzer analysis-stats token/ 2>&1 | (! grep ERROR)
+      run:
+        find . -maxdepth 1 -type d \( ! -name . \) -exec bash -c "cd '{}' && pwd" \;
+      rustup run nightly rust-analyzer analysis-stats token/ 2>&1 | (! grep ERROR)
     - run: rustup run nightly rust-analyzer analysis-stats deployer/deployer/ 2>&1 | (! grep ERROR)
     - run: rustup run nightly rust-analyzer analysis-stats deployer/contract/ 2>&1 | (! grep ERROR)
     - run: rustup run nightly rust-analyzer analysis-stats simple_account/ 2>&1 | (! grep ERROR)

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,9 +32,7 @@ jobs:
     - run: rustup update
     - run: rustup +nightly component add rust-analyzer
     - name: Check if rust-analyzer encounters any errors parsing project
-      run:
-        find . -maxdepth 1 -type d \( ! -name . \) -exec bash -c "cd '{}' && pwd" \;
-      rustup run nightly rust-analyzer analysis-stats token/ 2>&1 | (! grep ERROR)
+      run: rustup run nightly rust-analyzer analysis-stats token/ 2>&1 | (! grep ERROR)
     - run: rustup run nightly rust-analyzer analysis-stats deployer/deployer/ 2>&1 | (! grep ERROR)
     - run: rustup run nightly rust-analyzer analysis-stats deployer/contract/ 2>&1 | (! grep ERROR)
     - run: rustup run nightly rust-analyzer analysis-stats simple_account/ 2>&1 | (! grep ERROR)

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,7 +9,8 @@ env:
   RUSTFLAGS: -D warnings
 
 defaults:
-  shell: bash
+  run:
+    shell: bash
 
 jobs:
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,10 +8,6 @@ on:
 env:
   RUSTFLAGS: -D warnings
 
-defaults:
-  run:
-    shell: bash
-
 jobs:
 
   complete:
@@ -27,7 +23,9 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - run: rustup update
-    - run: "rustfmt **/*.rs"
+    - run: |
+      shopt -s globstar
+      rustfmt **/*.rs
 
   rust-analyzer-compat:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,6 +8,9 @@ on:
 env:
   RUSTFLAGS: -D warnings
 
+defaults:
+  shell: bash
+
 jobs:
 
   complete:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - run: rustup update
-    - run: rustfmt **/*.rs
+    - run: "rustfmt **/*.rs"
 
   rust-analyzer-compat:
     runs-on: ubuntu-latest

--- a/account/Makefile
+++ b/account/Makefile
@@ -13,7 +13,7 @@ watch:
 	cargo watch --clear --watch-when-idle --shell '$(MAKE)'
 
 fmt:
-	cargo fmt --all --check
+	cargo fmt --all
 
 clean:
 	cargo clean

--- a/alloc/Makefile
+++ b/alloc/Makefile
@@ -10,7 +10,7 @@ build:
 	@ls -l target/wasm32-unknown-unknown/release/*.wasm
 
 fmt:
-	cargo fmt --all --check
+	cargo fmt --all
 
 clean:
 	cargo clean

--- a/atomic_multiswap/Makefile
+++ b/atomic_multiswap/Makefile
@@ -11,7 +11,7 @@ build:
 	@ls -l target/wasm32-unknown-unknown/release/*.wasm
 
 fmt:
-	cargo fmt --all --check
+	cargo fmt --all
 
 clean:
 	cargo clean

--- a/atomic_swap/Makefile
+++ b/atomic_swap/Makefile
@@ -10,7 +10,7 @@ build:
 	@ls -l target/wasm32-unknown-unknown/release/*.wasm
 
 fmt:
-	cargo fmt --all --check
+	cargo fmt --all
 
 clean:
 	cargo clean

--- a/auth/Makefile
+++ b/auth/Makefile
@@ -10,7 +10,7 @@ build:
 	@ls -l target/wasm32-unknown-unknown/release/*.wasm
 
 fmt:
-	cargo fmt --all --check
+	cargo fmt --all
 
 clean:
 	cargo clean

--- a/cross_contract/contract_a/Makefile
+++ b/cross_contract/contract_a/Makefile
@@ -10,7 +10,7 @@ build:
 	@ls -l target/wasm32-unknown-unknown/release/*.wasm
 
 fmt:
-	cargo fmt --all --check
+	cargo fmt --all
 
 clean:
 	cargo clean

--- a/cross_contract/contract_b/Makefile
+++ b/cross_contract/contract_b/Makefile
@@ -11,7 +11,7 @@ build:
 	@ls -l target/wasm32-unknown-unknown/release/*.wasm
 
 fmt:
-	cargo fmt --all --check
+	cargo fmt --all
 
 clean:
 	cargo clean

--- a/custom_types/Makefile
+++ b/custom_types/Makefile
@@ -10,7 +10,7 @@ build:
 	@ls -l target/wasm32-unknown-unknown/release/*.wasm
 
 fmt:
-	cargo fmt --all --check
+	cargo fmt --all
 
 clean:
 	cargo clean

--- a/deployer/contract/Makefile
+++ b/deployer/contract/Makefile
@@ -13,7 +13,7 @@ watch:
 	cargo watch --clear --watch-when-idle --shell '$(MAKE)'
 
 fmt:
-	cargo fmt --all --check
+	cargo fmt --all
 
 clean:
 	cargo clean

--- a/deployer/deployer/Makefile
+++ b/deployer/deployer/Makefile
@@ -11,7 +11,7 @@ build:
 	@ls -l target/wasm32-unknown-unknown/release/*.wasm
 
 fmt:
-	cargo fmt --all --check
+	cargo fmt --all
 
 clean:
 	cargo clean

--- a/errors/Makefile
+++ b/errors/Makefile
@@ -10,7 +10,7 @@ build:
 	@ls -l target/wasm32-unknown-unknown/release/*.wasm
 
 fmt:
-	cargo fmt --all --check
+	cargo fmt --all
 
 clean:
 	cargo clean

--- a/events/Makefile
+++ b/events/Makefile
@@ -10,7 +10,7 @@ build:
 	@ls -l target/wasm32-unknown-unknown/release/*.wasm
 
 fmt:
-	cargo fmt --all --check
+	cargo fmt --all
 
 clean:
 	cargo clean

--- a/hello_world/Makefile
+++ b/hello_world/Makefile
@@ -10,7 +10,7 @@ build:
 	@ls -l target/wasm32-unknown-unknown/release/*.wasm
 
 fmt:
-	cargo fmt --all --check
+	cargo fmt --all
 
 clean:
 	cargo clean

--- a/increment/Makefile
+++ b/increment/Makefile
@@ -10,7 +10,7 @@ build:
 	@ls -l target/wasm32-unknown-unknown/release/*.wasm
 
 fmt:
-	cargo fmt --all --check
+	cargo fmt --all
 
 clean:
 	cargo clean

--- a/liquidity_pool/Makefile
+++ b/liquidity_pool/Makefile
@@ -10,7 +10,7 @@ build:
 	cargo build --target wasm32-unknown-unknown --release 
 	@ls -l target/wasm32-unknown-unknown/release/*.wasm
 fmt:
-	cargo fmt --all --check
+	cargo fmt --all
 
 clean:
 	cargo clean

--- a/logging/Makefile
+++ b/logging/Makefile
@@ -10,7 +10,7 @@ build:
 	@ls -l target/wasm32-unknown-unknown/release/*.wasm
 
 fmt:
-	cargo fmt --all --check
+	cargo fmt --all
 
 clean:
 	cargo clean

--- a/simple_account/Makefile
+++ b/simple_account/Makefile
@@ -10,7 +10,7 @@ build:
 	@ls -l target/wasm32-unknown-unknown/release/*.wasm
 
 fmt:
-	cargo fmt --all --check
+	cargo fmt --all
 
 clean:
 	cargo clean

--- a/single_offer/Makefile
+++ b/single_offer/Makefile
@@ -10,7 +10,7 @@ build:
 	@ls -l target/wasm32-unknown-unknown/release/*.wasm
 
 fmt:
-	cargo fmt --all --check
+	cargo fmt --all
 
 clean:
 	cargo clean

--- a/timelock/Makefile
+++ b/timelock/Makefile
@@ -10,7 +10,7 @@ build:
 	@ls -l target/wasm32-unknown-unknown/release/*.wasm
 
 fmt:
-	cargo fmt --all --check
+	cargo fmt --all
 
 clean:
 	cargo clean

--- a/token/Makefile
+++ b/token/Makefile
@@ -10,7 +10,7 @@ build:
 	@ls -l target/wasm32-unknown-unknown/release/*.wasm
 
 fmt:
-	cargo fmt --all --check
+	cargo fmt --all
 
 clean:
 	cargo clean

--- a/upgradeable_contract/new_contract/Makefile
+++ b/upgradeable_contract/new_contract/Makefile
@@ -10,7 +10,7 @@ build:
 	@ls -l target/wasm32-unknown-unknown/release/*.wasm
 
 fmt:
-	cargo fmt --all --check
+	cargo fmt --all
 
 clean:
 	cargo clean

--- a/upgradeable_contract/old_contract/Makefile
+++ b/upgradeable_contract/old_contract/Makefile
@@ -11,7 +11,7 @@ build:
 	@ls -l target/wasm32-unknown-unknown/release/*.wasm
 
 fmt:
-	cargo fmt --all --check
+	cargo fmt --all
 
 clean:
 	cargo clean


### PR DESCRIPTION
### What
Make the `make fmt` target of projects modify files, instead of erroring and displaying a diff.

### Why
The `make fmt` target used to update unformatted files in this repository, as it does in other repositories. It appears that recently it was changed to check, error, and display a diff, which is less convenient. I think this change was so that the `fmt` GitHub Action job could call a single command to run a check. We can get the same behavior in the GitHub Action by using rustfmt directly.

<a href="https://gitpod.io/#https://github.com/stellar/soroban-examples/pull/247"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

