### PR TITLE
Return strings for token name/symbol

### DIFF
--- a/token/src/contract.rs
+++ b/token/src/contract.rs
@@ -6,11 +6,11 @@ use crate::balance::{is_authorized, write_authorization};
 use crate::balance::{read_balance, receive_balance, spend_balance};
 use crate::event;
 use crate::metadata::{read_decimal, read_name, read_symbol, write_metadata};
-use soroban_sdk::{contractimpl, Address, Bytes, Env};
+use soroban_sdk::{contractimpl, Address, Env, String};
 use soroban_token_sdk::TokenMetadata;
 
 pub trait TokenTrait {
-    fn initialize(e: Env, admin: Address, decimal: u32, name: Bytes, symbol: Bytes);
+    fn initialize(e: Env, admin: Address, decimal: u32, name: String, symbol: String);
 
     fn allowance(e: Env, from: Address, spender: Address) -> i128;
 
@@ -42,9 +42,9 @@ pub trait TokenTrait {
 
     fn decimals(e: Env) -> u32;
 
-    fn name(e: Env) -> Bytes;
+    fn name(e: Env) -> String;
 
-    fn symbol(e: Env) -> Bytes;
+    fn symbol(e: Env) -> String;
 }
 
 fn check_nonnegative_amount(amount: i128) {
@@ -57,7 +57,7 @@ pub struct Token;
 
 #[contractimpl]
 impl TokenTrait for Token {
-    fn initialize(e: Env, admin: Address, decimal: u32, name: Bytes, symbol: Bytes) {
+    fn initialize(e: Env, admin: Address, decimal: u32, name: String, symbol: String) {
         if has_administrator(&e) {
             panic!("already initialized")
         }
@@ -190,11 +190,11 @@ impl TokenTrait for Token {
         read_decimal(&e)
     }
 
-    fn name(e: Env) -> Bytes {
+    fn name(e: Env) -> String {
         read_name(&e)
     }
 
-    fn symbol(e: Env) -> Bytes {
+    fn symbol(e: Env) -> String {
         read_symbol(&e)
     }
 }

--- a/token/src/metadata.rs
+++ b/token/src/metadata.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{Bytes, Env};
+use soroban_sdk::{Env, String};
 use soroban_token_sdk::{TokenMetadata, TokenUtils};
 
 pub fn read_decimal(e: &Env) -> u32 {
@@ -6,12 +6,12 @@ pub fn read_decimal(e: &Env) -> u32 {
     util.get_metadata_unchecked().unwrap().decimal
 }
 
-pub fn read_name(e: &Env) -> Bytes {
+pub fn read_name(e: &Env) -> String {
     let util = TokenUtils::new(e);
     util.get_metadata_unchecked().unwrap().name
 }
 
-pub fn read_symbol(e: &Env) -> Bytes {
+pub fn read_symbol(e: &Env) -> String {
     let util = TokenUtils::new(e);
     util.get_metadata_unchecked().unwrap().symbol
 }


### PR DESCRIPTION
### What

Update the example custom token contract to match changes in https://github.com/stellar/rs-soroban-env/pull/852

### Why

The example tutorial [here](https://soroban.stellar.org/docs/learn/migrating-from-evm/smart-contract-deployment#developing-smart-contracts-with-rust-and-soroban), uses this contract, and the hex-encoding/decoding of the name&symbol is tricky for some users.

### Depends on

https://github.com/stellar/rs-soroban-env/pull/852

<a href="https://gitpod.io/#https://github.com/stellar/soroban-examples/pull/256"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

