### PR TITLE
Update Cargo.toml file on all contracts.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -5,6 +5,9 @@ on:
     branches: [main, dev]
   pull_request:
 
+env:
+  MINIMUM_RUST_VERSION: 1.74.0
+
 jobs:
 
   complete:
@@ -75,9 +78,8 @@ jobs:
     - name: Use the minimum supported Rust version
       if: matrix.rust == 'msrv'
       run: |
-        msrv="$(cargo metadata --format-version 1 --no-deps | jq -r '.packages | map(.rust_version) | map(values) | min')"
-        rustup override set $msrv
-        rustup component add clippy --toolchain $msrv
+        rustup override set $MINIMUM_RUST_VERSION
+        rustup component add clippy --toolchain $MINIMUM_RUST_VERSION
     - name: Error on warnings and clippy checks
       # Only error on warnings and checks for the msrv, because new versions of
       # Rust will frequently add new warnings and checks.

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ target/
 /.sccache/
 .DS_Store
 .soroban
-errors/test_snapshots/
+test_snapshots

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ target/
 /.sccache/
 .DS_Store
 .soroban
+errors/test_snapshots/

--- a/account/Cargo.toml
+++ b/account/Cargo.toml
@@ -1,10 +1,7 @@
 [package]
 name = "soroban-account-contract"
 version = "0.0.0"
-authors = ["Stellar Development Foundation <info@stellar.org>"]
-license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.74.0"
 publish = false
 
 [lib]
@@ -14,7 +11,7 @@ doctest = false
 [dependencies]
 soroban-sdk = { version = "20.3.1" }
 
-[dev_dependencies]
+[dev-dependencies]
 soroban-sdk = { version = "20.3.1", features = ["testutils"] }
 ed25519-dalek = { version = "1.0.1" }
 rand = { version = "0.7.3" }

--- a/alloc/Cargo.toml
+++ b/alloc/Cargo.toml
@@ -1,10 +1,7 @@
 [package]
 name = "soroban-alloc-contract"
 version = "0.0.0"
-authors = ["Stellar Development Foundation <info@stellar.org>"]
-license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.74.0"
 publish = false
 
 [lib]
@@ -14,7 +11,7 @@ doctest = false
 [dependencies]
 soroban-sdk = { version = "20.3.1", features = ["alloc"] }
 
-[dev_dependencies]
+[dev-dependencies]
 soroban-sdk = { version = "20.3.1", features = ["testutils", "alloc"] }
 
 [profile.release]

--- a/atomic_multiswap/Cargo.toml
+++ b/atomic_multiswap/Cargo.toml
@@ -1,10 +1,7 @@
 [package]
 name = "soroban-atomic-multiswap-contract"
 version = "0.0.0"
-authors = ["Stellar Development Foundation <info@stellar.org>"]
-license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.74.0"
 publish = false
 
 [lib]
@@ -14,7 +11,7 @@ doctest = false
 [dependencies]
 soroban-sdk = { version = "20.3.1" }
 
-[dev_dependencies]
+[dev-dependencies]
 soroban-sdk = { version = "20.3.1", features = ["testutils"] }
 assert_unordered = "0.3.5"
 

--- a/atomic_swap/Cargo.toml
+++ b/atomic_swap/Cargo.toml
@@ -1,10 +1,7 @@
 [package]
 name = "soroban-atomic-swap-contract"
 version = "0.0.0"
-authors = ["Stellar Development Foundation <info@stellar.org>"]
-license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.74.0"
 publish = false
 
 [lib]
@@ -14,7 +11,7 @@ doctest = false
 [dependencies]
 soroban-sdk = { version = "20.3.1" }
 
-[dev_dependencies]
+[dev-dependencies]
 soroban-sdk = { version = "20.3.1", features = ["testutils"] }
 
 [profile.release]

--- a/auth/Cargo.toml
+++ b/auth/Cargo.toml
@@ -2,7 +2,6 @@
 name = "soroban-auth-contract"
 version = "0.0.0"
 edition = "2021"
-rust-version = "1.74.0"
 publish = false
 
 [lib]
@@ -11,7 +10,7 @@ crate-type = ["cdylib"]
 [dependencies]
 soroban-sdk = { version = "20.3.1" }
 
