### PR TITLE
Prevent match issue when ledger timestamp == time_bound.timestamp

### DIFF
--- a/timelock/src/lib.rs
+++ b/timelock/src/lib.rs
@@ -47,7 +47,7 @@ fn check_time_bound(env: &Env, time_bound: &TimeBound) -> bool {
     let ledger_timestamp = env.ledger().timestamp();
 
     match time_bound.kind {
-        TimeBoundKind::Before => ledger_timestamp <= time_bound.timestamp,
+        TimeBoundKind::Before => ledger_timestamp < time_bound.timestamp,
         TimeBoundKind::After => ledger_timestamp >= time_bound.timestamp,
     }
 }


### PR DESCRIPTION
### What

Fix issue where 'ledger timestamp == time_bound.timestamp' in timelock/src/lib.rs -> After and Before can both simultaneously be true

### Why

This is the only Soroban code I could find working with time, so I wanted to make sure it was correct/intuitive for anyone learning using this example (myself included)

### Known limitations

N/A