### PR TITLE
Add CI concurrency group

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -5,6 +5,10 @@ on:
     branches: [main, dev]
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_protected == 'true' && github.sha || github.ref }}
+  cancel-in-progress: true
+
 env:
   MINIMUM_RUST_VERSION: 1.74.0
 


### PR DESCRIPTION
### What

Add CI concurrency group limiting to one build per branch, excluding main, canceling any older runs.

### Why

Limit CI resource usage. We never need out-of-date commit CI runs to complete on PRs.

### Known limitations

[TODO or N/A]
