### PR TITLE
add option object vec

### DIFF
--- a/other_custom_types/src/lib.rs
+++ b/other_custom_types/src/lib.rs
@@ -199,4 +199,10 @@ impl CustomTypesContract {
     pub fn tuple_strukt(_env: Env, tuple_strukt: TupleStruct) -> TupleStruct {
         tuple_strukt
     }
+
+    pub fn get_object_vec_option(env: Env) -> Option<Vec<Test>> {
+        let obj: Test= Test{ a: 1, b: true, c: symbol_short!("hi") };
+        let obj2: Test= Test{ a: 2, b: false, c: symbol_short!("hello") };
+        Some(Vec::from_array(&env, [obj, obj2]))
+    }
 }


### PR DESCRIPTION
### What

Adds a test case for a js-stellar-sdk issue

### Why

When retrieving an Option<Vec<Object>> in the sdk you get the following error: TypeError: Type [object Object] was not vec, but [object Object] is


### Known limitations

We need to create a separate repo for test vectors but I put this here for now for the sdk bug report.
