### PR TITLE
Simplify token example removing authorization and clawback

### DIFF
--- a/token/src/balance.rs
+++ b/token/src/balance.rs
@@ -19,33 +19,13 @@ fn write_balance(e: &Env, addr: Address, amount: i128) {
 
 pub fn receive_balance(e: &Env, addr: Address, amount: i128) {
     let balance = read_balance(e, addr.clone());
-    if !is_authorized(e, addr.clone()) {
-        panic!("can't receive when deauthorized");
-    }
     write_balance(e, addr, balance + amount);
 }
 
 pub fn spend_balance(e: &Env, addr: Address, amount: i128) {
     let balance = read_balance(e, addr.clone());
-    if !is_authorized(e, addr.clone()) {
-        panic!("can't spend when deauthorized");
-    }
     if balance < amount {
         panic!("insufficient balance");
     }
     write_balance(e, addr, balance - amount);
-}
-
-pub fn is_authorized(e: &Env, addr: Address) -> bool {
-    let key = DataKey::State(addr);
-    if let Some(state) = e.storage().persistent().get::<DataKey, bool>(&key) {
-        state
-    } else {
-        true
-    }
-}
-
-pub fn write_authorization(e: &Env, addr: Address, is_authorized: bool) {
-    let key = DataKey::State(addr);
-    e.storage().persistent().set(&key, &is_authorized);
 }

--- a/token/src/contract.rs
+++ b/token/src/contract.rs
@@ -2,7 +2,6 @@
 //! interface.
 use crate::admin::{has_administrator, read_administrator, write_administrator};
 use crate::allowance::{read_allowance, spend_allowance, write_allowance};
-use crate::balance::{is_authorized, write_authorization};
 use crate::balance::{read_balance, receive_balance, spend_balance};
 use crate::event;
 use crate::metadata::{read_decimal, read_name, read_symbol, write_metadata};
@@ -39,27 +38,6 @@ impl Token {
                 symbol,
             },
         )
