### PR TITLE
Fixing the contract invocation in `.gitpod.yml` file

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -31,7 +31,7 @@ tasks:
       gp open increment/src/lib.rs
       gp open increment/src/test.rs
       gp open README.md
-      soroban contract invoke --id 1 --wasm increment/target/wasm32-unknown-unknown/release/soroban_increment_contract.wasm --fn increment
+      soroban contract invoke --id 1 --wasm increment/target/wasm32-unknown-unknown/release/soroban_increment_contract.wasm -- increment
 vscode:
   extensions:
     - rust-lang.rust-analyzer


### PR DESCRIPTION
### What

Change the contract invocation of the `increment` contract that is done at the end of the gitpod workspace instantiation.

### Why

It was still using the `--fn <fn_name>` syntax from an earlier preview release.