### PR TITLE
Token supply

### DIFF
--- a/token/src/contract.rs
+++ b/token/src/contract.rs
@@ -91,6 +91,10 @@ impl Token {
             return 0;
         }   
 
+        e.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+        
         read_supply(&e)
     }
 }

--- a/token/src/lib.rs
+++ b/token/src/lib.rs
@@ -6,6 +6,7 @@ mod balance;
 mod contract;
 mod metadata;
 mod storage_types;
+mod supply;
 mod test;
 
 pub use crate::contract::TokenClient;

--- a/token/src/storage_types.rs
+++ b/token/src/storage_types.rs
@@ -28,4 +28,6 @@ pub enum DataKey {
     Nonce(Address),
     State(Address),
     Admin,
+    Supply,
+    Supplied
 }

--- a/token/src/storage_types.rs
+++ b/token/src/storage_types.rs
@@ -28,6 +28,5 @@ pub enum DataKey {
     Nonce(Address),
     State(Address),
     Admin,
-    Supply,
-    Supplied
+    Supply
 }

--- a/token/src/supply.rs
+++ b/token/src/supply.rs
@@ -1,0 +1,33 @@
+use soroban_sdk::{Env};
+use crate::storage_types::DataKey;
+
+pub fn has_supply(e: &Env) -> bool {
+    let key = DataKey::Supply;
+    e.storage().instance().has(&key)
+}
+
+pub fn read_supply(e: &Env) -> i128 {
+    let key = DataKey::Supply;
+    e.storage().instance().get(&key).unwrap()
+}
+
+pub fn write_supply(e: &Env, amount: &i128) {
+    let key = DataKey::Supply;
+    e.storage().instance().set(&key, amount);
+}
+
+pub fn decrement_supply(e: &Env, amount: &i128) {
+    let key = DataKey::Supply;
+    let current_supply: i128 = e.storage().instance().get(&key).unwrap();
+    let new_supply = current_supply - amount;
+    
+    e.storage().instance().set(&key, &new_supply);
+}
+
+pub fn increment_supply(e: &Env, amount: &i128) {
+    let key = DataKey::Supply;
+    let current_supply: i128 = e.storage().instance().get(&key).unwrap();
+    let new_supply = current_supply + amount;
+    
+    e.storage().instance().set(&key, &new_supply);
+}


### PR DESCRIPTION
This adds supply control to the soroban token example:

- Can initialize the token with a supply amount (not required).
- If supply provided, cannot mint if amount to mint is greater than supply. If minted, supply is decremented with minted amount.
- burn and burn_from increments supply with the amount burned.
