### PR TITLE
Use a specific version of rust in gitpod

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -16,14 +16,11 @@ ENV SCCACHE_DIR=/workspace/.sccache
 # https://github.com/gitpod-io/workspace-images/issues/933#issuecomment-1272616892
 RUN rustup self uninstall -y
 RUN rm -rf .rustup
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain none -y
 
-RUN rustup update stable
-RUN rustup target add --toolchain stable wasm32-unknown-unknown
-RUN rustup component add --toolchain stable rust-src
-RUN rustup update nightly
-RUN rustup target add --toolchain nightly wasm32-unknown-unknown
-RUN rustup component add --toolchain nightly rust-src
+RUN rustup install 1.69
+RUN rustup target add --toolchain 1.69 wasm32-unknown-unknown
+RUN rustup component add --toolchain 1.69 rust-src
 RUN rustup default stable
 
 RUN sudo apt-get update && sudo apt-get install -y binaryen


### PR DESCRIPTION
### What
Use a specific version of rust in gitpod

### Why
To ensure the specific minimum version required by the SDK is installed.

To reduce oddities that might arise out of a rebuild of the gitpod image wher ea new version has been released. And to make sure that the minimum version is indeed installed.