### PR TITLE
change custom_types contract to be equivalent to the one in soroban-cli

### DIFF
--- a/custom_types/src/lib.rs
+++ b/custom_types/src/lib.rs
@@ -1,42 +1,213 @@
 #![no_std]
-use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Env, Symbol};
+use soroban_sdk::{
+    contract, contracterror, contractimpl, contracttype, symbol_short, vec, Address, Bytes, BytesN,
+    Env, Map, String, Symbol, Val, Vec, I256, U256,
+};
 
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct State {
-    pub count: u32,
-    pub last_incr: u32,
-}
-
-const STATE: Symbol = symbol_short!("STATE");
+const COUNTER: Symbol = symbol_short!("COUNTER");
 
 #[contract]
-pub struct IncrementContract;
+pub struct CustomTypesContract;
 
-#[contractimpl]
-impl IncrementContract {
-    /// Increment increments an internal counter, and returns the value.
-    pub fn increment(env: Env, incr: u32) -> u32 {
-        // Get the current count.
-        let mut state = Self::get_state(env.clone());
-
-        // Increment the count.
-        state.count += incr;
-        state.last_incr = incr;
-
-        // Save the count.
-        env.storage().instance().set(&STATE, &state);
-
-        // Return the count to the caller.
-        state.count
-    }
-    /// Return the current state.
-    pub fn get_state(env: Env) -> State {
-        env.storage().instance().get(&STATE).unwrap_or(State {
-            count: 0,
-            last_incr: 0,
-        }) // If no value set, assume 0.
-    }
+/// This is from the rust doc above the struct Test
+#[contracttype]
+pub struct Test {
+    pub a: u32,
+    pub b: bool,
+    pub c: Symbol,
 }
 
-mod test;
+#[contracttype]
+pub enum SimpleEnum {
+    First,
+    Second,
+    Third,
+}
+
+#[contracttype]
+#[derive(Clone, Copy)]
+// The `repr` attribute is here to specify the memory alignment for this type
+#[repr(u32)]
+pub enum RoyalCard {
+    // TODO: create the fields here for your `RoyalCard` type
+    Jack = 11,  // delete this
+    Queen = 12, // delete this
+    King = 13,  // delete this
+}
+
+#[contracttype]
+pub struct TupleStruct(Test, SimpleEnum);
+
+#[contracttype]
+pub enum ComplexEnum {
+    Struct(Test),
+    Tuple(TupleStruct),
+    Enum(SimpleEnum),
+    Asset(Address, i128),
+    Void,
+}
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum Error {
+    /// Please provide an odd number
+    NumberMustBeOdd = 1,
+}
+#[contractimpl]
+impl CustomTypesContract {
+    pub fn hello(_env: Env, hello: Symbol) -> Symbol {
+        hello
+    }
+
+    pub fn auth(env: Env, addr: Address, world: Symbol) -> Address {
+        addr.require_auth();
+        // Emit test event
+        env.events().publish(("auth",), world);
+
+        addr
+    }
+
+    // get current count
+    pub fn get_count(env: Env) -> u32 {
+        env.storage().persistent().get(&COUNTER).unwrap_or(0)
+    }
+
+    // increment count and return new one
+    pub fn inc(env: Env) -> u32 {
+        let mut count: u32 = env.storage().persistent().get(&COUNTER).unwrap_or(0); // Panic if the value of COUNTER is not u32.
+        // Increment the count.
+        count += 1;
+
+        // Save the count.
+        env.storage().persistent().set(&COUNTER, &count);
+        count
+    }
+
+    pub fn woid(_env: Env) {
+        // do nothing
+    }
+
+    pub fn val(_env: Env) -> Val {
+        Val::default()
+    }
+
+    pub fn u32_fail_on_even(_env: Env, u32_: u32) -> Result<u32, Error> {
+        if u32_ % 2 == 1 {
+            Ok(u32_)
+        } else {
+            Err(Error::NumberMustBeOdd)
+        }
+    }
+
+    pub fn u32_(_env: Env, u32_: u32) -> u32 {
+        u32_
+    }
+
+    pub fn i32_(_env: Env, i32_: i32) -> i32 {
+        i32_
+    }
+
+    pub fn i64_(_env: Env, i64_: i64) -> i64 {
+        i64_
+    }
+
+    /// Example contract method which takes a struct
+    pub fn strukt_hel(env: Env, strukt: Test) -> Vec<Symbol> {
+        vec![&env, symbol_short!("Hello"), strukt.c]
+    }
+
+    pub fn strukt(_env: Env, strukt: Test) -> Test {
+        strukt
+    }
+
+    pub fn simple(_env: Env, simple: SimpleEnum) -> SimpleEnum {
+        simple
+    }
+
+    pub fn complex(_env: Env, complex: ComplexEnum) -> ComplexEnum {
+        complex
+    }
+
+    pub fn addresse(_env: Env, addresse: Address) -> Address {
+        addresse
+    }
+
+    pub fn bytes(_env: Env, bytes: Bytes) -> Bytes {
+        bytes
+    }
+
+    pub fn bytes_n(_env: Env, bytes_n: BytesN<9>) -> BytesN<9> {
+        bytes_n
+    }
+
+    pub fn card(_env: Env, card: RoyalCard) -> RoyalCard {
+        card
+    }
+
+    pub fn boolean(_: Env, boolean: bool) -> bool {
+        boolean
+    }
+
+    /// Negates a boolean value
+    pub fn not(_env: Env, boolean: bool) -> bool {
+        !boolean
+    }
+
+    pub fn i128(_env: Env, i128: i128) -> i128 {
+        i128
+    }
+
+    pub fn u128(_env: Env, u128: u128) -> u128 {
+        u128
+    }
+
+    pub fn multi_args(_env: Env, a: u32, b: bool) -> u32 {
+        if b {
+            a
+        } else {
+            0
+        }
+    }
+
+    pub fn map(_env: Env, map: Map<u32, bool>) -> Map<u32, bool> {
+        map
+    }
+
+    pub fn vec(_env: Env, vec: Vec<u32>) -> Vec<u32> {
+        vec
+    }
+
+    pub fn tuple(_env: Env, tuple: (Symbol, u32)) -> (Symbol, u32) {
+        tuple
+    }
+
+    /// Example of an optional argument
+    pub fn option(_env: Env, option: Option<u32>) -> Option<u32> {
+        option
+    }
+
+    pub fn u256(_env: Env, u256: U256) -> U256 {
+        u256
+    }
+
+    pub fn i256(_env: Env, i256: I256) -> I256 {
+        i256
+    }
+
+    pub fn string(_env: Env, string: String) -> String {
+        string
+    }
+
+    pub fn tuple_strukt(_env: Env, tuple_strukt: TupleStruct) -> TupleStruct {
+        tuple_strukt
+    }
+
+    // pub fn timepoint(_env: Env, timepoint: TimePoint) -> TimePoint {
+    //     timepoint
+    // }
+
+    // pub fn duration(_env: Env, duration: Duration) -> Duration {
+    //     duration
+    // }
+}

--- a/custom_types/src/lib.rs
+++ b/custom_types/src/lib.rs
@@ -76,10 +76,7 @@ impl CustomTypesContract {
     // increment count and return new one
     pub fn inc(env: Env) -> u32 {
         let mut count: u32 = env.storage().persistent().get(&COUNTER).unwrap_or(0); // Panic if the value of COUNTER is not u32.
-        // Increment the count.
         count += 1;
-
-        // Save the count.
         env.storage().persistent().set(&COUNTER, &count);
         count
     }
@@ -202,12 +199,4 @@ impl CustomTypesContract {
     pub fn tuple_strukt(_env: Env, tuple_strukt: TupleStruct) -> TupleStruct {
         tuple_strukt
     }
-
-    // pub fn timepoint(_env: Env, timepoint: TimePoint) -> TimePoint {
-    //     timepoint
-    // }
-
-    // pub fn duration(_env: Env, duration: Duration) -> Duration {
-    //     duration
-    // }
 }

--- a/custom_types/src/test.rs
+++ b/custom_types/src/test.rs
@@ -6,16 +6,8 @@ use soroban_sdk::Env;
 #[test]
 fn test() {
     let env = Env::default();
-    let contract_id = env.register_contract(None, IncrementContract);
-    let client = IncrementContractClient::new(&env, &contract_id);
+    let contract_id = env.register_contract(None, CustomTypesContract);
+    let client = CustomTypesContractClient::new(&env, &contract_id);
 
-    assert_eq!(client.increment(&1), 1);
-    assert_eq!(client.increment(&10), 11);
-    assert_eq!(
-        client.get_state(),
-        State {
-            count: 11,
-            last_incr: 10
-        }
-    );
+    assert_eq!(client.u32_fail_on_even(&1), 1);
 }

--- a/custom_types/src/test.rs
+++ b/custom_types/src/test.rs
@@ -8,6 +8,5 @@ fn test() {
     let env = Env::default();
     let contract_id = env.register_contract(None, CustomTypesContract);
     let client = CustomTypesContractClient::new(&env, &contract_id);
-
     assert_eq!(client.u32_fail_on_even(&1), 1);
 }


### PR DESCRIPTION
### What

Changing custom_types contract to match the one in stellar-cli.

### Why

This allows us to use `soroban client init` in the `js-stellar-sdk` instead of using prebuilt wasms. We needed functions to do tests on. I noticed that custom_types in this repo was identical to increment so I figured it was fine to change it.

### Known limitations

N/A