-    }
-
-    pub fn clawback(e: Env, from: Address, amount: i128) {
-        check_nonnegative_amount(amount);
-        let admin = read_administrator(&e);
-        admin.require_auth();
-
-        e.storage().instance().bump(INSTANCE_BUMP_AMOUNT);
-
-        spend_balance(&e, from.clone(), amount);
-        event::clawback(&e, admin, from, amount);
-    }
-
-    pub fn set_authorized(e: Env, id: Address, authorize: bool) {
-        let admin = read_administrator(&e);
-        admin.require_auth();
-
-        e.storage().instance().bump(INSTANCE_BUMP_AMOUNT);
-
-        write_authorization(&e, id.clone(), authorize);
-        event::set_authorized(&e, admin, id, authorize);
     }
 
     pub fn mint(e: Env, to: Address, amount: i128) {
@@ -112,9 +90,8 @@ impl token::Interface for Token {
         read_balance(&e, id)
     }
 
-    fn authorized(e: Env, id: Address) -> bool {
-        e.storage().instance().bump(INSTANCE_BUMP_AMOUNT);
-        is_authorized(&e, id)
+    fn authorized(_e: Env, _id: Address) -> bool {
+        true
     }
 
     fn transfer(e: Env, from: Address, to: Address, amount: i128) {

--- a/token/src/event.rs
+++ b/token/src/event.rs
@@ -15,16 +15,6 @@ pub(crate) fn mint(e: &Env, admin: Address, to: Address, amount: i128) {
     e.events().publish(topics, amount);
 }
 
-pub(crate) fn clawback(e: &Env, admin: Address, from: Address, amount: i128) {
-    let topics = (symbol_short!("clawback"), admin, from);
-    e.events().publish(topics, amount);
-}
-
-pub(crate) fn set_authorized(e: &Env, admin: Address, id: Address, authorize: bool) {
-    let topics = (Symbol::new(e, "set_authorized"), admin, id);
-    e.events().publish(topics, authorize);
-}
-
 pub(crate) fn set_admin(e: &Env, admin: Address, new_admin: Address) {
     let topics = (symbol_short!("set_admin"), admin);
     e.events().publish(topics, new_admin);

--- a/token/src/test.rs
+++ b/token/src/test.rs
@@ -116,43 +116,6 @@ fn test() {
         )]
     );
 
-    token.set_authorized(&user2, &false);
-    assert_eq!(
-        e.auths(),
-        std::vec![(
-            admin2.clone(),
-            AuthorizedInvocation {
-                function: AuthorizedFunction::Contract((
-                    token.address.clone(),
-                    Symbol::new(&e, "set_authorized"),
-                    (&user2, false).into_val(&e),
-                )),
-                sub_invocations: std::vec![]
-            }
-        )]
-    );
-    assert_eq!(token.authorized(&user2), false);
-
-    token.set_authorized(&user3, &true);
-    assert_eq!(token.authorized(&user3), true);
-
-    token.clawback(&user3, &100);
-    assert_eq!(
-        e.auths(),
-        std::vec![(
-            admin2.clone(),
-            AuthorizedInvocation {
-                function: AuthorizedFunction::Contract((
-                    token.address.clone(),
-                    symbol_short!("clawback"),
-                    (&user3, 100_i128).into_val(&e),
-                )),
-                sub_invocations: std::vec![]
-            }
-        )]
-    );
-    assert_eq!(token.balance(&user3), 200);
-
     // Increase to 500
     token.approve(&user2, &user3, &500, &200);
     assert_eq!(token.allowance(&user2, &user3), 500);
@@ -245,42 +208,6 @@ fn transfer_insufficient_balance() {
     assert_eq!(token.balance(&user1), 1000);
 
     token.transfer(&user1, &user2, &1001);
-}
-
-#[test]
-#[should_panic(expected = "can't receive when deauthorized")]
-fn transfer_receive_deauthorized() {
-    let e = Env::default();
-    e.mock_all_auths();
-
-    let admin = Address::random(&e);
-    let user1 = Address::random(&e);
-    let user2 = Address::random(&e);
-    let token = create_token(&e, &admin);
-
-    token.mint(&user1, &1000);
-    assert_eq!(token.balance(&user1), 1000);
-
-    token.set_authorized(&user2, &false);
-    token.transfer(&user1, &user2, &1);
-}
-
-#[test]
-#[should_panic(expected = "can't spend when deauthorized")]
-fn transfer_spend_deauthorized() {
-    let e = Env::default();
-    e.mock_all_auths();
-
-    let admin = Address::random(&e);
-    let user1 = Address::random(&e);
-    let user2 = Address::random(&e);
-    let token = create_token(&e, &admin);
-
-    token.mint(&user1, &1000);
-    assert_eq!(token.balance(&user1), 1000);
-
-    token.set_authorized(&user1, &false);
-    token.transfer(&user1, &user2, &1);
 }
 
 #[test]


### PR DESCRIPTION
### What
Remove authoriation and clawback from the token example.

### Why
Clawback is not a feature of the standard token. It's a little odd in a lightweight token example to include functionality that isn't part of the standard token interface. It is part of the Stellar Asset contract, but other tokens do not need to provide clawback functionality. So it muddies the water on what is or isn't part of the standard token interface to provide it.

Likewise, I don't think authorization should be part of the standard token interface and I've opened a PR proposing its removal in https://github.com/stellar/rs-soroban-sdk/pull/1079. Authorization logic could be so varied, and many contracts are unlikely to have it. For the moment I've simplified the authorization logic in the example contract to simply say that all addresses are authorized.

As a side-effect these changes simplify the token example, which is helpful. The standard token has enough functions as it is for folks to wrap their minds arounds. Everything we can do to help them step into building their own token with reduced complexity and concerns lowers the barrier.
