### PR TITLE
Make the deep contract auth example consistent with other examples

### DIFF
--- a/deep_contract_auth/Makefile
+++ b/deep_contract_auth/Makefile
@@ -1,12 +1,13 @@
-default: test
+default: build
 
 all: test
 
-build:
-	cargo build
-
-test: 
+test: build
 	cargo test
+
+build:
+	soroban contract build
+	@ls -l target/wasm32-unknown-unknown/release/*.wasm
 
 fmt:
 	cargo fmt --all

--- a/deep_contract_auth/src/lib.rs
+++ b/deep_contract_auth/src/lib.rs
@@ -11,7 +11,7 @@
 /// for contract A address and contract A provides proper authorization to make
 /// the calls succeed.
 
-mod contract_a {
+pub mod contract_a {
 
     use soroban_sdk::{
         auth::{ContractContext, InvokerContractAuthEntry, SubContractInvocation},
@@ -50,7 +50,7 @@ mod contract_a {
     }
 }
 
-mod contract_b {
+pub mod contract_b {
     use soroban_sdk::{contract, contractimpl, Address, Env};
 
     use crate::contract_c::ContractCClient;
@@ -67,7 +67,8 @@ mod contract_b {
         }
     }
 }
-mod contract_c {
+
+pub mod contract_c {
 
     use soroban_sdk::{contract, contractimpl, Address, Env};
 
@@ -81,4 +82,5 @@ mod contract_c {
         }
     }
 }
+
 mod test;


### PR DESCRIPTION
### What
Make the deep contract auth example consistent with other examples.

### Why
The examples use the same setup, but the deep contract auth example seems to work a little differently. It doesn't use soroban-cli for contract builds. It defaults to running tests rather than building. Also the contract code is generating warnings.