### PR TITLE
Removing an out-dated comment in the tokens example `test.rs` file

### DIFF
--- a/token/src/test.rs
+++ b/token/src/test.rs
@@ -83,7 +83,7 @@ fn test() {
             admin1.clone(),
             token.address.clone(),
             Symbol::short("set_admin"),
-            (&admin2,).into_val(&e), //THIS DOESN'T WORK
+            (&admin2,).into_val(&e),
         )]
     );
 


### PR DESCRIPTION
### What

Removing an out-dated comment in the tokens example `test.rs` file.

### Why

In the process of working on the how-to guide for this example contract (stellar/soroban-docs#468), @sisuresh pointed out that the comment needs to be removed. So, here's a PR removing that.

### Known limitations

n/a


<a href="https://gitpod.io/#https://github.com/stellar/soroban-examples/pull/257"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