-[dev_dependencies]
+[dev-dependencies]
 soroban-sdk = { version = "20.3.1", features = ["testutils"] }
 
 [profile.release]

--- a/cross_contract/contract_a/Cargo.lock
+++ b/cross_contract/contract_a/Cargo.lock
@@ -986,9 +986,9 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "soroban-builtin-sdk-macros"
-version = "20.1.0"
+version = "20.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3aa4d0718c6bb74d5b9f77d54dde6cc08a7eb6ef0e76b524f723a48f1cf5db2c"
+checksum = "7cc32c6e817f3ca269764ec0d7d14da6210b74a5bf14d4e745aa3ee860558900"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1005,9 +1005,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-common"
-version = "20.1.0"
+version = "20.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0e3c4b5ea7936e814706f2a5da6af574260319bcc66fbf5517b39f19b5fa365"
+checksum = "c14e18d879c520ff82612eaae0590acaf6a7f3b977407e1abb1c9e31f94c7814"
 dependencies = [
  "arbitrary",
  "crate-git-revision",
@@ -1023,9 +1023,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-guest"
-version = "20.1.0"
+version = "20.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ff111936103653515b4471b951b6325b966c3bb31c4c1bd5892ea741aa028ca"
+checksum = "5122ca2abd5ebcc1e876a96b9b44f87ce0a0e06df8f7c09772ddb58b159b7454"
 dependencies = [
  "soroban-env-common",
  "static_assertions",
@@ -1033,9 +1033,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-host"
-version = "20.1.0"
+version = "20.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3d7de1f83760dddf9302dcc32f8adfebaff41946045ea67196511aca8d9f00"
+checksum = "114a0fa0d0cc39d0be16b1ee35b6e5f4ee0592ddcf459bde69391c02b03cf520"
 dependencies = [
  "backtrace",
  "curve25519-dalek",
@@ -1060,9 +1060,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-macros"
-version = "20.1.0"
+version = "20.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff774562cca63a173127b0b6679dce9afde49fd34474eec041dc5612134dda7"
+checksum = "b13e3f8c86f812e0669e78fcb3eae40c385c6a9dd1a4886a1de733230b4fcf27"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1075,9 +1075,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "20.2.0"
+version = "20.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b4166fef4218b0a23d9ef58f48dc57cf56bf7fbe46d410e0f8672e8986b42b"
+checksum = "61a54708f44890e0546180db6b4f530e2a88d83b05a9b38a131caa21d005e25a"
 dependencies = [
  "serde",
  "serde_json",
@@ -1089,9 +1089,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "20.2.0"
+version = "20.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf12b257428a9ec762491e76f80f7d7a6fa3b7994adbbdc559c787f64fcebff5"
+checksum = "84fc8be9068dd4e0212d8b13ad61089ea87e69ac212c262914503a961c8dc3a3"
 dependencies = [
  "arbitrary",
  "bytes-lit",
@@ -1109,9 +1109,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "20.2.0"
+version = "20.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74e591efb1b5850fb5c95dcac9efcd65fa3168f041fe7204edd4ecf592f01f21"
+checksum = "db20def4ead836663633f58d817d0ed8e1af052c9650a04adf730525af85b964"
 dependencies = [
  "crate-git-revision",
  "darling",
@@ -1129,9 +1129,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec"
-version = "20.2.0"
+version = "20.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bc6f22d7c303d8cb6e12d2dd04d4dfb38d773292f2721ea5ac15d3b0fd51c6c"
+checksum = "3eefeb5d373b43f6828145d00f0c5cc35e96db56a6671ae9614f84beb2711cab"
 dependencies = [
  "base64 0.13.1",
  "stellar-xdr",
@@ -1141,9 +1141,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-rust"
-version = "20.2.0"
+version = "20.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ffcc7e96ae13c3fdce8b132be2949784fc23d2234e9e591817e1b21ace9aa06"
+checksum = "3152bca4737ef734ac37fe47b225ee58765c9095970c481a18516a2b287c7a33"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -1157,9 +1157,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-wasmi"
-version = "0.31.1-soroban.20.0.0"
+version = "0.31.1-soroban.20.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1aaa682a67cbd2173f1d60cb1e7b951d490d7c4e0b7b6f5387cbb952e963c46"
+checksum = "710403de32d0e0c35375518cb995d4fc056d0d48966f2e56ea471b8cb8fc9719"
 dependencies = [
  "smallvec",
  "spin",
@@ -1203,9 +1203,9 @@ dependencies = [
 
 [[package]]
 name = "stellar-xdr"
-version = "20.0.2"
+version = "20.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f00a85bd9b1617d4cb7e741733889c9940e6bdeca360db81752b0ef04fe3a5"
+checksum = "e59cdf3eb4467fb5a4b00b52e7de6dca72f67fac6f9b700f55c95a5d86f09c9d"
 dependencies = [
  "arbitrary",
  "base64 0.13.1",

--- a/cross_contract/contract_a/Cargo.toml
+++ b/cross_contract/contract_a/Cargo.toml
@@ -1,10 +1,7 @@
 [package]
 name = "soroban-cross-contract-a-contract"
 version = "0.0.0"
-authors = ["Stellar Development Foundation <info@stellar.org>"]
-license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.74.0"
 publish = false
 
 [lib]
@@ -14,7 +11,7 @@ doctest = false
 [dependencies]
 soroban-sdk = { version = "20.3.1" }
 
-[dev_dependencies]
+[dev-dependencies]
 soroban-sdk = { version = "20.3.1", features = ["testutils"] }
 
 [profile.release]

--- a/cross_contract/contract_b/Cargo.lock
+++ b/cross_contract/contract_b/Cargo.lock
@@ -986,9 +986,9 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "soroban-builtin-sdk-macros"
-version = "20.1.0"
+version = "20.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3aa4d0718c6bb74d5b9f77d54dde6cc08a7eb6ef0e76b524f723a48f1cf5db2c"
+checksum = "7cc32c6e817f3ca269764ec0d7d14da6210b74a5bf14d4e745aa3ee860558900"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1005,9 +1005,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-common"
-version = "20.1.0"
+version = "20.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0e3c4b5ea7936e814706f2a5da6af574260319bcc66fbf5517b39f19b5fa365"
+checksum = "c14e18d879c520ff82612eaae0590acaf6a7f3b977407e1abb1c9e31f94c7814"
 dependencies = [
  "arbitrary",
  "crate-git-revision",
@@ -1023,9 +1023,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-guest"
-version = "20.1.0"
+version = "20.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ff111936103653515b4471b951b6325b966c3bb31c4c1bd5892ea741aa028ca"
+checksum = "5122ca2abd5ebcc1e876a96b9b44f87ce0a0e06df8f7c09772ddb58b159b7454"
 dependencies = [
  "soroban-env-common",
  "static_assertions",
@@ -1033,9 +1033,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-host"
-version = "20.1.0"
+version = "20.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3d7de1f83760dddf9302dcc32f8adfebaff41946045ea67196511aca8d9f00"
+checksum = "114a0fa0d0cc39d0be16b1ee35b6e5f4ee0592ddcf459bde69391c02b03cf520"
 dependencies = [
  "backtrace",
  "curve25519-dalek",
@@ -1060,9 +1060,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-macros"
-version = "20.1.0"
+version = "20.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff774562cca63a173127b0b6679dce9afde49fd34474eec041dc5612134dda7"
+checksum = "b13e3f8c86f812e0669e78fcb3eae40c385c6a9dd1a4886a1de733230b4fcf27"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1075,9 +1075,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "20.2.0"
+version = "20.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b4166fef4218b0a23d9ef58f48dc57cf56bf7fbe46d410e0f8672e8986b42b"
+checksum = "61a54708f44890e0546180db6b4f530e2a88d83b05a9b38a131caa21d005e25a"
 dependencies = [
  "serde",
  "serde_json",
@@ -1089,9 +1089,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "20.2.0"
+version = "20.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf12b257428a9ec762491e76f80f7d7a6fa3b7994adbbdc559c787f64fcebff5"
+checksum = "84fc8be9068dd4e0212d8b13ad61089ea87e69ac212c262914503a961c8dc3a3"
 dependencies = [
  "arbitrary",
  "bytes-lit",
@@ -1109,9 +1109,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "20.2.0"
+version = "20.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74e591efb1b5850fb5c95dcac9efcd65fa3168f041fe7204edd4ecf592f01f21"
+checksum = "db20def4ead836663633f58d817d0ed8e1af052c9650a04adf730525af85b964"
 dependencies = [
  "crate-git-revision",
  "darling",
@@ -1129,9 +1129,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec"
-version = "20.2.0"
+version = "20.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bc6f22d7c303d8cb6e12d2dd04d4dfb38d773292f2721ea5ac15d3b0fd51c6c"
+checksum = "3eefeb5d373b43f6828145d00f0c5cc35e96db56a6671ae9614f84beb2711cab"
 dependencies = [
  "base64 0.13.1",
  "stellar-xdr",
@@ -1141,9 +1141,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-rust"
-version = "20.2.0"
+version = "20.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ffcc7e96ae13c3fdce8b132be2949784fc23d2234e9e591817e1b21ace9aa06"
+checksum = "3152bca4737ef734ac37fe47b225ee58765c9095970c481a18516a2b287c7a33"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -1157,9 +1157,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-wasmi"
-version = "0.31.1-soroban.20.0.0"
+version = "0.31.1-soroban.20.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1aaa682a67cbd2173f1d60cb1e7b951d490d7c4e0b7b6f5387cbb952e963c46"
+checksum = "710403de32d0e0c35375518cb995d4fc056d0d48966f2e56ea471b8cb8fc9719"
 dependencies = [
  "smallvec",
  "spin",
@@ -1203,9 +1203,9 @@ dependencies = [
 
 [[package]]
 name = "stellar-xdr"
-version = "20.0.2"
+version = "20.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f00a85bd9b1617d4cb7e741733889c9940e6bdeca360db81752b0ef04fe3a5"
+checksum = "e59cdf3eb4467fb5a4b00b52e7de6dca72f67fac6f9b700f55c95a5d86f09c9d"
 dependencies = [
  "arbitrary",
  "base64 0.13.1",

--- a/cross_contract/contract_b/Cargo.toml
+++ b/cross_contract/contract_b/Cargo.toml
@@ -1,10 +1,7 @@
 [package]
 name = "soroban-cross-contract-b-contract"
 version = "0.0.0"
-authors = ["Stellar Development Foundation <info@stellar.org>"]
-license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.74.0"
 publish = false
 
 [lib]
@@ -14,7 +11,7 @@ doctest = false
 [dependencies]
 soroban-sdk = { version = "20.3.1" }
 
-[dev_dependencies]
+[dev-dependencies]
 soroban-sdk = { version = "20.3.1", features = ["testutils"] }
 
 [profile.release]

--- a/custom_types/Cargo.toml
+++ b/custom_types/Cargo.toml
@@ -1,10 +1,7 @@
 [package]
 name = "soroban-custom-types-contract"
 version = "0.0.0"
-authors = ["Stellar Development Foundation <info@stellar.org>"]
-license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.74.0"
 publish = false
 
 [lib]
@@ -14,7 +11,7 @@ doctest = false
 [dependencies]
 soroban-sdk = { version = "20.3.1" }
 
-[dev_dependencies]
+[dev-dependencies]
 soroban-sdk = { version = "20.3.1", features = ["testutils"] }
 
 [profile.release]

--- a/deep_contract_auth/Cargo.toml
+++ b/deep_contract_auth/Cargo.toml
@@ -1,10 +1,7 @@
 [package]
 name = "soroban-deployer-contract"
 version = "0.0.0"
-authors = ["Stellar Development Foundation <info@stellar.org>"]
-license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.74.0"
 publish = false
 
 [lib]
@@ -14,7 +11,7 @@ doctest = false
 [dependencies]
 soroban-sdk = { version = "20.3.1" }
 
-[dev_dependencies]
+[dev-dependencies]
 soroban-sdk = { version = "20.3.1", features = ["testutils"] }
 
 [profile.release]

--- a/deployer/contract/Cargo.toml
+++ b/deployer/contract/Cargo.toml
@@ -1,10 +1,7 @@
 [package]
 name = "soroban-deployer-test-contract"
 version = "0.0.0"
-authors = ["Stellar Development Foundation <info@stellar.org>"]
-license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.74.0"
 publish = false
 
 [lib]
@@ -14,7 +11,7 @@ doctest = false
 [dependencies]
 soroban-sdk = { version = "20.3.1" }
 
-[dev_dependencies]
+[dev-dependencies]
 soroban-sdk = { version = "20.3.1", features = ["testutils"] }
 
 [profile.release]

--- a/deployer/deployer/Cargo.toml
+++ b/deployer/deployer/Cargo.toml
@@ -1,10 +1,7 @@
 [package]
 name = "soroban-deployer-contract"
 version = "0.0.0"
-authors = ["Stellar Development Foundation <info@stellar.org>"]
-license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.74.0"
 publish = false
 
 [lib]
@@ -14,7 +11,7 @@ doctest = false
 [dependencies]
 soroban-sdk = { version = "20.3.1" }
 
-[dev_dependencies]
+[dev-dependencies]
 soroban-sdk = { version = "20.3.1", features = ["testutils"] }
 
 [profile.release]

--- a/errors/Cargo.toml
+++ b/errors/Cargo.toml
@@ -1,10 +1,7 @@
 [package]
 name = "soroban-errors-contract"
 version = "0.0.0"
-authors = ["Stellar Development Foundation <info@stellar.org>"]
-license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.74.0"
 publish = false
 
 [lib]
@@ -14,7 +11,7 @@ doctest = false
 [dependencies]
 soroban-sdk = { version = "20.3.1" }
 
-[dev_dependencies]
+[dev-dependencies]
 soroban-sdk = { version = "20.3.1", features = ["testutils"] }
 
 [profile.release]

--- a/eth_abi/Cargo.toml
+++ b/eth_abi/Cargo.toml
@@ -1,11 +1,8 @@
 [package]
 name = "soroban-eth-abi"
 version = "0.1.0"
-authors = ["Stellar Development Foundation <info@stellar.org>"]
-license = "Apache-2.0"
 edition = "2021"
 publish = false
-rust-version = "1.74"
 
 [lib]
 crate-type = ["cdylib"]

--- a/events/Cargo.toml
+++ b/events/Cargo.toml
@@ -1,10 +1,7 @@
 [package]
 name = "soroban-events-contract"
 version = "0.0.0"
-authors = ["Stellar Development Foundation <info@stellar.org>"]
-license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.74.0"
 publish = false
 
 [lib]
@@ -14,7 +11,7 @@ doctest = false
 [dependencies]
 soroban-sdk = { version = "20.3.1" }
 
-[dev_dependencies]
+[dev-dependencies]
 soroban-sdk = { version = "20.3.1", features = ["testutils"] }
 
 [profile.release]

--- a/fuzzing/Cargo.toml
+++ b/fuzzing/Cargo.toml
@@ -1,10 +1,7 @@
 [package]
 name = "soroban-fuzzing-contract"
 version = "0.0.0"
-authors = ["Stellar Development Foundation <info@stellar.org>"]
-license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.74.0"
 publish = false
 
 [lib]
@@ -17,7 +14,7 @@ testutils = []
 [dependencies]
 soroban-sdk = { version = "20.3.1" }
 
-[dev_dependencies]
+[dev-dependencies]
 soroban-sdk = { version = "20.3.1", features = ["testutils"] }
 arbitrary = { version = "1.1.3", features = ["derive"] }
 proptest  = "1.2.0"

--- a/hello_world/Cargo.toml
+++ b/hello_world/Cargo.toml
@@ -1,10 +1,7 @@
 [package]
 name = "soroban-hello-world-contract"
 version = "0.0.0"
-authors = ["Stellar Development Foundation <info@stellar.org>"]
-license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.74.0"
 publish = false
 
 [lib]
@@ -14,7 +11,7 @@ doctest = false
 [dependencies]
 soroban-sdk = { version = "20.3.1" }
 
-[dev_dependencies]
+[dev-dependencies]
 soroban-sdk = { version = "20.3.1", features = ["testutils"] }
 
 [profile.release]

--- a/increment/Cargo.toml
+++ b/increment/Cargo.toml
@@ -1,10 +1,7 @@
 [package]
 name = "soroban-increment-contract"
 version = "0.0.0"
-authors = ["Stellar Development Foundation <info@stellar.org>"]
-license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.74.0"
 publish = false
 
 [lib]
@@ -14,7 +11,7 @@ doctest = false
 [dependencies]
 soroban-sdk = { version = "20.3.1" }
 
-[dev_dependencies]
+[dev-dependencies]
 soroban-sdk = { version = "20.3.1", features = ["testutils"] }
 
 [profile.release]

--- a/liquidity_pool/Cargo.toml
+++ b/liquidity_pool/Cargo.toml
@@ -2,7 +2,6 @@
 name = "soroban-liquidity-pool-contract"
 version = "0.0.0"
 edition = "2021"
-rust-version = "1.74.0"
 publish = false
 
 [lib]
@@ -12,7 +11,7 @@ crate-type = ["cdylib"]
 soroban-sdk = { version = "20.3.1" }
 num-integer = { version = "0.1.45", default-features = false, features = ["i128"] }
 
-[dev_dependencies]
+[dev-dependencies]
 soroban-sdk = { version = "20.3.1", features = ["testutils"] }
 
 [profile.release]

--- a/logging/Cargo.toml
+++ b/logging/Cargo.toml
@@ -1,10 +1,7 @@
 [package]
 name = "soroban-logging-contract"
 version = "0.0.0"
-authors = ["Stellar Development Foundation <info@stellar.org>"]
-license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.74.0"
 publish = false
 
 [lib]
@@ -17,7 +14,7 @@ testutils = ["soroban-sdk/testutils"]
 [dependencies]
 soroban-sdk = { version = "20.3.1" }
 
-[dev_dependencies]
+[dev-dependencies]
 soroban-sdk = { version = "20.3.1", features = ["testutils"] }
 
 [profile.release]

--- a/mint-lock/Cargo.toml
+++ b/mint-lock/Cargo.toml
@@ -1,10 +1,7 @@
 [package]
 name = "soroban-mint-lock-contract"
 version = "0.0.0"
-authors = ["Stellar Development Foundation <info@stellar.org>"]
-license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.74.0"
 publish = false
 
 [lib]
@@ -14,7 +11,7 @@ doctest = false
 [dependencies]
 soroban-sdk = { version = "20.3.1" }
 
-[dev_dependencies]
+[dev-dependencies]
 soroban-sdk = { version = "20.3.1", features = ["testutils"] }
 
 [profile.release]

--- a/simple_account/Cargo.toml
+++ b/simple_account/Cargo.toml
@@ -1,10 +1,7 @@
 [package]
 name = "soroban-simple-account-contract"
 version = "0.0.0"
-authors = ["Stellar Development Foundation <info@stellar.org>"]
-license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.74.0"
 publish = false
 
 [lib]
@@ -14,7 +11,7 @@ doctest = false
 [dependencies]
 soroban-sdk = { version = "20.3.1" }
 
-[dev_dependencies]
+[dev-dependencies]
 soroban-sdk = { version = "20.3.1", features = ["testutils"] }
 ed25519-dalek = { version = "1.0.1" }
 rand = { version = "0.7.3" }

--- a/single_offer/Cargo.toml
+++ b/single_offer/Cargo.toml
@@ -2,7 +2,6 @@
 name = "soroban-single-offer-contract"
 version = "0.0.0"
 edition = "2021"
-rust-version = "1.74.0"
 publish = false
 
 [lib]
@@ -11,7 +10,7 @@ crate-type = ["cdylib"]
 [dependencies]
 soroban-sdk = { version = "20.3.1" }
 
-[dev_dependencies]
+[dev-dependencies]
 soroban-sdk = { version = "20.3.1", features = ["testutils"] }
 
 [profile.release]

--- a/timelock/Cargo.toml
+++ b/timelock/Cargo.toml
@@ -1,10 +1,7 @@
 [package]
 name = "soroban-timelock-contract"
 version = "0.0.0"
-authors = ["Stellar Development Foundation <info@stellar.org>"]
-license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.74.0"
 publish = false
 
 [lib]
@@ -14,7 +11,7 @@ doctest = false
 [dependencies]
 soroban-sdk = { version = "20.3.1" }
 
-[dev_dependencies]
+[dev-dependencies]
 soroban-sdk = { version = "20.3.1", features = ["testutils"] }
 
 [profile.release]

--- a/token/Cargo.toml
+++ b/token/Cargo.toml
@@ -3,7 +3,6 @@ name = "soroban-token-contract"
 description = "Soroban standard token contract"
 version = "0.0.6"
 edition = "2021"
-rust-version = "1.74.0"
 
 [lib]
 crate-type = ["cdylib"]
@@ -12,7 +11,7 @@ crate-type = ["cdylib"]
 soroban-sdk = { version = "20.3.1" }
 soroban-token-sdk = { version = "20.3.1" }
 
-[dev_dependencies]
+[dev-dependencies]
 soroban-sdk = { version = "20.3.1", features = ["testutils"] }
 
 [profile.release]

--- a/upgradeable_contract/new_contract/Cargo.toml
+++ b/upgradeable_contract/new_contract/Cargo.toml
@@ -1,10 +1,7 @@
 [package]
 name = "soroban-upgradeable-contract-new-contract"
 version = "0.0.0"
-authors = ["Stellar Development Foundation <info@stellar.org>"]
-license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.74.0"
 publish = false
 
 [lib]
@@ -14,7 +11,7 @@ doctest = false
 [dependencies]
 soroban-sdk = { version = "20.3.1" }
 
-[dev_dependencies]
+[dev-dependencies]
 soroban-sdk = { version = "20.3.1", features = ["testutils"] }
 
 [profile.release]

--- a/upgradeable_contract/old_contract/Cargo.toml
+++ b/upgradeable_contract/old_contract/Cargo.toml
@@ -1,10 +1,7 @@
 [package]
 name = "soroban-upgradeable-contract-old-contract"
 version = "0.0.0"
-authors = ["Stellar Development Foundation <info@stellar.org>"]
-license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.74.0"
 publish = false
 
 [lib]
@@ -14,7 +11,7 @@ doctest = false
 [dependencies]
 soroban-sdk = { version = "20.3.1" }
 
-[dev_dependencies]
+[dev-dependencies]
 soroban-sdk = { version = "20.3.1", features = ["testutils"] }
 
 [profile.release]

--- a/workspace/contract_a/Cargo.toml
+++ b/workspace/contract_a/Cargo.toml
@@ -1,10 +1,7 @@
 [package]
 name = "soroban-workspace-contract-a"
 version.workspace = true
-authors = ["Stellar Development Foundation <info@stellar.org>"]
-license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.74.0"
 publish = false
 
 [lib]
@@ -18,6 +15,6 @@ testutils = []
 soroban-sdk = { workspace = true }
 soroban-workspace-contract-a-interface = { workspace = true }
 
-[dev_dependencies]
+[dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }
 soroban-workspace-contract-a-interface = { workspace = true, features = ["testutils"] }

--- a/workspace/contract_a_interface/Cargo.toml
+++ b/workspace/contract_a_interface/Cargo.toml
@@ -1,10 +1,7 @@
 [package]
 name = "soroban-workspace-contract-a-interface"
 version.workspace = true
-authors = ["Stellar Development Foundation <info@stellar.org>"]
-license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.74.0"
 publish = false
 
 [lib]
@@ -17,5 +14,5 @@ testutils = []
 [dependencies]
 soroban-sdk = { workspace = true }
 
-[dev_dependencies]
+[dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/workspace/contract_b/Cargo.toml
+++ b/workspace/contract_b/Cargo.toml
@@ -1,10 +1,7 @@
 [package]
 name = "soroban-workspace-contract-b"
 version.workspace = true
-authors = ["Stellar Development Foundation <info@stellar.org>"]
-license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.74.0"
 publish = false
 
 [lib]
@@ -15,7 +12,7 @@ doctest = false
 soroban-sdk = { workspace = true }
 soroban-workspace-contract-a-interface = { workspace = true }
 
-[dev_dependencies]
+[dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }
 soroban-workspace-contract-a-interface = { workspace = true, features = ["testutils"] }
 soroban-workspace-contract-a = { workspace = true, features = ["testutils"] }


### PR DESCRIPTION
### What

Simplify all Cargo.toml files, matching what's generated by `soroban contract init`.

### Why

`soroban contract init --with-example <name>` uses this repo as the source. By making these changes, we are able to copy examples that are closer to the actual generated contract.

### Known limitations

N/A
