### PR TITLE
feat: switch hello_world to String

### DIFF
--- a/hello_world/src/lib.rs
+++ b/hello_world/src/lib.rs
@@ -1,13 +1,13 @@
 #![no_std]
-use soroban_sdk::{contract, contractimpl, symbol_short, vec, Env, Symbol, Vec};
+use soroban_sdk::{contract, contractimpl, vec, Env, String, Vec};
 
 #[contract]
 pub struct HelloContract;
 
 #[contractimpl]
 impl HelloContract {
-    pub fn hello(env: Env, to: Symbol) -> Vec<Symbol> {
-        vec![&env, symbol_short!("Hello"), to]
+    pub fn hello(env: Env, to: String) -> Vec<String> {
+        vec![&env, String::from_str(&env, "Hello"), to]
     }
 }
 

--- a/hello_world/src/test.rs
+++ b/hello_world/src/test.rs
@@ -1,7 +1,7 @@
 #![cfg(test)]
 
 use super::*;
-use soroban_sdk::{symbol_short, vec, Env};
+use soroban_sdk::{vec, Env, String};
 
 #[test]
 fn test() {
@@ -9,9 +9,13 @@ fn test() {
     let contract_id = env.register_contract(None, HelloContract);
     let client = HelloContractClient::new(&env, &contract_id);
 
-    let words = client.hello(&symbol_short!("Dev"));
+    let words = client.hello(&String::from_str(&env, "Dev"));
     assert_eq!(
         words,
-        vec![&env, symbol_short!("Hello"), symbol_short!("Dev"),]
+        vec![
+            &env,
+            String::from_str(&env, "Hello"),
+            String::from_str(&env, "Dev"),
+        ]
     );
 }


### PR DESCRIPTION
### What

`hello_world` example now uses `String` instead of `Symbol`

### Why

Symbols seem generally inferior?

### Known limitations

Maybe we want to push newbies toward `Symbol` for some reason?