### PR TITLE
PR: decimal value shall not be greater than 18

### DIFF
--- a/token/src/contract.rs
+++ b/token/src/contract.rs
@@ -28,8 +28,8 @@ impl Token {
             panic!("already initialized")
         }
         write_administrator(&e, &admin);
-        if decimal > u8::MAX.into() {
-            panic!("Decimal must fit in a u8");
+        if decimal > 18 {
+            panic!("Decimal must not be greater than 18");
         }
 
         write_metadata(

--- a/token/src/test.rs
+++ b/token/src/test.rs
@@ -242,14 +242,14 @@ fn initialize_already_initialized() {
 }
 
 #[test]
-#[should_panic(expected = "Decimal must fit in a u8")]
-fn decimal_is_over_max() {
+#[should_panic(expected = "Decimal must not be greater than 18")]
+fn decimal_is_over_eighteen() {
     let e = Env::default();
     let admin = Address::generate(&e);
     let token = TokenClient::new(&e, &e.register_contract(None, Token {}));
     token.initialize(
         &admin,
-        &(u32::from(u8::MAX) + 1),
+        &19,
         &"name".into_val(&e),
         &"symbol".into_val(&e),
     );

--- a/token/src/test.rs
+++ b/token/src/test.rs
@@ -247,12 +247,7 @@ fn decimal_is_over_eighteen() {
     let e = Env::default();
     let admin = Address::generate(&e);
     let token = TokenClient::new(&e, &e.register_contract(None, Token {}));
-    token.initialize(
-        &admin,
-        &19,
-        &"name".into_val(&e),
-        &"symbol".into_val(&e),
-    );
+    token.initialize(&admin, &19, &"name".into_val(&e), &"symbol".into_val(&e));
 }
 
 #[test]


### PR DESCRIPTION
### What

initialize() shall panic in case the supplied decimal value is greater than 18.

### Why

The Soroban token has a balance type of i128, which allows for up to 38 digits (base 10), including the decimal part. However, the current token implementation allows decimal values up to u8::MAX. This is an overly loose input validation, since providing a value of >=39 would result in a unusable token, as 10^39 is not representable in i128  and will lead to overflows. Also, having this value slightly below 38 could may cause sporadic overflows in a protocol that rely on this token, due to the limited size of the integer part of the number.

The recommended upper bound for decimal value is 18. With this, you would still have ~20 digits available for the integer part, which should be sufficient for most use-cases.  Also, 18 decimals is a standard value for Ethereum tokens, so using the same value leads to a greater compatibility between platforms.  
