### PR TITLE
Update custom account examples to use the SDK interface

### DIFF
--- a/account/src/lib.rs
+++ b/account/src/lib.rs
@@ -16,7 +16,7 @@ struct AccountContract;
 
 #[contracttype]
 #[derive(Clone)]
-pub struct Signature {
+pub struct AccSignature {
     pub public_key: BytesN<32>,
     pub signature: BytesN<64>,
 }
@@ -73,7 +73,7 @@ impl AccountContract {
 
 #[contractimpl]
 impl CustomAccountInterface for AccountContract {
-    type Signature = Vec<Signature>;
+    type Signature = Vec<AccSignature>;
     type Error = AccError;
 
     // This is the 'entry point' of the account contract and every account
@@ -85,7 +85,7 @@ impl CustomAccountInterface for AccountContract {
     // been passed and return an error (or panic) otherwise.
     //
     // `__check_auth` takes the payload that needed to be signed, arbitrarily
-    // typed signatures (`Signature` contract type here) and authorization
+    // typed signatures (`Vec<AccSignature>` contract type here) and authorization
     // context that contains all the invocations that this call tries to verify.
     //
     // `__check_auth` has to authenticate the signatures. It also may use
@@ -104,7 +104,7 @@ impl CustomAccountInterface for AccountContract {
     fn __check_auth(
         env: Env,
         signature_payload: BytesN<32>,
-        signatures: Vec<Signature>,
+        signatures: Vec<AccSignature>,
         auth_context: Vec<Context>,
     ) -> Result<(), AccError> {
         // Perform authentication.
@@ -141,7 +141,7 @@ impl CustomAccountInterface for AccountContract {
 fn authenticate(
     env: &Env,
     signature_payload: &BytesN<32>,
-    signatures: &Vec<Signature>,
+    signatures: &Vec<AccSignature>,
 ) -> Result<(), AccError> {
     for i in 0..signatures.len() {
         let signature = signatures.get_unchecked(i);

--- a/account/src/lib.rs
+++ b/account/src/lib.rs
@@ -7,8 +7,9 @@
 #![no_std]
 
 use soroban_sdk::{
-    auth::Context, contract, contracterror, contractimpl, contracttype, symbol_short, Address,
-    BytesN, Env, Map, Symbol, TryIntoVal, Vec,
+    auth::{Context, CustomAccountInterface},
+    contract, contracterror, contractimpl, contracttype, symbol_short, Address, BytesN, Env, Map,
+    Symbol, TryIntoVal, Vec,
 };
 #[contract]
 struct AccountContract;
@@ -68,6 +69,12 @@ impl AccountContract {
             .instance()
             .set(&DataKey::SpendLimit(token), &limit);
     }
+}
+
+#[contractimpl]
+impl CustomAccountInterface for AccountContract {
+    type Signature = Vec<Signature>;
+    type Error = AccError;
 
     // This is the 'entry point' of the account contract and every account
     // contract has to implement it. `require_auth` calls for the Address of
@@ -94,7 +101,7 @@ impl AccountContract {
     // Note, that `__check_auth` function shouldn't call `require_auth` on the
     // contract's own address in order to avoid infinite recursion.
     #[allow(non_snake_case)]
-    pub fn __check_auth(
+    fn __check_auth(
         env: Env,
         signature_payload: BytesN<32>,
         signatures: Vec<Signature>,

--- a/account/src/test.rs
+++ b/account/src/test.rs
@@ -15,7 +15,7 @@ use soroban_sdk::{
 };
 
 use crate::AccError;
-use crate::{AccountContract, AccountContractClient, Signature};
+use crate::{AccSignature, AccountContract, AccountContractClient};
 
 fn generate_keypair() -> Keypair {
     Keypair::generate(&mut thread_rng())

--- a/account/src/test.rs
+++ b/account/src/test.rs
@@ -30,7 +30,7 @@ fn create_account_contract(e: &Env) -> AccountContractClient {
 }
 
 fn sign(e: &Env, signer: &Keypair, payload: &BytesN<32>) -> Val {
-    Signature {
+    AccSignature {
         public_key: signer_public_key(e, signer),
         signature: signer
             .sign(payload.to_array().as_slice())

--- a/simple_account/src/lib.rs
+++ b/simple_account/src/lib.rs
@@ -10,10 +10,7 @@
 #[contract]
 struct SimpleAccount;
 
-use soroban_sdk::{
-    auth::{Context, CustomAccountInterface},
-    contract, contractimpl, contracttype, BytesN, Env, Vec,
-};
+use soroban_sdk::{auth::Context, contract, contractimpl, contracttype, BytesN, Env, Vec};
 
 #[derive(Clone)]
 #[contracttype]
@@ -33,10 +30,7 @@ impl SimpleAccount {
 }
 
 #[contractimpl]
-impl CustomAccountInterface for SimpleAccount {
-    type Signature = BytesN<64>;
-    type Error = ();
-
+impl SimpleAccount {
     // This is the 'entry point' of the account contract and every account
     // contract has to implement it. `require_auth` calls for the Address of
     // this contract will result in calling this `__check_auth` function with
@@ -55,22 +49,19 @@ impl CustomAccountInterface for SimpleAccount {
     // Note, that `__check_auth` function shouldn't call `require_auth` on the
     // contract's own address in order to avoid infinite recursion.
     #[allow(non_snake_case)]
-    fn __check_auth(
+    pub fn __check_auth(
         env: Env,
         signature_payload: BytesN<32>,
         signature: BytesN<64>,
         _auth_context: Vec<Context>,
-    ) -> Result<(), ()> {
+    ) {
         let public_key: BytesN<32> = env
             .storage()
             .instance()
             .get::<_, BytesN<32>>(&DataKey::Owner)
             .unwrap();
-        // Verifies the signature and panics if verification fails, causing an
-        // error to be passed back.
         env.crypto()
             .ed25519_verify(&public_key, &signature_payload.into(), &signature);
-        Ok(())
     }
 }
 

--- a/simple_account/src/lib.rs
+++ b/simple_account/src/lib.rs
@@ -10,7 +10,10 @@
 #[contract]
 struct SimpleAccount;
 
-use soroban_sdk::{auth::Context, contract, contractimpl, contracttype, BytesN, Env, Vec};
+use soroban_sdk::{
+    auth::{Context, CustomAccountInterface},
+    contract, contractimpl, contracttype, BytesN, Env, Vec,
+};
 
 #[derive(Clone)]
 #[contracttype]
@@ -27,6 +30,12 @@ impl SimpleAccount {
         }
         env.storage().instance().set(&DataKey::Owner, &public_key);
     }
+}
+
+#[contractimpl]
+impl CustomAccountInterface for SimpleAccount {
+    type Signature = BytesN<64>;
+    type Error = ();
 
     // This is the 'entry point' of the account contract and every account
     // contract has to implement it. `require_auth` calls for the Address of
@@ -46,19 +55,22 @@ impl SimpleAccount {
     // Note, that `__check_auth` function shouldn't call `require_auth` on the
     // contract's own address in order to avoid infinite recursion.
     #[allow(non_snake_case)]
-    pub fn __check_auth(
+    fn __check_auth(
         env: Env,
         signature_payload: BytesN<32>,
         signature: BytesN<64>,
         _auth_context: Vec<Context>,
-    ) {
+    ) -> Result<(), ()> {
         let public_key: BytesN<32> = env
             .storage()
             .instance()
             .get::<_, BytesN<32>>(&DataKey::Owner)
             .unwrap();
+        // Verifies the signature and panics if verification fails, causing an
+        // error to be passed back.
         env.crypto()
             .ed25519_verify(&public_key, &signature_payload.into(), &signature);
+        Ok(())
     }
 }
 

--- a/simple_account/src/lib.rs
+++ b/simple_account/src/lib.rs
@@ -27,10 +27,7 @@ impl SimpleAccount {
         }
         env.storage().instance().set(&DataKey::Owner, &public_key);
     }
-}
 
-#[contractimpl]
-impl SimpleAccount {
     // This is the 'entry point' of the account contract and every account
     // contract has to implement it. `require_auth` calls for the Address of
     // this contract will result in calling this `__check_auth` function with


### PR DESCRIPTION
### What
Update custom account examples to use the SDK interface.

### Why
The interface is there to help make sure that implementations match the interface that the Soroban Env expects. The examples should encourage use of them, even though they aren't required.