### PR TITLE
Fixing the download URL for the updated version of soroban-cli

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,7 +1,7 @@
 FROM gitpod/workspace-full:2023-01-16-03-31-28
 
 RUN mkdir -p ~/.local/bin
-RUN curl -L https://github.com/stellar/soroban-tools/releases/download/v0.9.1/soroban-cli-0.9.1-x86_64-unknown-linux-gnu | tar xz -C ~/.local/bin soroban
+RUN curl -L https://github.com/stellar/soroban-tools/releases/download/v0.9.1/soroban-cli-0.9.1-x86_64-unknown-linux-gnu.tar.gz | tar xz -C ~/.local/bin soroban
 RUN chmod +x ~/.local/bin/soroban
 RUN curl -L https://github.com/mozilla/sccache/releases/download/v0.3.3/sccache-v0.3.3-x86_64-unknown-linux-musl.tar.gz | tar xz --strip-components 1 -C ~/.local/bin sccache-v0.3.3-x86_64-unknown-linux-musl/sccache
 RUN chmod +x ~/.local/bin/sccache

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,7 +1,7 @@
 FROM gitpod/workspace-full:2023-01-16-03-31-28
 
 RUN mkdir -p ~/.local/bin
-RUN curl -L -o ~/.local/bin/soroban https://github.com/stellar/soroban-tools/releases/download/v0.9.1/soroban-cli-0.9.1-x86_64-unknown-linux-gnu
+RUN curl -L https://github.com/stellar/soroban-tools/releases/download/v0.9.1/soroban-cli-0.9.1-x86_64-unknown-linux-gnu | tar xz -C ~/.local/bin soroban
 RUN chmod +x ~/.local/bin/soroban
 RUN curl -L https://github.com/mozilla/sccache/releases/download/v0.3.3/sccache-v0.3.3-x86_64-unknown-linux-musl.tar.gz | tar xz --strip-components 1 -C ~/.local/bin sccache-v0.3.3-x86_64-unknown-linux-musl/sccache
 RUN chmod +x ~/.local/bin/sccache


### PR DESCRIPTION
### What

Changes the way the gitpod dockerfile downloads and installs the `soroban-cli` package

### Why

At some point, stellar/soroban-tools stopped distributing the CLI as an executable file, and it's now the executable wrapped in a `tar.gz` tarball. So, now I we download and decompress the file in the dockerfile.

<a href="https://gitpod.io/#https://github.com/stellar/soroban-examples/pull/269"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

