### PR TITLE
Update Gitpod Environment and Soroban SDK

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,7 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  MINIMUM_RUST_VERSION: 1.81.0
+  MINIMUM_RUST_VERSION: 1.74.0
 
 jobs:
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -77,9 +77,9 @@ jobs:
     - run: cargo version
     - run: rustup target add ${{ matrix.sys.target }}
     - run: rustup target add wasm32-unknown-unknown
-    - name: Install cargo binstall
-      run: curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
-    - run: cargo binstall -y stellar-cli
+    - uses: stellar/stellar-cli@3fd8cec40ab1a77b86b22e086607eebd3a80b7fb
+      with:
+        version: 21.5.0
     - run: make test
       env:
         CARGO_BUILD_TARGET: ${{ matrix.sys.target }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,7 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  MINIMUM_RUST_VERSION: 1.74.0
+  MINIMUM_RUST_VERSION: 1.81.0
 
 jobs:
 
@@ -77,10 +77,8 @@ jobs:
     - run: cargo version
     - run: rustup target add ${{ matrix.sys.target }}
     - run: rustup target add wasm32-unknown-unknown
-    - uses: stellar/binaries@v16
-      with:
-        name: soroban-cli
-        version: 0.8.7
+    - run: cargo install --locked cargo-binstall
+    - run: cargo binstall -y stellar-cli
     - run: make test
       env:
         CARGO_BUILD_TARGET: ${{ matrix.sys.target }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -77,7 +77,7 @@ jobs:
     - run: cargo version
     - run: rustup target add ${{ matrix.sys.target }}
     - run: rustup target add wasm32-unknown-unknown
-    - uses: stellar/stellar-cli@3fd8cec40ab1a77b86b22e086607eebd3a80b7fb
+    - uses: stellar/stellar-cli@d538ea9a1b5bbf1847a987ccf316d34e55465313
       with:
         version: 21.5.0
     - run: make test

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -77,7 +77,8 @@ jobs:
     - run: cargo version
     - run: rustup target add ${{ matrix.sys.target }}
     - run: rustup target add wasm32-unknown-unknown
-    - run: cargo install --locked cargo-binstall
+    - name: Install cargo binstall
+      run: curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
     - run: cargo binstall -y stellar-cli
     - run: make test
       env:

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -6,10 +6,10 @@ RUN rustup self uninstall -y
 RUN rm -rf .rustup
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain none -y
 
-RUN rustup install stable
-RUN rustup target add --toolchain stable wasm32-unknown-unknown
-RUN rustup component add --toolchain stable rust-src
-RUN rustup default stable
+RUN rustup install 1.81
+RUN rustup target add --toolchain 1.81 wasm32-unknown-unknown
+RUN rustup component add --toolchain 1.81 rust-src
+RUN rustup default 1.81
 
 RUN sudo apt-get update && sudo apt-get install -y binaryen
 

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,16 +1,4 @@
-FROM gitpod/workspace-full:2023-01-16-03-31-28
-
-RUN mkdir -p ~/.local/bin
-RUN curl -L https://github.com/stellar/soroban-tools/releases/download/v20.3.0/soroban-cli-20.3.0-x86_64-unknown-linux-gnu.tar.gz | tar xz -C ~/.local/bin soroban
-RUN chmod +x ~/.local/bin/soroban
-RUN curl -L https://github.com/mozilla/sccache/releases/download/v0.3.3/sccache-v0.3.3-x86_64-unknown-linux-musl.tar.gz | tar xz --strip-components 1 -C ~/.local/bin sccache-v0.3.3-x86_64-unknown-linux-musl/sccache
-RUN chmod +x ~/.local/bin/sccache
-
-RUN curl -L https://github.com/watchexec/cargo-watch/releases/download/v8.1.2/cargo-watch-v8.1.2-x86_64-unknown-linux-gnu.tar.xz | tar xJ --strip-components 1 -C ~/.local/bin cargo-watch-v8.1.2-x86_64-unknown-linux-gnu/cargo-watch
-
-ENV RUSTC_WRAPPER=sccache
-ENV SCCACHE_CACHE_SIZE=5G
-ENV SCCACHE_DIR=/workspace/.sccache
+FROM gitpod/workspace-full:latest
 
 # Remove the existing rustup installation before updating due to:
 # https://github.com/gitpod-io/workspace-images/issues/933#issuecomment-1272616892
@@ -18,13 +6,21 @@ RUN rustup self uninstall -y
 RUN rm -rf .rustup
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain none -y
 
-RUN rustup install 1.69
-RUN rustup target add --toolchain 1.69 wasm32-unknown-unknown
-RUN rustup component add --toolchain 1.69 rust-src
-RUN rustup default 1.69
+RUN rustup install stable
+RUN rustup target add --toolchain stable wasm32-unknown-unknown
+RUN rustup component add --toolchain stable rust-src
+RUN rustup default stable
 
 RUN sudo apt-get update && sudo apt-get install -y binaryen
 
 # Enable sparse registry support, which will cause cargo to download only what
 # it needs from crates.io, rather than the entire registry.
 ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
+
+# Install cargo binstall
+RUN curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+RUN cargo binstall -y stellar-cli cargo-watch sccache
+
+ENV RUSTC_WRAPPER=sccache
+ENV SCCACHE_CACHE_SIZE=5G
+ENV SCCACHE_DIR=/workspace/.sccache

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -2,24 +2,14 @@ image:
   file: .gitpod.Dockerfile
 
 tasks:
-  - name: Futurenet
-    init: |
-      docker pull stellar/quickstart:soroban-dev
-    command: |
-      docker run --rm -it \
-      --name stellar \
-      -p 8000:8000 \
-      stellar/quickstart:soroban-dev \
-      --futurenet \
-      --enable-soroban-rpc
-  # This "CLI - Futurenet" task opens a terminal for you to interact with the
-  # futurenet network.
-  - name: CLI - Futurenet
-    # We specify some required environment variables for use on the futurenet.
+  # This "CLI - Testnet" task opens a terminal for you to interact with the
+  # testnet network.
+  - name: CLI - Testnet
+    # We specify some required environment variables for use on the testnet.
     env:
-      # This can be set by the user, but this terminal is dedicated to futurenet so set for convenience.
-      SOROBAN_RPC_URL: "http://127.0.0.1:8000/soroban/rpc"
-      SOROBAN_NETWORK_PASSPHRASE: "Test SDF Future Network ; October 2022"
+      # This can be set by the user, but this terminal is dedicated to testnet so set for convenience.
+      SOROBAN_RPC_URL: "https://soroban-testnet.stellar.org"
+      SOROBAN_NETWORK_PASSPHRASE: "Test SDF Network ; September 2015"
     # To keep things tidy, we clear the terminal from the previous output.
     command: |
       clear
@@ -31,7 +21,7 @@ tasks:
       gp open increment/src/lib.rs
       gp open increment/src/test.rs
       gp open README.md
-      soroban contract invoke --id 1 --wasm increment/target/wasm32-unknown-unknown/release/soroban_increment_contract.wasm -- increment
+      stellar contract inspect --wasm increment/target/wasm32-unknown-unknown/release/soroban_increment_contract.wasm
 vscode:
   extensions:
     - rust-lang.rust-analyzer
@@ -44,12 +34,6 @@ github:
     pullRequests: true
     pullRequestsFromForks: true
 ports:
-  # Your quickstart node has a Horizon API server and an RPC endpoint, both
-  # listening on port 8000. It's publicly accessible through the internet.
-  - name: Futurenet
-    port: 8000
-    visibility: public
-    onOpen: ignore
   # This port is open for "Something with cargo test I think"??
   - port: 4226
     visibility: private

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -27,12 +27,6 @@ vscode:
     - rust-lang.rust-analyzer
     - vadimcn.vscode-lldb
 
-github:
-  prebuilds:
-    addBadge: true
-    addComment: true
-    pullRequests: true
-    pullRequestsFromForks: true
 ports:
   # This port is open for "Something with cargo test I think"??
   - port: 4226

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -21,7 +21,7 @@ tasks:
       gp open increment/src/lib.rs
       gp open increment/src/test.rs
       gp open README.md
-      stellar contract inspect --wasm increment/target/wasm32-unknown-unknown/release/soroban_increment_contract.wasm
+      stellar version
 vscode:
   extensions:
     - rust-lang.rust-analyzer

--- a/account/Cargo.lock
+++ b/account/Cargo.lock
@@ -1238,9 +1238,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07a2c3aeb3dba21530133f7f1dc533f53d96abff0df6497a5a2fad8f0fbda200"
+checksum = "15263ad07a3e0ec3f2ee3aea83b7c1a0610ad26ba76819f5092afcfaf0f3a3ed"
 dependencies = [
  "serde",
  "serde_json",
@@ -1252,9 +1252,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab66a39d18a5d8ed60df8cb77fc51067ef45a69af3c8fec52b6bc3bf7190351"
+checksum = "73e995a8604a01ec7a8c1e1f60a890981eb00f1cd25c3b15f5194364f27993cc"
 dependencies = [
  "arbitrary",
  "bytes-lit",
@@ -1272,9 +1272,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d92e9fb43bc3ca5180ff7f115156e732817fe27f8328787991c5eb38b30c26c"
+checksum = "c3eda569fe4c3aa2b45f2366e07d9476127e141c7f376d625b6a8217ee99f81f"
 dependencies = [
  "crate-git-revision",
  "darling",
@@ -1292,9 +1292,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f92a657578b121b06a29ab630bf24f02a32327cf9858c474157f0a8c25bfdb2"
+checksum = "87cfbe92fbabaea20517dc76fc89227735ffda2f19a10e2fe96db0ecb19b72b1"
 dependencies = [
  "base64 0.13.1",
  "stellar-xdr",
@@ -1304,9 +1304,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-rust"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7d95644321515640288dae87e71264ed070454c22b6bdf3527423dcaccdfff0"
+checksum = "6569ea39d9f4d8cafadd0a2a77fc94991f7870d4d3c2a1fa401db9cb02d6082b"
 dependencies = [
  "prettyplease",
  "proc-macro2",

--- a/account/Cargo.lock
+++ b/account/Cargo.lock
@@ -1238,9 +1238,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15263ad07a3e0ec3f2ee3aea83b7c1a0610ad26ba76819f5092afcfaf0f3a3ed"
+checksum = "956476365ff3f9bf429ff23fa11ac75798347a2bfc3c9e5e12638dbe3a6b17a8"
 dependencies = [
  "serde",
  "serde_json",
@@ -1252,9 +1252,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73e995a8604a01ec7a8c1e1f60a890981eb00f1cd25c3b15f5194364f27993cc"
+checksum = "c7767472f00a4053e86d5c37b3c814a6bc01c9230004713328d73d2a3444e72e"
 dependencies = [
  "arbitrary",
  "bytes-lit",
@@ -1272,9 +1272,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3eda569fe4c3aa2b45f2366e07d9476127e141c7f376d625b6a8217ee99f81f"
+checksum = "be8cf8fa10f3ad62509ff7b25cd696fb837da692c40264d1abb393e117aad75c"
 dependencies = [
  "crate-git-revision",
  "darling",
@@ -1292,9 +1292,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cfbe92fbabaea20517dc76fc89227735ffda2f19a10e2fe96db0ecb19b72b1"
+checksum = "12d306f61ef5c1247dca1562e04cc74b6e3adf107631c168b2ce0d5f1cf1fa13"
 dependencies = [
  "base64 0.13.1",
  "stellar-xdr",
@@ -1304,9 +1304,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-rust"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6569ea39d9f4d8cafadd0a2a77fc94991f7870d4d3c2a1fa401db9cb02d6082b"
+checksum = "bed06e0f622fb878fc439643f2fd86163223ac33a468beeea96e5d33f79b08b3"
 dependencies = [
  "prettyplease",
  "proc-macro2",

--- a/account/Cargo.toml
+++ b/account/Cargo.toml
@@ -9,10 +9,10 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = { version = "21.6.0" }
+soroban-sdk = { version = "21.7.1" }
 
 [dev-dependencies]
-soroban-sdk = { version = "21.6.0", features = ["testutils"] }
+soroban-sdk = { version = "21.7.1", features = ["testutils"] }
 ed25519-dalek = { version = "1.0.1" }
 rand = { version = "0.7.3" }
 

--- a/account/Cargo.toml
+++ b/account/Cargo.toml
@@ -9,10 +9,10 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = { version = "21.7.1" }
+soroban-sdk = { version = "21.7.4" }
 
 [dev-dependencies]
-soroban-sdk = { version = "21.7.1", features = ["testutils"] }
+soroban-sdk = { version = "21.7.4", features = ["testutils"] }
 ed25519-dalek = { version = "1.0.1" }
 rand = { version = "0.7.3" }
 

--- a/account/Makefile
+++ b/account/Makefile
@@ -6,7 +6,7 @@ test: build
 	cargo test
 
 build:
-	soroban contract build
+	stellar contract build
 	@ls -l target/wasm32-unknown-unknown/release/*.wasm
 
 fmt:

--- a/alloc/Cargo.lock
+++ b/alloc/Cargo.lock
@@ -1099,9 +1099,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15263ad07a3e0ec3f2ee3aea83b7c1a0610ad26ba76819f5092afcfaf0f3a3ed"
+checksum = "956476365ff3f9bf429ff23fa11ac75798347a2bfc3c9e5e12638dbe3a6b17a8"
 dependencies = [
  "serde",
  "serde_json",
@@ -1113,9 +1113,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73e995a8604a01ec7a8c1e1f60a890981eb00f1cd25c3b15f5194364f27993cc"
+checksum = "c7767472f00a4053e86d5c37b3c814a6bc01c9230004713328d73d2a3444e72e"
 dependencies = [
  "arbitrary",
  "bytes-lit",
@@ -1133,9 +1133,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3eda569fe4c3aa2b45f2366e07d9476127e141c7f376d625b6a8217ee99f81f"
+checksum = "be8cf8fa10f3ad62509ff7b25cd696fb837da692c40264d1abb393e117aad75c"
 dependencies = [
  "crate-git-revision",
  "darling",
@@ -1153,9 +1153,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cfbe92fbabaea20517dc76fc89227735ffda2f19a10e2fe96db0ecb19b72b1"
+checksum = "12d306f61ef5c1247dca1562e04cc74b6e3adf107631c168b2ce0d5f1cf1fa13"
 dependencies = [
  "base64 0.13.1",
  "stellar-xdr",
@@ -1165,9 +1165,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-rust"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6569ea39d9f4d8cafadd0a2a77fc94991f7870d4d3c2a1fa401db9cb02d6082b"
+checksum = "bed06e0f622fb878fc439643f2fd86163223ac33a468beeea96e5d33f79b08b3"
 dependencies = [
  "prettyplease",
  "proc-macro2",

--- a/alloc/Cargo.lock
+++ b/alloc/Cargo.lock
@@ -1099,9 +1099,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07a2c3aeb3dba21530133f7f1dc533f53d96abff0df6497a5a2fad8f0fbda200"
+checksum = "15263ad07a3e0ec3f2ee3aea83b7c1a0610ad26ba76819f5092afcfaf0f3a3ed"
 dependencies = [
  "serde",
  "serde_json",
@@ -1113,9 +1113,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab66a39d18a5d8ed60df8cb77fc51067ef45a69af3c8fec52b6bc3bf7190351"
+checksum = "73e995a8604a01ec7a8c1e1f60a890981eb00f1cd25c3b15f5194364f27993cc"
 dependencies = [
  "arbitrary",
  "bytes-lit",
@@ -1133,9 +1133,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d92e9fb43bc3ca5180ff7f115156e732817fe27f8328787991c5eb38b30c26c"
+checksum = "c3eda569fe4c3aa2b45f2366e07d9476127e141c7f376d625b6a8217ee99f81f"
 dependencies = [
  "crate-git-revision",
  "darling",
@@ -1153,9 +1153,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f92a657578b121b06a29ab630bf24f02a32327cf9858c474157f0a8c25bfdb2"
+checksum = "87cfbe92fbabaea20517dc76fc89227735ffda2f19a10e2fe96db0ecb19b72b1"
 dependencies = [
  "base64 0.13.1",
  "stellar-xdr",
@@ -1165,9 +1165,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-rust"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7d95644321515640288dae87e71264ed070454c22b6bdf3527423dcaccdfff0"
+checksum = "6569ea39d9f4d8cafadd0a2a77fc94991f7870d4d3c2a1fa401db9cb02d6082b"
 dependencies = [
  "prettyplease",
  "proc-macro2",

--- a/alloc/Cargo.toml
+++ b/alloc/Cargo.toml
@@ -9,10 +9,10 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = { version = "21.6.0", features = ["alloc"] }
+soroban-sdk = { version = "21.7.1", features = ["alloc"] }
 
 [dev-dependencies]
-soroban-sdk = { version = "21.6.0", features = ["testutils", "alloc"] }
+soroban-sdk = { version = "21.7.1", features = ["testutils", "alloc"] }
 
 [profile.release]
 opt-level = "z"

--- a/alloc/Cargo.toml
+++ b/alloc/Cargo.toml
@@ -9,10 +9,10 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = { version = "21.7.1", features = ["alloc"] }
+soroban-sdk = { version = "21.7.4", features = ["alloc"] }
 
 [dev-dependencies]
-soroban-sdk = { version = "21.7.1", features = ["testutils", "alloc"] }
+soroban-sdk = { version = "21.7.4", features = ["testutils", "alloc"] }
 
 [profile.release]
 opt-level = "z"

--- a/alloc/Makefile
+++ b/alloc/Makefile
@@ -6,7 +6,7 @@ test: build
 	cargo test
 
 build:
-	soroban contract build
+	stellar contract build
 	@ls -l target/wasm32-unknown-unknown/release/*.wasm
 
 fmt:

--- a/atomic_multiswap/Cargo.lock
+++ b/atomic_multiswap/Cargo.lock
@@ -1118,9 +1118,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07a2c3aeb3dba21530133f7f1dc533f53d96abff0df6497a5a2fad8f0fbda200"
+checksum = "15263ad07a3e0ec3f2ee3aea83b7c1a0610ad26ba76819f5092afcfaf0f3a3ed"
 dependencies = [
  "serde",
  "serde_json",
@@ -1132,9 +1132,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab66a39d18a5d8ed60df8cb77fc51067ef45a69af3c8fec52b6bc3bf7190351"
+checksum = "73e995a8604a01ec7a8c1e1f60a890981eb00f1cd25c3b15f5194364f27993cc"
 dependencies = [
  "arbitrary",
  "bytes-lit",
@@ -1152,9 +1152,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d92e9fb43bc3ca5180ff7f115156e732817fe27f8328787991c5eb38b30c26c"
+checksum = "c3eda569fe4c3aa2b45f2366e07d9476127e141c7f376d625b6a8217ee99f81f"
 dependencies = [
  "crate-git-revision",
  "darling",
@@ -1172,9 +1172,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f92a657578b121b06a29ab630bf24f02a32327cf9858c474157f0a8c25bfdb2"
+checksum = "87cfbe92fbabaea20517dc76fc89227735ffda2f19a10e2fe96db0ecb19b72b1"
 dependencies = [
  "base64 0.13.1",
  "stellar-xdr",
@@ -1184,9 +1184,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-rust"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7d95644321515640288dae87e71264ed070454c22b6bdf3527423dcaccdfff0"
+checksum = "6569ea39d9f4d8cafadd0a2a77fc94991f7870d4d3c2a1fa401db9cb02d6082b"
 dependencies = [
  "prettyplease",
  "proc-macro2",

--- a/atomic_multiswap/Cargo.lock
+++ b/atomic_multiswap/Cargo.lock
@@ -1118,9 +1118,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15263ad07a3e0ec3f2ee3aea83b7c1a0610ad26ba76819f5092afcfaf0f3a3ed"
+checksum = "956476365ff3f9bf429ff23fa11ac75798347a2bfc3c9e5e12638dbe3a6b17a8"
 dependencies = [
  "serde",
  "serde_json",
@@ -1132,9 +1132,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73e995a8604a01ec7a8c1e1f60a890981eb00f1cd25c3b15f5194364f27993cc"
+checksum = "c7767472f00a4053e86d5c37b3c814a6bc01c9230004713328d73d2a3444e72e"
 dependencies = [
  "arbitrary",
  "bytes-lit",
@@ -1152,9 +1152,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3eda569fe4c3aa2b45f2366e07d9476127e141c7f376d625b6a8217ee99f81f"
+checksum = "be8cf8fa10f3ad62509ff7b25cd696fb837da692c40264d1abb393e117aad75c"
 dependencies = [
  "crate-git-revision",
  "darling",
@@ -1172,9 +1172,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cfbe92fbabaea20517dc76fc89227735ffda2f19a10e2fe96db0ecb19b72b1"
+checksum = "12d306f61ef5c1247dca1562e04cc74b6e3adf107631c168b2ce0d5f1cf1fa13"
 dependencies = [
  "base64 0.13.1",
  "stellar-xdr",
@@ -1184,9 +1184,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-rust"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6569ea39d9f4d8cafadd0a2a77fc94991f7870d4d3c2a1fa401db9cb02d6082b"
+checksum = "bed06e0f622fb878fc439643f2fd86163223ac33a468beeea96e5d33f79b08b3"
 dependencies = [
  "prettyplease",
  "proc-macro2",

--- a/atomic_multiswap/Cargo.toml
+++ b/atomic_multiswap/Cargo.toml
@@ -9,10 +9,10 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = { version = "21.7.1" }
+soroban-sdk = { version = "21.7.4" }
 
 [dev-dependencies]
-soroban-sdk = { version = "21.7.1", features = ["testutils"] }
+soroban-sdk = { version = "21.7.4", features = ["testutils"] }
 assert_unordered = "0.3.5"
 
 [profile.release]

--- a/atomic_multiswap/Cargo.toml
+++ b/atomic_multiswap/Cargo.toml
@@ -9,10 +9,10 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = { version = "21.6.0" }
+soroban-sdk = { version = "21.7.1" }
 
 [dev-dependencies]
-soroban-sdk = { version = "21.6.0", features = ["testutils"] }
+soroban-sdk = { version = "21.7.1", features = ["testutils"] }
 assert_unordered = "0.3.5"
 
 [profile.release]

--- a/atomic_multiswap/Makefile
+++ b/atomic_multiswap/Makefile
@@ -7,7 +7,7 @@ test: build
 
 build:
 	$(MAKE) -C ../atomic_swap || break; 
-	soroban contract build
+	stellar contract build
 	@ls -l target/wasm32-unknown-unknown/release/*.wasm
 
 fmt:

--- a/atomic_swap/Cargo.lock
+++ b/atomic_swap/Cargo.lock
@@ -1032,9 +1032,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15263ad07a3e0ec3f2ee3aea83b7c1a0610ad26ba76819f5092afcfaf0f3a3ed"
+checksum = "956476365ff3f9bf429ff23fa11ac75798347a2bfc3c9e5e12638dbe3a6b17a8"
 dependencies = [
  "serde",
  "serde_json",
@@ -1046,9 +1046,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73e995a8604a01ec7a8c1e1f60a890981eb00f1cd25c3b15f5194364f27993cc"
+checksum = "c7767472f00a4053e86d5c37b3c814a6bc01c9230004713328d73d2a3444e72e"
 dependencies = [
  "arbitrary",
  "bytes-lit",
@@ -1066,9 +1066,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3eda569fe4c3aa2b45f2366e07d9476127e141c7f376d625b6a8217ee99f81f"
+checksum = "be8cf8fa10f3ad62509ff7b25cd696fb837da692c40264d1abb393e117aad75c"
 dependencies = [
  "crate-git-revision",
  "darling",
@@ -1086,9 +1086,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cfbe92fbabaea20517dc76fc89227735ffda2f19a10e2fe96db0ecb19b72b1"
+checksum = "12d306f61ef5c1247dca1562e04cc74b6e3adf107631c168b2ce0d5f1cf1fa13"
 dependencies = [
  "base64 0.13.1",
  "stellar-xdr",
@@ -1098,9 +1098,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-rust"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6569ea39d9f4d8cafadd0a2a77fc94991f7870d4d3c2a1fa401db9cb02d6082b"
+checksum = "bed06e0f622fb878fc439643f2fd86163223ac33a468beeea96e5d33f79b08b3"
 dependencies = [
  "prettyplease",
  "proc-macro2",

--- a/atomic_swap/Cargo.lock
+++ b/atomic_swap/Cargo.lock
@@ -1032,9 +1032,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07a2c3aeb3dba21530133f7f1dc533f53d96abff0df6497a5a2fad8f0fbda200"
+checksum = "15263ad07a3e0ec3f2ee3aea83b7c1a0610ad26ba76819f5092afcfaf0f3a3ed"
 dependencies = [
  "serde",
  "serde_json",
@@ -1046,9 +1046,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab66a39d18a5d8ed60df8cb77fc51067ef45a69af3c8fec52b6bc3bf7190351"
+checksum = "73e995a8604a01ec7a8c1e1f60a890981eb00f1cd25c3b15f5194364f27993cc"
 dependencies = [
  "arbitrary",
  "bytes-lit",
@@ -1066,9 +1066,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d92e9fb43bc3ca5180ff7f115156e732817fe27f8328787991c5eb38b30c26c"
+checksum = "c3eda569fe4c3aa2b45f2366e07d9476127e141c7f376d625b6a8217ee99f81f"
 dependencies = [
  "crate-git-revision",
  "darling",
@@ -1086,9 +1086,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f92a657578b121b06a29ab630bf24f02a32327cf9858c474157f0a8c25bfdb2"
+checksum = "87cfbe92fbabaea20517dc76fc89227735ffda2f19a10e2fe96db0ecb19b72b1"
 dependencies = [
  "base64 0.13.1",
  "stellar-xdr",
@@ -1098,9 +1098,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-rust"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7d95644321515640288dae87e71264ed070454c22b6bdf3527423dcaccdfff0"
+checksum = "6569ea39d9f4d8cafadd0a2a77fc94991f7870d4d3c2a1fa401db9cb02d6082b"
 dependencies = [
  "prettyplease",
  "proc-macro2",

--- a/atomic_swap/Cargo.toml
+++ b/atomic_swap/Cargo.toml
@@ -9,10 +9,10 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = { version = "21.7.1" }
+soroban-sdk = { version = "21.7.4" }
 
 [dev-dependencies]
-soroban-sdk = { version = "21.7.1", features = ["testutils"] }
+soroban-sdk = { version = "21.7.4", features = ["testutils"] }
 
 [profile.release]
 opt-level = "z"

--- a/atomic_swap/Cargo.toml
+++ b/atomic_swap/Cargo.toml
@@ -9,10 +9,10 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = { version = "21.6.0" }
+soroban-sdk = { version = "21.7.1" }
 
 [dev-dependencies]
-soroban-sdk = { version = "21.6.0", features = ["testutils"] }
+soroban-sdk = { version = "21.7.1", features = ["testutils"] }
 
 [profile.release]
 opt-level = "z"

--- a/atomic_swap/Makefile
+++ b/atomic_swap/Makefile
@@ -6,7 +6,7 @@ test: build
 	cargo test
 
 build:
-	soroban contract build
+	stellar contract build
 	@ls -l target/wasm32-unknown-unknown/release/*.wasm
 
 fmt:

--- a/auth/Cargo.lock
+++ b/auth/Cargo.lock
@@ -1099,9 +1099,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15263ad07a3e0ec3f2ee3aea83b7c1a0610ad26ba76819f5092afcfaf0f3a3ed"
+checksum = "956476365ff3f9bf429ff23fa11ac75798347a2bfc3c9e5e12638dbe3a6b17a8"
 dependencies = [
  "serde",
  "serde_json",
@@ -1113,9 +1113,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73e995a8604a01ec7a8c1e1f60a890981eb00f1cd25c3b15f5194364f27993cc"
+checksum = "c7767472f00a4053e86d5c37b3c814a6bc01c9230004713328d73d2a3444e72e"
 dependencies = [
  "arbitrary",
  "bytes-lit",
@@ -1133,9 +1133,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3eda569fe4c3aa2b45f2366e07d9476127e141c7f376d625b6a8217ee99f81f"
+checksum = "be8cf8fa10f3ad62509ff7b25cd696fb837da692c40264d1abb393e117aad75c"
 dependencies = [
  "crate-git-revision",
  "darling",
@@ -1153,9 +1153,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cfbe92fbabaea20517dc76fc89227735ffda2f19a10e2fe96db0ecb19b72b1"
+checksum = "12d306f61ef5c1247dca1562e04cc74b6e3adf107631c168b2ce0d5f1cf1fa13"
 dependencies = [
  "base64 0.13.1",
  "stellar-xdr",
@@ -1165,9 +1165,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-rust"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6569ea39d9f4d8cafadd0a2a77fc94991f7870d4d3c2a1fa401db9cb02d6082b"
+checksum = "bed06e0f622fb878fc439643f2fd86163223ac33a468beeea96e5d33f79b08b3"
 dependencies = [
  "prettyplease",
  "proc-macro2",

--- a/auth/Cargo.lock
+++ b/auth/Cargo.lock
@@ -1099,9 +1099,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07a2c3aeb3dba21530133f7f1dc533f53d96abff0df6497a5a2fad8f0fbda200"
+checksum = "15263ad07a3e0ec3f2ee3aea83b7c1a0610ad26ba76819f5092afcfaf0f3a3ed"
 dependencies = [
  "serde",
  "serde_json",
@@ -1113,9 +1113,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab66a39d18a5d8ed60df8cb77fc51067ef45a69af3c8fec52b6bc3bf7190351"
+checksum = "73e995a8604a01ec7a8c1e1f60a890981eb00f1cd25c3b15f5194364f27993cc"
 dependencies = [
  "arbitrary",
  "bytes-lit",
@@ -1133,9 +1133,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d92e9fb43bc3ca5180ff7f115156e732817fe27f8328787991c5eb38b30c26c"
+checksum = "c3eda569fe4c3aa2b45f2366e07d9476127e141c7f376d625b6a8217ee99f81f"
 dependencies = [
  "crate-git-revision",
  "darling",
@@ -1153,9 +1153,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f92a657578b121b06a29ab630bf24f02a32327cf9858c474157f0a8c25bfdb2"
+checksum = "87cfbe92fbabaea20517dc76fc89227735ffda2f19a10e2fe96db0ecb19b72b1"
 dependencies = [
  "base64 0.13.1",
  "stellar-xdr",
@@ -1165,9 +1165,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-rust"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7d95644321515640288dae87e71264ed070454c22b6bdf3527423dcaccdfff0"
+checksum = "6569ea39d9f4d8cafadd0a2a77fc94991f7870d4d3c2a1fa401db9cb02d6082b"
 dependencies = [
  "prettyplease",
  "proc-macro2",

--- a/auth/Cargo.toml
+++ b/auth/Cargo.toml
@@ -8,10 +8,10 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
-soroban-sdk = { version = "21.7.1" }
+soroban-sdk = { version = "21.7.4" }
 
 [dev-dependencies]
-soroban-sdk = { version = "21.7.1", features = ["testutils"] }
+soroban-sdk = { version = "21.7.4", features = ["testutils"] }
 
 [profile.release]
 opt-level = "z"

--- a/auth/Cargo.toml
+++ b/auth/Cargo.toml
@@ -8,10 +8,10 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
-soroban-sdk = { version = "21.6.0" }
+soroban-sdk = { version = "21.7.1" }
 
 [dev-dependencies]
-soroban-sdk = { version = "21.6.0", features = ["testutils"] }
+soroban-sdk = { version = "21.7.1", features = ["testutils"] }
 
 [profile.release]
 opt-level = "z"

--- a/auth/Makefile
+++ b/auth/Makefile
@@ -6,7 +6,7 @@ test: build
 	cargo test
 
 build:
-	soroban contract build
+	stellar contract build
 	@ls -l target/wasm32-unknown-unknown/release/*.wasm
 
 fmt:

--- a/cross_contract/contract_a/Cargo.lock
+++ b/cross_contract/contract_a/Cargo.lock
@@ -1099,9 +1099,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07a2c3aeb3dba21530133f7f1dc533f53d96abff0df6497a5a2fad8f0fbda200"
+checksum = "15263ad07a3e0ec3f2ee3aea83b7c1a0610ad26ba76819f5092afcfaf0f3a3ed"
 dependencies = [
  "serde",
  "serde_json",
@@ -1113,9 +1113,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab66a39d18a5d8ed60df8cb77fc51067ef45a69af3c8fec52b6bc3bf7190351"
+checksum = "73e995a8604a01ec7a8c1e1f60a890981eb00f1cd25c3b15f5194364f27993cc"
 dependencies = [
  "arbitrary",
  "bytes-lit",
@@ -1133,9 +1133,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d92e9fb43bc3ca5180ff7f115156e732817fe27f8328787991c5eb38b30c26c"
+checksum = "c3eda569fe4c3aa2b45f2366e07d9476127e141c7f376d625b6a8217ee99f81f"
 dependencies = [
  "crate-git-revision",
  "darling",
@@ -1153,9 +1153,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f92a657578b121b06a29ab630bf24f02a32327cf9858c474157f0a8c25bfdb2"
+checksum = "87cfbe92fbabaea20517dc76fc89227735ffda2f19a10e2fe96db0ecb19b72b1"
 dependencies = [
  "base64 0.13.1",
  "stellar-xdr",
@@ -1165,9 +1165,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-rust"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7d95644321515640288dae87e71264ed070454c22b6bdf3527423dcaccdfff0"
+checksum = "6569ea39d9f4d8cafadd0a2a77fc94991f7870d4d3c2a1fa401db9cb02d6082b"
 dependencies = [
  "prettyplease",
  "proc-macro2",

--- a/cross_contract/contract_a/Cargo.toml
+++ b/cross_contract/contract_a/Cargo.toml
@@ -9,10 +9,10 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = { version = "21.7.1" }
+soroban-sdk = { version = "21.7.4" }
 
 [dev-dependencies]
-soroban-sdk = { version = "21.7.1", features = ["testutils"] }
+soroban-sdk = { version = "21.7.4", features = ["testutils"] }
 
 [profile.release]
 opt-level = "z"

--- a/cross_contract/contract_a/Cargo.toml
+++ b/cross_contract/contract_a/Cargo.toml
@@ -9,10 +9,10 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = { version = "21.6.0" }
+soroban-sdk = { version = "21.7.1" }
 
 [dev-dependencies]
-soroban-sdk = { version = "21.6.0", features = ["testutils"] }
+soroban-sdk = { version = "21.7.1", features = ["testutils"] }
 
 [profile.release]
 opt-level = "z"

--- a/cross_contract/contract_a/Makefile
+++ b/cross_contract/contract_a/Makefile
@@ -6,7 +6,7 @@ test: build
 	cargo test
 
 build:
-	soroban contract build
+	stellar contract build
 	@ls -l target/wasm32-unknown-unknown/release/*.wasm
 
 fmt:

--- a/cross_contract/contract_b/Cargo.lock
+++ b/cross_contract/contract_b/Cargo.lock
@@ -1099,9 +1099,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07a2c3aeb3dba21530133f7f1dc533f53d96abff0df6497a5a2fad8f0fbda200"
+checksum = "15263ad07a3e0ec3f2ee3aea83b7c1a0610ad26ba76819f5092afcfaf0f3a3ed"
 dependencies = [
  "serde",
  "serde_json",
@@ -1113,9 +1113,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab66a39d18a5d8ed60df8cb77fc51067ef45a69af3c8fec52b6bc3bf7190351"
+checksum = "73e995a8604a01ec7a8c1e1f60a890981eb00f1cd25c3b15f5194364f27993cc"
 dependencies = [
  "arbitrary",
  "bytes-lit",
@@ -1133,9 +1133,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d92e9fb43bc3ca5180ff7f115156e732817fe27f8328787991c5eb38b30c26c"
+checksum = "c3eda569fe4c3aa2b45f2366e07d9476127e141c7f376d625b6a8217ee99f81f"
 dependencies = [
  "crate-git-revision",
  "darling",
@@ -1153,9 +1153,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f92a657578b121b06a29ab630bf24f02a32327cf9858c474157f0a8c25bfdb2"
+checksum = "87cfbe92fbabaea20517dc76fc89227735ffda2f19a10e2fe96db0ecb19b72b1"
 dependencies = [
  "base64 0.13.1",
  "stellar-xdr",
@@ -1165,9 +1165,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-rust"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7d95644321515640288dae87e71264ed070454c22b6bdf3527423dcaccdfff0"
+checksum = "6569ea39d9f4d8cafadd0a2a77fc94991f7870d4d3c2a1fa401db9cb02d6082b"
 dependencies = [
  "prettyplease",
  "proc-macro2",

--- a/cross_contract/contract_b/Cargo.toml
+++ b/cross_contract/contract_b/Cargo.toml
@@ -9,10 +9,10 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = { version = "21.7.1" }
+soroban-sdk = { version = "21.7.4" }
 
 [dev-dependencies]
-soroban-sdk = { version = "21.7.1", features = ["testutils"] }
+soroban-sdk = { version = "21.7.4", features = ["testutils"] }
 
 [profile.release]
 opt-level = "z"

--- a/cross_contract/contract_b/Cargo.toml
+++ b/cross_contract/contract_b/Cargo.toml
@@ -9,10 +9,10 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = { version = "21.6.0" }
+soroban-sdk = { version = "21.7.1" }
 
 [dev-dependencies]
-soroban-sdk = { version = "21.6.0", features = ["testutils"] }
+soroban-sdk = { version = "21.7.1", features = ["testutils"] }
 
 [profile.release]
 opt-level = "z"

--- a/cross_contract/contract_b/Makefile
+++ b/cross_contract/contract_b/Makefile
@@ -7,7 +7,7 @@ test: build
 
 build:
 	$(MAKE) -C ../contract_a || break; 
-	soroban contract build
+	stellar contract build
 	@ls -l target/wasm32-unknown-unknown/release/*.wasm
 
 fmt:

--- a/custom_types/Cargo.lock
+++ b/custom_types/Cargo.lock
@@ -1099,9 +1099,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15263ad07a3e0ec3f2ee3aea83b7c1a0610ad26ba76819f5092afcfaf0f3a3ed"
+checksum = "956476365ff3f9bf429ff23fa11ac75798347a2bfc3c9e5e12638dbe3a6b17a8"
 dependencies = [
  "serde",
  "serde_json",
@@ -1113,9 +1113,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73e995a8604a01ec7a8c1e1f60a890981eb00f1cd25c3b15f5194364f27993cc"
+checksum = "c7767472f00a4053e86d5c37b3c814a6bc01c9230004713328d73d2a3444e72e"
 dependencies = [
  "arbitrary",
  "bytes-lit",
@@ -1133,9 +1133,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3eda569fe4c3aa2b45f2366e07d9476127e141c7f376d625b6a8217ee99f81f"
+checksum = "be8cf8fa10f3ad62509ff7b25cd696fb837da692c40264d1abb393e117aad75c"
 dependencies = [
  "crate-git-revision",
  "darling",
@@ -1153,9 +1153,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cfbe92fbabaea20517dc76fc89227735ffda2f19a10e2fe96db0ecb19b72b1"
+checksum = "12d306f61ef5c1247dca1562e04cc74b6e3adf107631c168b2ce0d5f1cf1fa13"
 dependencies = [
  "base64 0.13.1",
  "stellar-xdr",
@@ -1165,9 +1165,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-rust"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6569ea39d9f4d8cafadd0a2a77fc94991f7870d4d3c2a1fa401db9cb02d6082b"
+checksum = "bed06e0f622fb878fc439643f2fd86163223ac33a468beeea96e5d33f79b08b3"
 dependencies = [
  "prettyplease",
  "proc-macro2",

--- a/custom_types/Cargo.lock
+++ b/custom_types/Cargo.lock
@@ -1099,9 +1099,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07a2c3aeb3dba21530133f7f1dc533f53d96abff0df6497a5a2fad8f0fbda200"
+checksum = "15263ad07a3e0ec3f2ee3aea83b7c1a0610ad26ba76819f5092afcfaf0f3a3ed"
 dependencies = [
  "serde",
  "serde_json",
@@ -1113,9 +1113,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab66a39d18a5d8ed60df8cb77fc51067ef45a69af3c8fec52b6bc3bf7190351"
+checksum = "73e995a8604a01ec7a8c1e1f60a890981eb00f1cd25c3b15f5194364f27993cc"
 dependencies = [
  "arbitrary",
  "bytes-lit",
@@ -1133,9 +1133,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d92e9fb43bc3ca5180ff7f115156e732817fe27f8328787991c5eb38b30c26c"
+checksum = "c3eda569fe4c3aa2b45f2366e07d9476127e141c7f376d625b6a8217ee99f81f"
 dependencies = [
  "crate-git-revision",
  "darling",
@@ -1153,9 +1153,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f92a657578b121b06a29ab630bf24f02a32327cf9858c474157f0a8c25bfdb2"
+checksum = "87cfbe92fbabaea20517dc76fc89227735ffda2f19a10e2fe96db0ecb19b72b1"
 dependencies = [
  "base64 0.13.1",
  "stellar-xdr",
@@ -1165,9 +1165,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-rust"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7d95644321515640288dae87e71264ed070454c22b6bdf3527423dcaccdfff0"
+checksum = "6569ea39d9f4d8cafadd0a2a77fc94991f7870d4d3c2a1fa401db9cb02d6082b"
 dependencies = [
  "prettyplease",
  "proc-macro2",

--- a/custom_types/Cargo.toml
+++ b/custom_types/Cargo.toml
@@ -9,10 +9,10 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = { version = "21.7.1" }
+soroban-sdk = { version = "21.7.4" }
 
 [dev-dependencies]
-soroban-sdk = { version = "21.7.1", features = ["testutils"] }
+soroban-sdk = { version = "21.7.4", features = ["testutils"] }
 
 [profile.release]
 opt-level = "z"

--- a/custom_types/Cargo.toml
+++ b/custom_types/Cargo.toml
@@ -9,10 +9,10 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = { version = "21.6.0" }
+soroban-sdk = { version = "21.7.1" }
 
 [dev-dependencies]
-soroban-sdk = { version = "21.6.0", features = ["testutils"] }
+soroban-sdk = { version = "21.7.1", features = ["testutils"] }
 
 [profile.release]
 opt-level = "z"

--- a/custom_types/Makefile
+++ b/custom_types/Makefile
@@ -6,7 +6,7 @@ test: build
 	cargo test
 
 build:
-	soroban contract build
+	stellar contract build
 	@ls -l target/wasm32-unknown-unknown/release/*.wasm
 
 fmt:

--- a/deep_contract_auth/Cargo.lock
+++ b/deep_contract_auth/Cargo.lock
@@ -1032,9 +1032,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15263ad07a3e0ec3f2ee3aea83b7c1a0610ad26ba76819f5092afcfaf0f3a3ed"
+checksum = "956476365ff3f9bf429ff23fa11ac75798347a2bfc3c9e5e12638dbe3a6b17a8"
 dependencies = [
  "serde",
  "serde_json",
@@ -1046,9 +1046,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73e995a8604a01ec7a8c1e1f60a890981eb00f1cd25c3b15f5194364f27993cc"
+checksum = "c7767472f00a4053e86d5c37b3c814a6bc01c9230004713328d73d2a3444e72e"
 dependencies = [
  "arbitrary",
  "bytes-lit",
@@ -1066,9 +1066,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3eda569fe4c3aa2b45f2366e07d9476127e141c7f376d625b6a8217ee99f81f"
+checksum = "be8cf8fa10f3ad62509ff7b25cd696fb837da692c40264d1abb393e117aad75c"
 dependencies = [
  "crate-git-revision",
  "darling",
@@ -1086,9 +1086,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cfbe92fbabaea20517dc76fc89227735ffda2f19a10e2fe96db0ecb19b72b1"
+checksum = "12d306f61ef5c1247dca1562e04cc74b6e3adf107631c168b2ce0d5f1cf1fa13"
 dependencies = [
  "base64 0.13.1",
  "stellar-xdr",
@@ -1098,9 +1098,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-rust"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6569ea39d9f4d8cafadd0a2a77fc94991f7870d4d3c2a1fa401db9cb02d6082b"
+checksum = "bed06e0f622fb878fc439643f2fd86163223ac33a468beeea96e5d33f79b08b3"
 dependencies = [
  "prettyplease",
  "proc-macro2",

--- a/deep_contract_auth/Cargo.lock
+++ b/deep_contract_auth/Cargo.lock
@@ -1032,9 +1032,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07a2c3aeb3dba21530133f7f1dc533f53d96abff0df6497a5a2fad8f0fbda200"
+checksum = "15263ad07a3e0ec3f2ee3aea83b7c1a0610ad26ba76819f5092afcfaf0f3a3ed"
 dependencies = [
  "serde",
  "serde_json",
@@ -1046,9 +1046,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab66a39d18a5d8ed60df8cb77fc51067ef45a69af3c8fec52b6bc3bf7190351"
+checksum = "73e995a8604a01ec7a8c1e1f60a890981eb00f1cd25c3b15f5194364f27993cc"
 dependencies = [
  "arbitrary",
  "bytes-lit",
@@ -1066,9 +1066,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d92e9fb43bc3ca5180ff7f115156e732817fe27f8328787991c5eb38b30c26c"
+checksum = "c3eda569fe4c3aa2b45f2366e07d9476127e141c7f376d625b6a8217ee99f81f"
 dependencies = [
  "crate-git-revision",
  "darling",
@@ -1086,9 +1086,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f92a657578b121b06a29ab630bf24f02a32327cf9858c474157f0a8c25bfdb2"
+checksum = "87cfbe92fbabaea20517dc76fc89227735ffda2f19a10e2fe96db0ecb19b72b1"
 dependencies = [
  "base64 0.13.1",
  "stellar-xdr",
@@ -1098,9 +1098,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-rust"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7d95644321515640288dae87e71264ed070454c22b6bdf3527423dcaccdfff0"
+checksum = "6569ea39d9f4d8cafadd0a2a77fc94991f7870d4d3c2a1fa401db9cb02d6082b"
 dependencies = [
  "prettyplease",
  "proc-macro2",

--- a/deep_contract_auth/Cargo.toml
+++ b/deep_contract_auth/Cargo.toml
@@ -9,10 +9,10 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = { version = "21.7.1" }
+soroban-sdk = { version = "21.7.4" }
 
 [dev-dependencies]
-soroban-sdk = { version = "21.7.1", features = ["testutils"] }
+soroban-sdk = { version = "21.7.4", features = ["testutils"] }
 
 [profile.release]
 opt-level = "z"

--- a/deep_contract_auth/Cargo.toml
+++ b/deep_contract_auth/Cargo.toml
@@ -9,10 +9,10 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = { version = "21.6.0" }
+soroban-sdk = { version = "21.7.1" }
 
 [dev-dependencies]
-soroban-sdk = { version = "21.6.0", features = ["testutils"] }
+soroban-sdk = { version = "21.7.1", features = ["testutils"] }
 
 [profile.release]
 opt-level = "z"

--- a/deep_contract_auth/Makefile
+++ b/deep_contract_auth/Makefile
@@ -6,7 +6,7 @@ test: build
 	cargo test
 
 build:
-	soroban contract build
+	stellar contract build
 	@ls -l target/wasm32-unknown-unknown/release/*.wasm
 
 fmt:

--- a/deployer/contract/Cargo.lock
+++ b/deployer/contract/Cargo.lock
@@ -1032,9 +1032,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07a2c3aeb3dba21530133f7f1dc533f53d96abff0df6497a5a2fad8f0fbda200"
+checksum = "15263ad07a3e0ec3f2ee3aea83b7c1a0610ad26ba76819f5092afcfaf0f3a3ed"
 dependencies = [
  "serde",
  "serde_json",
@@ -1046,9 +1046,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab66a39d18a5d8ed60df8cb77fc51067ef45a69af3c8fec52b6bc3bf7190351"
+checksum = "73e995a8604a01ec7a8c1e1f60a890981eb00f1cd25c3b15f5194364f27993cc"
 dependencies = [
  "arbitrary",
  "bytes-lit",
@@ -1066,9 +1066,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d92e9fb43bc3ca5180ff7f115156e732817fe27f8328787991c5eb38b30c26c"
+checksum = "c3eda569fe4c3aa2b45f2366e07d9476127e141c7f376d625b6a8217ee99f81f"
 dependencies = [
  "crate-git-revision",
  "darling",
@@ -1086,9 +1086,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f92a657578b121b06a29ab630bf24f02a32327cf9858c474157f0a8c25bfdb2"
+checksum = "87cfbe92fbabaea20517dc76fc89227735ffda2f19a10e2fe96db0ecb19b72b1"
 dependencies = [
  "base64 0.13.1",
  "stellar-xdr",
@@ -1098,9 +1098,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-rust"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7d95644321515640288dae87e71264ed070454c22b6bdf3527423dcaccdfff0"
+checksum = "6569ea39d9f4d8cafadd0a2a77fc94991f7870d4d3c2a1fa401db9cb02d6082b"
 dependencies = [
  "prettyplease",
  "proc-macro2",

--- a/deployer/contract/Cargo.toml
+++ b/deployer/contract/Cargo.toml
@@ -9,10 +9,10 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = { version = "21.7.1" }
+soroban-sdk = { version = "21.7.4" }
 
 [dev-dependencies]
-soroban-sdk = { version = "21.7.1", features = ["testutils"] }
+soroban-sdk = { version = "21.7.4", features = ["testutils"] }
 
 [profile.release]
 opt-level = "z"

--- a/deployer/contract/Cargo.toml
+++ b/deployer/contract/Cargo.toml
@@ -9,10 +9,10 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = { version = "21.6.0" }
+soroban-sdk = { version = "21.7.1" }
 
 [dev-dependencies]
-soroban-sdk = { version = "21.6.0", features = ["testutils"] }
+soroban-sdk = { version = "21.7.1", features = ["testutils"] }
 
 [profile.release]
 opt-level = "z"

--- a/deployer/contract/Makefile
+++ b/deployer/contract/Makefile
@@ -6,7 +6,7 @@ test: build
 	cargo test
 
 build:
-	soroban contract build
+	stellar contract build
 	@ls -l target/wasm32-unknown-unknown/release/*.wasm
 
 fmt:

--- a/deployer/deployer/Cargo.lock
+++ b/deployer/deployer/Cargo.lock
@@ -1032,9 +1032,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07a2c3aeb3dba21530133f7f1dc533f53d96abff0df6497a5a2fad8f0fbda200"
+checksum = "15263ad07a3e0ec3f2ee3aea83b7c1a0610ad26ba76819f5092afcfaf0f3a3ed"
 dependencies = [
  "serde",
  "serde_json",
@@ -1046,9 +1046,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab66a39d18a5d8ed60df8cb77fc51067ef45a69af3c8fec52b6bc3bf7190351"
+checksum = "73e995a8604a01ec7a8c1e1f60a890981eb00f1cd25c3b15f5194364f27993cc"
 dependencies = [
  "arbitrary",
  "bytes-lit",
@@ -1066,9 +1066,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d92e9fb43bc3ca5180ff7f115156e732817fe27f8328787991c5eb38b30c26c"
+checksum = "c3eda569fe4c3aa2b45f2366e07d9476127e141c7f376d625b6a8217ee99f81f"
 dependencies = [
  "crate-git-revision",
  "darling",
@@ -1086,9 +1086,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f92a657578b121b06a29ab630bf24f02a32327cf9858c474157f0a8c25bfdb2"
+checksum = "87cfbe92fbabaea20517dc76fc89227735ffda2f19a10e2fe96db0ecb19b72b1"
 dependencies = [
  "base64 0.13.1",
  "stellar-xdr",
@@ -1098,9 +1098,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-rust"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7d95644321515640288dae87e71264ed070454c22b6bdf3527423dcaccdfff0"
+checksum = "6569ea39d9f4d8cafadd0a2a77fc94991f7870d4d3c2a1fa401db9cb02d6082b"
 dependencies = [
  "prettyplease",
  "proc-macro2",

--- a/deployer/deployer/Cargo.toml
+++ b/deployer/deployer/Cargo.toml
@@ -9,10 +9,10 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = { version = "21.7.1" }
+soroban-sdk = { version = "21.7.4" }
 
 [dev-dependencies]
-soroban-sdk = { version = "21.7.1", features = ["testutils"] }
+soroban-sdk = { version = "21.7.4", features = ["testutils"] }
 
 [profile.release]
 opt-level = "z"

--- a/deployer/deployer/Cargo.toml
+++ b/deployer/deployer/Cargo.toml
@@ -9,10 +9,10 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = { version = "21.6.0" }
+soroban-sdk = { version = "21.7.1" }
 
 [dev-dependencies]
-soroban-sdk = { version = "21.6.0", features = ["testutils"] }
+soroban-sdk = { version = "21.7.1", features = ["testutils"] }
 
 [profile.release]
 opt-level = "z"

--- a/deployer/deployer/Makefile
+++ b/deployer/deployer/Makefile
@@ -7,7 +7,7 @@ test: build
 
 build:
 	$(MAKE) -C ../contract || break;
-	soroban contract build
+	stellar contract build
 	@ls -l target/wasm32-unknown-unknown/release/*.wasm
 
 fmt:

--- a/errors/Cargo.lock
+++ b/errors/Cargo.lock
@@ -1099,9 +1099,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15263ad07a3e0ec3f2ee3aea83b7c1a0610ad26ba76819f5092afcfaf0f3a3ed"
+checksum = "956476365ff3f9bf429ff23fa11ac75798347a2bfc3c9e5e12638dbe3a6b17a8"
 dependencies = [
  "serde",
  "serde_json",
@@ -1113,9 +1113,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73e995a8604a01ec7a8c1e1f60a890981eb00f1cd25c3b15f5194364f27993cc"
+checksum = "c7767472f00a4053e86d5c37b3c814a6bc01c9230004713328d73d2a3444e72e"
 dependencies = [
  "arbitrary",
  "bytes-lit",
@@ -1133,9 +1133,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3eda569fe4c3aa2b45f2366e07d9476127e141c7f376d625b6a8217ee99f81f"
+checksum = "be8cf8fa10f3ad62509ff7b25cd696fb837da692c40264d1abb393e117aad75c"
 dependencies = [
  "crate-git-revision",
  "darling",
@@ -1153,9 +1153,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cfbe92fbabaea20517dc76fc89227735ffda2f19a10e2fe96db0ecb19b72b1"
+checksum = "12d306f61ef5c1247dca1562e04cc74b6e3adf107631c168b2ce0d5f1cf1fa13"
 dependencies = [
  "base64 0.13.1",
  "stellar-xdr",
@@ -1165,9 +1165,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-rust"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6569ea39d9f4d8cafadd0a2a77fc94991f7870d4d3c2a1fa401db9cb02d6082b"
+checksum = "bed06e0f622fb878fc439643f2fd86163223ac33a468beeea96e5d33f79b08b3"
 dependencies = [
  "prettyplease",
  "proc-macro2",

--- a/errors/Cargo.lock
+++ b/errors/Cargo.lock
@@ -1099,9 +1099,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07a2c3aeb3dba21530133f7f1dc533f53d96abff0df6497a5a2fad8f0fbda200"
+checksum = "15263ad07a3e0ec3f2ee3aea83b7c1a0610ad26ba76819f5092afcfaf0f3a3ed"
 dependencies = [
  "serde",
  "serde_json",
@@ -1113,9 +1113,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab66a39d18a5d8ed60df8cb77fc51067ef45a69af3c8fec52b6bc3bf7190351"
+checksum = "73e995a8604a01ec7a8c1e1f60a890981eb00f1cd25c3b15f5194364f27993cc"
 dependencies = [
  "arbitrary",
  "bytes-lit",
@@ -1133,9 +1133,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d92e9fb43bc3ca5180ff7f115156e732817fe27f8328787991c5eb38b30c26c"
+checksum = "c3eda569fe4c3aa2b45f2366e07d9476127e141c7f376d625b6a8217ee99f81f"
 dependencies = [
  "crate-git-revision",
  "darling",
@@ -1153,9 +1153,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f92a657578b121b06a29ab630bf24f02a32327cf9858c474157f0a8c25bfdb2"
+checksum = "87cfbe92fbabaea20517dc76fc89227735ffda2f19a10e2fe96db0ecb19b72b1"
 dependencies = [
  "base64 0.13.1",
  "stellar-xdr",
@@ -1165,9 +1165,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-rust"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7d95644321515640288dae87e71264ed070454c22b6bdf3527423dcaccdfff0"
+checksum = "6569ea39d9f4d8cafadd0a2a77fc94991f7870d4d3c2a1fa401db9cb02d6082b"
 dependencies = [
  "prettyplease",
  "proc-macro2",

--- a/errors/Cargo.toml
+++ b/errors/Cargo.toml
@@ -9,10 +9,10 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = { version = "21.7.1" }
+soroban-sdk = { version = "21.7.4" }
 
 [dev-dependencies]
-soroban-sdk = { version = "21.7.1", features = ["testutils"] }
+soroban-sdk = { version = "21.7.4", features = ["testutils"] }
 
 [profile.release]
 opt-level = "z"

--- a/errors/Cargo.toml
+++ b/errors/Cargo.toml
@@ -9,10 +9,10 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = { version = "21.6.0" }
+soroban-sdk = { version = "21.7.1" }
 
 [dev-dependencies]
-soroban-sdk = { version = "21.6.0", features = ["testutils"] }
+soroban-sdk = { version = "21.7.1", features = ["testutils"] }
 
 [profile.release]
 opt-level = "z"

--- a/errors/Makefile
+++ b/errors/Makefile
@@ -6,7 +6,7 @@ test: build
 	cargo test
 
 build:
-	soroban contract build
+	stellar contract build
 	@ls -l target/wasm32-unknown-unknown/release/*.wasm
 
 fmt:

--- a/eth_abi/Cargo.lock
+++ b/eth_abi/Cargo.lock
@@ -1708,9 +1708,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07a2c3aeb3dba21530133f7f1dc533f53d96abff0df6497a5a2fad8f0fbda200"
+checksum = "15263ad07a3e0ec3f2ee3aea83b7c1a0610ad26ba76819f5092afcfaf0f3a3ed"
 dependencies = [
  "serde",
  "serde_json",
@@ -1722,9 +1722,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab66a39d18a5d8ed60df8cb77fc51067ef45a69af3c8fec52b6bc3bf7190351"
+checksum = "73e995a8604a01ec7a8c1e1f60a890981eb00f1cd25c3b15f5194364f27993cc"
 dependencies = [
  "arbitrary",
  "bytes-lit",
@@ -1742,9 +1742,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d92e9fb43bc3ca5180ff7f115156e732817fe27f8328787991c5eb38b30c26c"
+checksum = "c3eda569fe4c3aa2b45f2366e07d9476127e141c7f376d625b6a8217ee99f81f"
 dependencies = [
  "crate-git-revision",
  "darling",
@@ -1762,9 +1762,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f92a657578b121b06a29ab630bf24f02a32327cf9858c474157f0a8c25bfdb2"
+checksum = "87cfbe92fbabaea20517dc76fc89227735ffda2f19a10e2fe96db0ecb19b72b1"
 dependencies = [
  "base64 0.13.1",
  "stellar-xdr",
@@ -1774,9 +1774,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-rust"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7d95644321515640288dae87e71264ed070454c22b6bdf3527423dcaccdfff0"
+checksum = "6569ea39d9f4d8cafadd0a2a77fc94991f7870d4d3c2a1fa401db9cb02d6082b"
 dependencies = [
  "prettyplease",
  "proc-macro2",

--- a/eth_abi/Cargo.lock
+++ b/eth_abi/Cargo.lock
@@ -1708,9 +1708,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15263ad07a3e0ec3f2ee3aea83b7c1a0610ad26ba76819f5092afcfaf0f3a3ed"
+checksum = "956476365ff3f9bf429ff23fa11ac75798347a2bfc3c9e5e12638dbe3a6b17a8"
 dependencies = [
  "serde",
  "serde_json",
@@ -1722,9 +1722,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73e995a8604a01ec7a8c1e1f60a890981eb00f1cd25c3b15f5194364f27993cc"
+checksum = "c7767472f00a4053e86d5c37b3c814a6bc01c9230004713328d73d2a3444e72e"
 dependencies = [
  "arbitrary",
  "bytes-lit",
@@ -1742,9 +1742,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3eda569fe4c3aa2b45f2366e07d9476127e141c7f376d625b6a8217ee99f81f"
+checksum = "be8cf8fa10f3ad62509ff7b25cd696fb837da692c40264d1abb393e117aad75c"
 dependencies = [
  "crate-git-revision",
  "darling",
@@ -1762,9 +1762,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cfbe92fbabaea20517dc76fc89227735ffda2f19a10e2fe96db0ecb19b72b1"
+checksum = "12d306f61ef5c1247dca1562e04cc74b6e3adf107631c168b2ce0d5f1cf1fa13"
 dependencies = [
  "base64 0.13.1",
  "stellar-xdr",
@@ -1774,9 +1774,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-rust"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6569ea39d9f4d8cafadd0a2a77fc94991f7870d4d3c2a1fa401db9cb02d6082b"
+checksum = "bed06e0f622fb878fc439643f2fd86163223ac33a468beeea96e5d33f79b08b3"
 dependencies = [
  "prettyplease",
  "proc-macro2",

--- a/eth_abi/Cargo.toml
+++ b/eth_abi/Cargo.toml
@@ -9,11 +9,11 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = { version = "21.6.0", features = ["alloc"] }
-alloy-sol-types = {version="0.6.3" }
+soroban-sdk = { version = "21.7.1", features = ["alloc"] }
+alloy-sol-types = { version = "0.6.3" }
 
 [dev-dependencies]
-soroban-sdk = { version = "21.6.0", features = ["testutils"] }
+soroban-sdk = { version = "21.7.1", features = ["testutils"] }
 
 [profile.release]
 opt-level = "z"

--- a/eth_abi/Cargo.toml
+++ b/eth_abi/Cargo.toml
@@ -9,11 +9,11 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = { version = "21.7.1", features = ["alloc"] }
+soroban-sdk = { version = "21.7.4", features = ["alloc"] }
 alloy-sol-types = { version = "0.6.3" }
 
 [dev-dependencies]
-soroban-sdk = { version = "21.7.1", features = ["testutils"] }
+soroban-sdk = { version = "21.7.4", features = ["testutils"] }
 
 [profile.release]
 opt-level = "z"

--- a/eth_abi/Makefile
+++ b/eth_abi/Makefile
@@ -6,7 +6,7 @@ test: build
 	cargo test
 
 build:
-	soroban contract build
+	stellar contract build
 	@ls -l target/wasm32-unknown-unknown/release/*.wasm
 
 fmt:

--- a/events/Cargo.lock
+++ b/events/Cargo.lock
@@ -1099,9 +1099,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15263ad07a3e0ec3f2ee3aea83b7c1a0610ad26ba76819f5092afcfaf0f3a3ed"
+checksum = "956476365ff3f9bf429ff23fa11ac75798347a2bfc3c9e5e12638dbe3a6b17a8"
 dependencies = [
  "serde",
  "serde_json",
@@ -1113,9 +1113,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73e995a8604a01ec7a8c1e1f60a890981eb00f1cd25c3b15f5194364f27993cc"
+checksum = "c7767472f00a4053e86d5c37b3c814a6bc01c9230004713328d73d2a3444e72e"
 dependencies = [
  "arbitrary",
  "bytes-lit",
@@ -1133,9 +1133,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3eda569fe4c3aa2b45f2366e07d9476127e141c7f376d625b6a8217ee99f81f"
+checksum = "be8cf8fa10f3ad62509ff7b25cd696fb837da692c40264d1abb393e117aad75c"
 dependencies = [
  "crate-git-revision",
  "darling",
@@ -1153,9 +1153,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cfbe92fbabaea20517dc76fc89227735ffda2f19a10e2fe96db0ecb19b72b1"
+checksum = "12d306f61ef5c1247dca1562e04cc74b6e3adf107631c168b2ce0d5f1cf1fa13"
 dependencies = [
  "base64 0.13.1",
  "stellar-xdr",
@@ -1165,9 +1165,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-rust"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6569ea39d9f4d8cafadd0a2a77fc94991f7870d4d3c2a1fa401db9cb02d6082b"
+checksum = "bed06e0f622fb878fc439643f2fd86163223ac33a468beeea96e5d33f79b08b3"
 dependencies = [
  "prettyplease",
  "proc-macro2",

--- a/events/Cargo.lock
+++ b/events/Cargo.lock
@@ -1099,9 +1099,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07a2c3aeb3dba21530133f7f1dc533f53d96abff0df6497a5a2fad8f0fbda200"
+checksum = "15263ad07a3e0ec3f2ee3aea83b7c1a0610ad26ba76819f5092afcfaf0f3a3ed"
 dependencies = [
  "serde",
  "serde_json",
@@ -1113,9 +1113,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab66a39d18a5d8ed60df8cb77fc51067ef45a69af3c8fec52b6bc3bf7190351"
+checksum = "73e995a8604a01ec7a8c1e1f60a890981eb00f1cd25c3b15f5194364f27993cc"
 dependencies = [
  "arbitrary",
  "bytes-lit",
@@ -1133,9 +1133,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d92e9fb43bc3ca5180ff7f115156e732817fe27f8328787991c5eb38b30c26c"
+checksum = "c3eda569fe4c3aa2b45f2366e07d9476127e141c7f376d625b6a8217ee99f81f"
 dependencies = [
  "crate-git-revision",
  "darling",
@@ -1153,9 +1153,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f92a657578b121b06a29ab630bf24f02a32327cf9858c474157f0a8c25bfdb2"
+checksum = "87cfbe92fbabaea20517dc76fc89227735ffda2f19a10e2fe96db0ecb19b72b1"
 dependencies = [
  "base64 0.13.1",
  "stellar-xdr",
@@ -1165,9 +1165,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-rust"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7d95644321515640288dae87e71264ed070454c22b6bdf3527423dcaccdfff0"
+checksum = "6569ea39d9f4d8cafadd0a2a77fc94991f7870d4d3c2a1fa401db9cb02d6082b"
 dependencies = [
  "prettyplease",
  "proc-macro2",

--- a/events/Cargo.toml
+++ b/events/Cargo.toml
@@ -9,10 +9,10 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = { version = "21.7.1" }
+soroban-sdk = { version = "21.7.4" }
 
 [dev-dependencies]
-soroban-sdk = { version = "21.7.1", features = ["testutils"] }
+soroban-sdk = { version = "21.7.4", features = ["testutils"] }
 
 [profile.release]
 opt-level = "z"

--- a/events/Cargo.toml
+++ b/events/Cargo.toml
@@ -9,10 +9,10 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = { version = "21.6.0" }
+soroban-sdk = { version = "21.7.1" }
 
 [dev-dependencies]
-soroban-sdk = { version = "21.6.0", features = ["testutils"] }
+soroban-sdk = { version = "21.7.1", features = ["testutils"] }
 
 [profile.release]
 opt-level = "z"

--- a/events/Makefile
+++ b/events/Makefile
@@ -6,7 +6,7 @@ test: build
 	cargo test
 
 build:
-	soroban contract build
+	stellar contract build
 	@ls -l target/wasm32-unknown-unknown/release/*.wasm
 
 fmt:

--- a/fuzzing/Cargo.lock
+++ b/fuzzing/Cargo.lock
@@ -1217,9 +1217,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15263ad07a3e0ec3f2ee3aea83b7c1a0610ad26ba76819f5092afcfaf0f3a3ed"
+checksum = "956476365ff3f9bf429ff23fa11ac75798347a2bfc3c9e5e12638dbe3a6b17a8"
 dependencies = [
  "serde",
  "serde_json",
@@ -1231,9 +1231,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73e995a8604a01ec7a8c1e1f60a890981eb00f1cd25c3b15f5194364f27993cc"
+checksum = "c7767472f00a4053e86d5c37b3c814a6bc01c9230004713328d73d2a3444e72e"
 dependencies = [
  "arbitrary",
  "bytes-lit",
@@ -1251,9 +1251,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3eda569fe4c3aa2b45f2366e07d9476127e141c7f376d625b6a8217ee99f81f"
+checksum = "be8cf8fa10f3ad62509ff7b25cd696fb837da692c40264d1abb393e117aad75c"
 dependencies = [
  "crate-git-revision",
  "darling",
@@ -1271,9 +1271,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cfbe92fbabaea20517dc76fc89227735ffda2f19a10e2fe96db0ecb19b72b1"
+checksum = "12d306f61ef5c1247dca1562e04cc74b6e3adf107631c168b2ce0d5f1cf1fa13"
 dependencies = [
  "base64 0.13.1",
  "stellar-xdr",
@@ -1283,9 +1283,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-rust"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6569ea39d9f4d8cafadd0a2a77fc94991f7870d4d3c2a1fa401db9cb02d6082b"
+checksum = "bed06e0f622fb878fc439643f2fd86163223ac33a468beeea96e5d33f79b08b3"
 dependencies = [
  "prettyplease",
  "proc-macro2",

--- a/fuzzing/Cargo.lock
+++ b/fuzzing/Cargo.lock
@@ -1217,9 +1217,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07a2c3aeb3dba21530133f7f1dc533f53d96abff0df6497a5a2fad8f0fbda200"
+checksum = "15263ad07a3e0ec3f2ee3aea83b7c1a0610ad26ba76819f5092afcfaf0f3a3ed"
 dependencies = [
  "serde",
  "serde_json",
@@ -1231,9 +1231,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab66a39d18a5d8ed60df8cb77fc51067ef45a69af3c8fec52b6bc3bf7190351"
+checksum = "73e995a8604a01ec7a8c1e1f60a890981eb00f1cd25c3b15f5194364f27993cc"
 dependencies = [
  "arbitrary",
  "bytes-lit",
@@ -1251,9 +1251,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d92e9fb43bc3ca5180ff7f115156e732817fe27f8328787991c5eb38b30c26c"
+checksum = "c3eda569fe4c3aa2b45f2366e07d9476127e141c7f376d625b6a8217ee99f81f"
 dependencies = [
  "crate-git-revision",
  "darling",
@@ -1271,9 +1271,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f92a657578b121b06a29ab630bf24f02a32327cf9858c474157f0a8c25bfdb2"
+checksum = "87cfbe92fbabaea20517dc76fc89227735ffda2f19a10e2fe96db0ecb19b72b1"
 dependencies = [
  "base64 0.13.1",
  "stellar-xdr",
@@ -1283,9 +1283,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-rust"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7d95644321515640288dae87e71264ed070454c22b6bdf3527423dcaccdfff0"
+checksum = "6569ea39d9f4d8cafadd0a2a77fc94991f7870d4d3c2a1fa401db9cb02d6082b"
 dependencies = [
  "prettyplease",
  "proc-macro2",

--- a/fuzzing/Cargo.toml
+++ b/fuzzing/Cargo.toml
@@ -12,12 +12,12 @@ doctest = false
 testutils = []
 
 [dependencies]
-soroban-sdk = { version = "21.6.0" }
+soroban-sdk = { version = "21.7.1" }
 
 [dev-dependencies]
-soroban-sdk = { version = "21.6.0", features = ["testutils"] }
+soroban-sdk = { version = "21.7.1", features = ["testutils"] }
 arbitrary = { version = "1.1.3", features = ["derive"] }
-proptest  = "1.2.0"
+proptest = "1.2.0"
 proptest-arbitrary-interop = "0.1.0"
 
 [profile.release]

--- a/fuzzing/Cargo.toml
+++ b/fuzzing/Cargo.toml
@@ -12,10 +12,10 @@ doctest = false
 testutils = []
 
 [dependencies]
-soroban-sdk = { version = "21.7.1" }
+soroban-sdk = { version = "21.7.4" }
 
 [dev-dependencies]
-soroban-sdk = { version = "21.7.1", features = ["testutils"] }
+soroban-sdk = { version = "21.7.4", features = ["testutils"] }
 arbitrary = { version = "1.1.3", features = ["derive"] }
 proptest = "1.2.0"
 proptest-arbitrary-interop = "0.1.0"

--- a/fuzzing/Makefile
+++ b/fuzzing/Makefile
@@ -7,7 +7,7 @@ test: build
 	cargo check --manifest-path=fuzz/Cargo.toml
 
 build:
-	soroban contract build
+	stellar contract build
 	@ls -l target/wasm32-unknown-unknown/release/*.wasm
 
 fmt:

--- a/fuzzing/fuzz/Cargo.lock
+++ b/fuzzing/fuzz/Cargo.lock
@@ -1065,9 +1065,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07a2c3aeb3dba21530133f7f1dc533f53d96abff0df6497a5a2fad8f0fbda200"
+checksum = "15263ad07a3e0ec3f2ee3aea83b7c1a0610ad26ba76819f5092afcfaf0f3a3ed"
 dependencies = [
  "serde",
  "serde_json",
@@ -1079,9 +1079,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab66a39d18a5d8ed60df8cb77fc51067ef45a69af3c8fec52b6bc3bf7190351"
+checksum = "73e995a8604a01ec7a8c1e1f60a890981eb00f1cd25c3b15f5194364f27993cc"
 dependencies = [
  "arbitrary",
  "bytes-lit",
@@ -1099,9 +1099,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d92e9fb43bc3ca5180ff7f115156e732817fe27f8328787991c5eb38b30c26c"
+checksum = "c3eda569fe4c3aa2b45f2366e07d9476127e141c7f376d625b6a8217ee99f81f"
 dependencies = [
  "crate-git-revision",
  "darling",
@@ -1119,9 +1119,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f92a657578b121b06a29ab630bf24f02a32327cf9858c474157f0a8c25bfdb2"
+checksum = "87cfbe92fbabaea20517dc76fc89227735ffda2f19a10e2fe96db0ecb19b72b1"
 dependencies = [
  "base64 0.13.1",
  "stellar-xdr",
@@ -1131,9 +1131,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-rust"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7d95644321515640288dae87e71264ed070454c22b6bdf3527423dcaccdfff0"
+checksum = "6569ea39d9f4d8cafadd0a2a77fc94991f7870d4d3c2a1fa401db9cb02d6082b"
 dependencies = [
  "prettyplease",
  "proc-macro2",

--- a/fuzzing/fuzz/Cargo.toml
+++ b/fuzzing/fuzz/Cargo.toml
@@ -10,7 +10,7 @@ cargo-fuzz = true
 
 [dependencies]
 libfuzzer-sys = "0.4"
-soroban-sdk = { version = "21.6.0", features = ["testutils"] }
+soroban-sdk = { version = "21.7.1", features = ["testutils"] }
 soroban-ledger-snapshot = { version = "21.2.0" }
 
 [dependencies.soroban-fuzzing-contract]

--- a/fuzzing/fuzz/Cargo.toml
+++ b/fuzzing/fuzz/Cargo.toml
@@ -10,8 +10,8 @@ cargo-fuzz = true
 
 [dependencies]
 libfuzzer-sys = "0.4"
-soroban-sdk = { version = "21.7.1", features = ["testutils"] }
-soroban-ledger-snapshot = { version = "21.7.1" }
+soroban-sdk = { version = "21.7.4", features = ["testutils"] }
+soroban-ledger-snapshot = { version = "21.7.4" }
 
 [dependencies.soroban-fuzzing-contract]
 path = ".."

--- a/fuzzing/fuzz/Cargo.toml
+++ b/fuzzing/fuzz/Cargo.toml
@@ -11,7 +11,7 @@ cargo-fuzz = true
 [dependencies]
 libfuzzer-sys = "0.4"
 soroban-sdk = { version = "21.7.1", features = ["testutils"] }
-soroban-ledger-snapshot = { version = "21.2.0" }
+soroban-ledger-snapshot = { version = "21.7.1" }
 
 [dependencies.soroban-fuzzing-contract]
 path = ".."

--- a/hello_world/Cargo.lock
+++ b/hello_world/Cargo.lock
@@ -1099,9 +1099,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15263ad07a3e0ec3f2ee3aea83b7c1a0610ad26ba76819f5092afcfaf0f3a3ed"
+checksum = "956476365ff3f9bf429ff23fa11ac75798347a2bfc3c9e5e12638dbe3a6b17a8"
 dependencies = [
  "serde",
  "serde_json",
@@ -1113,9 +1113,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73e995a8604a01ec7a8c1e1f60a890981eb00f1cd25c3b15f5194364f27993cc"
+checksum = "c7767472f00a4053e86d5c37b3c814a6bc01c9230004713328d73d2a3444e72e"
 dependencies = [
  "arbitrary",
  "bytes-lit",
@@ -1133,9 +1133,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3eda569fe4c3aa2b45f2366e07d9476127e141c7f376d625b6a8217ee99f81f"
+checksum = "be8cf8fa10f3ad62509ff7b25cd696fb837da692c40264d1abb393e117aad75c"
 dependencies = [
  "crate-git-revision",
  "darling",
@@ -1153,9 +1153,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cfbe92fbabaea20517dc76fc89227735ffda2f19a10e2fe96db0ecb19b72b1"
+checksum = "12d306f61ef5c1247dca1562e04cc74b6e3adf107631c168b2ce0d5f1cf1fa13"
 dependencies = [
  "base64 0.13.1",
  "stellar-xdr",
@@ -1165,9 +1165,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-rust"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6569ea39d9f4d8cafadd0a2a77fc94991f7870d4d3c2a1fa401db9cb02d6082b"
+checksum = "bed06e0f622fb878fc439643f2fd86163223ac33a468beeea96e5d33f79b08b3"
 dependencies = [
  "prettyplease",
  "proc-macro2",

--- a/hello_world/Cargo.lock
+++ b/hello_world/Cargo.lock
@@ -1099,9 +1099,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07a2c3aeb3dba21530133f7f1dc533f53d96abff0df6497a5a2fad8f0fbda200"
+checksum = "15263ad07a3e0ec3f2ee3aea83b7c1a0610ad26ba76819f5092afcfaf0f3a3ed"
 dependencies = [
  "serde",
  "serde_json",
@@ -1113,9 +1113,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab66a39d18a5d8ed60df8cb77fc51067ef45a69af3c8fec52b6bc3bf7190351"
+checksum = "73e995a8604a01ec7a8c1e1f60a890981eb00f1cd25c3b15f5194364f27993cc"
 dependencies = [
  "arbitrary",
  "bytes-lit",
@@ -1133,9 +1133,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d92e9fb43bc3ca5180ff7f115156e732817fe27f8328787991c5eb38b30c26c"
+checksum = "c3eda569fe4c3aa2b45f2366e07d9476127e141c7f376d625b6a8217ee99f81f"
 dependencies = [
  "crate-git-revision",
  "darling",
@@ -1153,9 +1153,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f92a657578b121b06a29ab630bf24f02a32327cf9858c474157f0a8c25bfdb2"
+checksum = "87cfbe92fbabaea20517dc76fc89227735ffda2f19a10e2fe96db0ecb19b72b1"
 dependencies = [
  "base64 0.13.1",
  "stellar-xdr",
@@ -1165,9 +1165,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-rust"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7d95644321515640288dae87e71264ed070454c22b6bdf3527423dcaccdfff0"
+checksum = "6569ea39d9f4d8cafadd0a2a77fc94991f7870d4d3c2a1fa401db9cb02d6082b"
 dependencies = [
  "prettyplease",
  "proc-macro2",

--- a/hello_world/Cargo.toml
+++ b/hello_world/Cargo.toml
@@ -9,10 +9,10 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = { version = "21.7.1" }
+soroban-sdk = { version = "21.7.4" }
 
 [dev-dependencies]
-soroban-sdk = { version = "21.7.1", features = ["testutils"] }
+soroban-sdk = { version = "21.7.4", features = ["testutils"] }
 
 [profile.release]
 opt-level = "z"

--- a/hello_world/Cargo.toml
+++ b/hello_world/Cargo.toml
@@ -9,10 +9,10 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = { version = "21.6.0" }
+soroban-sdk = { version = "21.7.1" }
 
 [dev-dependencies]
-soroban-sdk = { version = "21.6.0", features = ["testutils"] }
+soroban-sdk = { version = "21.7.1", features = ["testutils"] }
 
 [profile.release]
 opt-level = "z"

--- a/hello_world/Makefile
+++ b/hello_world/Makefile
@@ -6,7 +6,7 @@ test: build
 	cargo test
 
 build:
-	soroban contract build
+	stellar contract build
 	@ls -l target/wasm32-unknown-unknown/release/*.wasm
 
 fmt:

--- a/increment/Cargo.lock
+++ b/increment/Cargo.lock
@@ -1099,9 +1099,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15263ad07a3e0ec3f2ee3aea83b7c1a0610ad26ba76819f5092afcfaf0f3a3ed"
+checksum = "956476365ff3f9bf429ff23fa11ac75798347a2bfc3c9e5e12638dbe3a6b17a8"
 dependencies = [
  "serde",
  "serde_json",
@@ -1113,9 +1113,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73e995a8604a01ec7a8c1e1f60a890981eb00f1cd25c3b15f5194364f27993cc"
+checksum = "c7767472f00a4053e86d5c37b3c814a6bc01c9230004713328d73d2a3444e72e"
 dependencies = [
  "arbitrary",
  "bytes-lit",
@@ -1133,9 +1133,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3eda569fe4c3aa2b45f2366e07d9476127e141c7f376d625b6a8217ee99f81f"
+checksum = "be8cf8fa10f3ad62509ff7b25cd696fb837da692c40264d1abb393e117aad75c"
 dependencies = [
  "crate-git-revision",
  "darling",
@@ -1153,9 +1153,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cfbe92fbabaea20517dc76fc89227735ffda2f19a10e2fe96db0ecb19b72b1"
+checksum = "12d306f61ef5c1247dca1562e04cc74b6e3adf107631c168b2ce0d5f1cf1fa13"
 dependencies = [
  "base64 0.13.1",
  "stellar-xdr",
@@ -1165,9 +1165,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-rust"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6569ea39d9f4d8cafadd0a2a77fc94991f7870d4d3c2a1fa401db9cb02d6082b"
+checksum = "bed06e0f622fb878fc439643f2fd86163223ac33a468beeea96e5d33f79b08b3"
 dependencies = [
  "prettyplease",
  "proc-macro2",

--- a/increment/Cargo.lock
+++ b/increment/Cargo.lock
@@ -1099,9 +1099,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07a2c3aeb3dba21530133f7f1dc533f53d96abff0df6497a5a2fad8f0fbda200"
+checksum = "15263ad07a3e0ec3f2ee3aea83b7c1a0610ad26ba76819f5092afcfaf0f3a3ed"
 dependencies = [
  "serde",
  "serde_json",
@@ -1113,9 +1113,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab66a39d18a5d8ed60df8cb77fc51067ef45a69af3c8fec52b6bc3bf7190351"
+checksum = "73e995a8604a01ec7a8c1e1f60a890981eb00f1cd25c3b15f5194364f27993cc"
 dependencies = [
  "arbitrary",
  "bytes-lit",
@@ -1133,9 +1133,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d92e9fb43bc3ca5180ff7f115156e732817fe27f8328787991c5eb38b30c26c"
+checksum = "c3eda569fe4c3aa2b45f2366e07d9476127e141c7f376d625b6a8217ee99f81f"
 dependencies = [
  "crate-git-revision",
  "darling",
@@ -1153,9 +1153,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f92a657578b121b06a29ab630bf24f02a32327cf9858c474157f0a8c25bfdb2"
+checksum = "87cfbe92fbabaea20517dc76fc89227735ffda2f19a10e2fe96db0ecb19b72b1"
 dependencies = [
  "base64 0.13.1",
  "stellar-xdr",
@@ -1165,9 +1165,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-rust"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7d95644321515640288dae87e71264ed070454c22b6bdf3527423dcaccdfff0"
+checksum = "6569ea39d9f4d8cafadd0a2a77fc94991f7870d4d3c2a1fa401db9cb02d6082b"
 dependencies = [
  "prettyplease",
  "proc-macro2",

--- a/increment/Cargo.toml
+++ b/increment/Cargo.toml
@@ -9,10 +9,10 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = { version = "21.7.1" }
+soroban-sdk = { version = "21.7.4" }
 
 [dev-dependencies]
-soroban-sdk = { version = "21.7.1", features = ["testutils"] }
+soroban-sdk = { version = "21.7.4", features = ["testutils"] }
 
 [profile.release]
 opt-level = "z"

--- a/increment/Cargo.toml
+++ b/increment/Cargo.toml
@@ -9,10 +9,10 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = { version = "21.6.0" }
+soroban-sdk = { version = "21.7.1" }
 
 [dev-dependencies]
-soroban-sdk = { version = "21.6.0", features = ["testutils"] }
+soroban-sdk = { version = "21.7.1", features = ["testutils"] }
 
 [profile.release]
 opt-level = "z"

--- a/increment/Makefile
+++ b/increment/Makefile
@@ -6,7 +6,7 @@ test: build
 	cargo test
 
 build:
-	soroban contract build
+	stellar contract build
 	@ls -l target/wasm32-unknown-unknown/release/*.wasm
 
 fmt:

--- a/liquidity_pool/Cargo.lock
+++ b/liquidity_pool/Cargo.lock
@@ -1092,9 +1092,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07a2c3aeb3dba21530133f7f1dc533f53d96abff0df6497a5a2fad8f0fbda200"
+checksum = "15263ad07a3e0ec3f2ee3aea83b7c1a0610ad26ba76819f5092afcfaf0f3a3ed"
 dependencies = [
  "serde",
  "serde_json",
@@ -1114,9 +1114,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab66a39d18a5d8ed60df8cb77fc51067ef45a69af3c8fec52b6bc3bf7190351"
+checksum = "73e995a8604a01ec7a8c1e1f60a890981eb00f1cd25c3b15f5194364f27993cc"
 dependencies = [
  "arbitrary",
  "bytes-lit",
@@ -1134,9 +1134,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d92e9fb43bc3ca5180ff7f115156e732817fe27f8328787991c5eb38b30c26c"
+checksum = "c3eda569fe4c3aa2b45f2366e07d9476127e141c7f376d625b6a8217ee99f81f"
 dependencies = [
  "crate-git-revision",
  "darling",
@@ -1154,9 +1154,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f92a657578b121b06a29ab630bf24f02a32327cf9858c474157f0a8c25bfdb2"
+checksum = "87cfbe92fbabaea20517dc76fc89227735ffda2f19a10e2fe96db0ecb19b72b1"
 dependencies = [
  "base64 0.13.1",
  "stellar-xdr",
@@ -1166,9 +1166,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-rust"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7d95644321515640288dae87e71264ed070454c22b6bdf3527423dcaccdfff0"
+checksum = "6569ea39d9f4d8cafadd0a2a77fc94991f7870d4d3c2a1fa401db9cb02d6082b"
 dependencies = [
  "prettyplease",
  "proc-macro2",

--- a/liquidity_pool/Cargo.lock
+++ b/liquidity_pool/Cargo.lock
@@ -1092,9 +1092,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15263ad07a3e0ec3f2ee3aea83b7c1a0610ad26ba76819f5092afcfaf0f3a3ed"
+checksum = "956476365ff3f9bf429ff23fa11ac75798347a2bfc3c9e5e12638dbe3a6b17a8"
 dependencies = [
  "serde",
  "serde_json",
@@ -1114,9 +1114,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73e995a8604a01ec7a8c1e1f60a890981eb00f1cd25c3b15f5194364f27993cc"
+checksum = "c7767472f00a4053e86d5c37b3c814a6bc01c9230004713328d73d2a3444e72e"
 dependencies = [
  "arbitrary",
  "bytes-lit",
@@ -1134,9 +1134,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3eda569fe4c3aa2b45f2366e07d9476127e141c7f376d625b6a8217ee99f81f"
+checksum = "be8cf8fa10f3ad62509ff7b25cd696fb837da692c40264d1abb393e117aad75c"
 dependencies = [
  "crate-git-revision",
  "darling",
@@ -1154,9 +1154,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cfbe92fbabaea20517dc76fc89227735ffda2f19a10e2fe96db0ecb19b72b1"
+checksum = "12d306f61ef5c1247dca1562e04cc74b6e3adf107631c168b2ce0d5f1cf1fa13"
 dependencies = [
  "base64 0.13.1",
  "stellar-xdr",
@@ -1166,9 +1166,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-rust"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6569ea39d9f4d8cafadd0a2a77fc94991f7870d4d3c2a1fa401db9cb02d6082b"
+checksum = "bed06e0f622fb878fc439643f2fd86163223ac33a468beeea96e5d33f79b08b3"
 dependencies = [
  "prettyplease",
  "proc-macro2",

--- a/liquidity_pool/Cargo.toml
+++ b/liquidity_pool/Cargo.toml
@@ -8,13 +8,13 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
-soroban-sdk = { version = "21.7.1" }
+soroban-sdk = { version = "21.7.4" }
 num-integer = { version = "0.1.45", default-features = false, features = [
     "i128",
 ] }
 
 [dev-dependencies]
-soroban-sdk = { version = "21.7.1", features = ["testutils"] }
+soroban-sdk = { version = "21.7.4", features = ["testutils"] }
 
 [profile.release]
 opt-level = "z"

--- a/liquidity_pool/Cargo.toml
+++ b/liquidity_pool/Cargo.toml
@@ -8,11 +8,13 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
-soroban-sdk = { version = "21.6.0" }
-num-integer = { version = "0.1.45", default-features = false, features = ["i128"] }
+soroban-sdk = { version = "21.7.1" }
+num-integer = { version = "0.1.45", default-features = false, features = [
+    "i128",
+] }
 
 [dev-dependencies]
-soroban-sdk = { version = "21.6.0", features = ["testutils"] }
+soroban-sdk = { version = "21.7.1", features = ["testutils"] }
 
 [profile.release]
 opt-level = "z"

--- a/liquidity_pool/Makefile
+++ b/liquidity_pool/Makefile
@@ -7,7 +7,7 @@ test: build
 
 build:
 	$(MAKE) -C ../token || break;
-	soroban contract build
+	stellar contract build
 	@ls -l target/wasm32-unknown-unknown/release/*.wasm
 fmt:
 	cargo fmt --all

--- a/logging/Cargo.lock
+++ b/logging/Cargo.lock
@@ -1092,9 +1092,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15263ad07a3e0ec3f2ee3aea83b7c1a0610ad26ba76819f5092afcfaf0f3a3ed"
+checksum = "956476365ff3f9bf429ff23fa11ac75798347a2bfc3c9e5e12638dbe3a6b17a8"
 dependencies = [
  "serde",
  "serde_json",
@@ -1113,9 +1113,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73e995a8604a01ec7a8c1e1f60a890981eb00f1cd25c3b15f5194364f27993cc"
+checksum = "c7767472f00a4053e86d5c37b3c814a6bc01c9230004713328d73d2a3444e72e"
 dependencies = [
  "arbitrary",
  "bytes-lit",
@@ -1133,9 +1133,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3eda569fe4c3aa2b45f2366e07d9476127e141c7f376d625b6a8217ee99f81f"
+checksum = "be8cf8fa10f3ad62509ff7b25cd696fb837da692c40264d1abb393e117aad75c"
 dependencies = [
  "crate-git-revision",
  "darling",
@@ -1153,9 +1153,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cfbe92fbabaea20517dc76fc89227735ffda2f19a10e2fe96db0ecb19b72b1"
+checksum = "12d306f61ef5c1247dca1562e04cc74b6e3adf107631c168b2ce0d5f1cf1fa13"
 dependencies = [
  "base64 0.13.1",
  "stellar-xdr",
@@ -1165,9 +1165,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-rust"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6569ea39d9f4d8cafadd0a2a77fc94991f7870d4d3c2a1fa401db9cb02d6082b"
+checksum = "bed06e0f622fb878fc439643f2fd86163223ac33a468beeea96e5d33f79b08b3"
 dependencies = [
  "prettyplease",
  "proc-macro2",

--- a/logging/Cargo.lock
+++ b/logging/Cargo.lock
@@ -1092,9 +1092,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07a2c3aeb3dba21530133f7f1dc533f53d96abff0df6497a5a2fad8f0fbda200"
+checksum = "15263ad07a3e0ec3f2ee3aea83b7c1a0610ad26ba76819f5092afcfaf0f3a3ed"
 dependencies = [
  "serde",
  "serde_json",
@@ -1113,9 +1113,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab66a39d18a5d8ed60df8cb77fc51067ef45a69af3c8fec52b6bc3bf7190351"
+checksum = "73e995a8604a01ec7a8c1e1f60a890981eb00f1cd25c3b15f5194364f27993cc"
 dependencies = [
  "arbitrary",
  "bytes-lit",
@@ -1133,9 +1133,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d92e9fb43bc3ca5180ff7f115156e732817fe27f8328787991c5eb38b30c26c"
+checksum = "c3eda569fe4c3aa2b45f2366e07d9476127e141c7f376d625b6a8217ee99f81f"
 dependencies = [
  "crate-git-revision",
  "darling",
@@ -1153,9 +1153,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f92a657578b121b06a29ab630bf24f02a32327cf9858c474157f0a8c25bfdb2"
+checksum = "87cfbe92fbabaea20517dc76fc89227735ffda2f19a10e2fe96db0ecb19b72b1"
 dependencies = [
  "base64 0.13.1",
  "stellar-xdr",
@@ -1165,9 +1165,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-rust"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7d95644321515640288dae87e71264ed070454c22b6bdf3527423dcaccdfff0"
+checksum = "6569ea39d9f4d8cafadd0a2a77fc94991f7870d4d3c2a1fa401db9cb02d6082b"
 dependencies = [
  "prettyplease",
  "proc-macro2",

--- a/logging/Cargo.toml
+++ b/logging/Cargo.toml
@@ -12,10 +12,10 @@ doctest = false
 testutils = ["soroban-sdk/testutils"]
 
 [dependencies]
-soroban-sdk = { version = "21.6.0" }
+soroban-sdk = { version = "21.7.1" }
 
 [dev-dependencies]
-soroban-sdk = { version = "21.6.0", features = ["testutils"] }
+soroban-sdk = { version = "21.7.1", features = ["testutils"] }
 
 [profile.release]
 opt-level = "z"

--- a/logging/Cargo.toml
+++ b/logging/Cargo.toml
@@ -12,10 +12,10 @@ doctest = false
 testutils = ["soroban-sdk/testutils"]
 
 [dependencies]
-soroban-sdk = { version = "21.7.1" }
+soroban-sdk = { version = "21.7.4" }
 
 [dev-dependencies]
-soroban-sdk = { version = "21.7.1", features = ["testutils"] }
+soroban-sdk = { version = "21.7.4", features = ["testutils"] }
 
 [profile.release]
 opt-level = "z"

--- a/logging/Makefile
+++ b/logging/Makefile
@@ -6,7 +6,7 @@ test: build
 	cargo test
 
 build:
-	soroban contract build
+	stellar contract build
 	@ls -l target/wasm32-unknown-unknown/release/*.wasm
 
 fmt:

--- a/mint-lock/Cargo.lock
+++ b/mint-lock/Cargo.lock
@@ -1092,9 +1092,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15263ad07a3e0ec3f2ee3aea83b7c1a0610ad26ba76819f5092afcfaf0f3a3ed"
+checksum = "956476365ff3f9bf429ff23fa11ac75798347a2bfc3c9e5e12638dbe3a6b17a8"
 dependencies = [
  "serde",
  "serde_json",
@@ -1113,9 +1113,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73e995a8604a01ec7a8c1e1f60a890981eb00f1cd25c3b15f5194364f27993cc"
+checksum = "c7767472f00a4053e86d5c37b3c814a6bc01c9230004713328d73d2a3444e72e"
 dependencies = [
  "arbitrary",
  "bytes-lit",
@@ -1133,9 +1133,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3eda569fe4c3aa2b45f2366e07d9476127e141c7f376d625b6a8217ee99f81f"
+checksum = "be8cf8fa10f3ad62509ff7b25cd696fb837da692c40264d1abb393e117aad75c"
 dependencies = [
  "crate-git-revision",
  "darling",
@@ -1153,9 +1153,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cfbe92fbabaea20517dc76fc89227735ffda2f19a10e2fe96db0ecb19b72b1"
+checksum = "12d306f61ef5c1247dca1562e04cc74b6e3adf107631c168b2ce0d5f1cf1fa13"
 dependencies = [
  "base64 0.13.1",
  "stellar-xdr",
@@ -1165,9 +1165,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-rust"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6569ea39d9f4d8cafadd0a2a77fc94991f7870d4d3c2a1fa401db9cb02d6082b"
+checksum = "bed06e0f622fb878fc439643f2fd86163223ac33a468beeea96e5d33f79b08b3"
 dependencies = [
  "prettyplease",
  "proc-macro2",

--- a/mint-lock/Cargo.lock
+++ b/mint-lock/Cargo.lock
@@ -1092,9 +1092,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07a2c3aeb3dba21530133f7f1dc533f53d96abff0df6497a5a2fad8f0fbda200"
+checksum = "15263ad07a3e0ec3f2ee3aea83b7c1a0610ad26ba76819f5092afcfaf0f3a3ed"
 dependencies = [
  "serde",
  "serde_json",
@@ -1113,9 +1113,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab66a39d18a5d8ed60df8cb77fc51067ef45a69af3c8fec52b6bc3bf7190351"
+checksum = "73e995a8604a01ec7a8c1e1f60a890981eb00f1cd25c3b15f5194364f27993cc"
 dependencies = [
  "arbitrary",
  "bytes-lit",
@@ -1133,9 +1133,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d92e9fb43bc3ca5180ff7f115156e732817fe27f8328787991c5eb38b30c26c"
+checksum = "c3eda569fe4c3aa2b45f2366e07d9476127e141c7f376d625b6a8217ee99f81f"
 dependencies = [
  "crate-git-revision",
  "darling",
@@ -1153,9 +1153,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f92a657578b121b06a29ab630bf24f02a32327cf9858c474157f0a8c25bfdb2"
+checksum = "87cfbe92fbabaea20517dc76fc89227735ffda2f19a10e2fe96db0ecb19b72b1"
 dependencies = [
  "base64 0.13.1",
  "stellar-xdr",
@@ -1165,9 +1165,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-rust"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7d95644321515640288dae87e71264ed070454c22b6bdf3527423dcaccdfff0"
+checksum = "6569ea39d9f4d8cafadd0a2a77fc94991f7870d4d3c2a1fa401db9cb02d6082b"
 dependencies = [
  "prettyplease",
  "proc-macro2",

--- a/mint-lock/Cargo.toml
+++ b/mint-lock/Cargo.toml
@@ -9,10 +9,10 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = { version = "21.7.1" }
+soroban-sdk = { version = "21.7.4" }
 
 [dev-dependencies]
-soroban-sdk = { version = "21.7.1", features = ["testutils"] }
+soroban-sdk = { version = "21.7.4", features = ["testutils"] }
 
 [profile.release]
 opt-level = "z"

--- a/mint-lock/Cargo.toml
+++ b/mint-lock/Cargo.toml
@@ -9,10 +9,10 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = { version = "21.6.0" }
+soroban-sdk = { version = "21.7.1" }
 
 [dev-dependencies]
-soroban-sdk = { version = "21.6.0", features = ["testutils"] }
+soroban-sdk = { version = "21.7.1", features = ["testutils"] }
 
 [profile.release]
 opt-level = "z"

--- a/mint-lock/Makefile
+++ b/mint-lock/Makefile
@@ -6,7 +6,7 @@ test: build
 	cargo test
 
 build:
-	soroban contract build
+	stellar contract build
 	@ls -l target/wasm32-unknown-unknown/release/*.wasm
 
 fmt:

--- a/mint-lock/src/lib.rs
+++ b/mint-lock/src/lib.rs
@@ -3,6 +3,7 @@ use soroban_sdk::{
     contract, contractclient, contracterror, contractimpl, contracttype, Address, Env, IntoVal,
 };
 
+#[allow(dead_code)]
 #[contractclient(name = "MintClient")]
 trait MintInterface {
     fn mint(env: Env, to: Address, amount: i128);

--- a/other_custom_types/Cargo.lock
+++ b/other_custom_types/Cargo.lock
@@ -1092,9 +1092,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15263ad07a3e0ec3f2ee3aea83b7c1a0610ad26ba76819f5092afcfaf0f3a3ed"
+checksum = "956476365ff3f9bf429ff23fa11ac75798347a2bfc3c9e5e12638dbe3a6b17a8"
 dependencies = [
  "serde",
  "serde_json",
@@ -1113,9 +1113,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73e995a8604a01ec7a8c1e1f60a890981eb00f1cd25c3b15f5194364f27993cc"
+checksum = "c7767472f00a4053e86d5c37b3c814a6bc01c9230004713328d73d2a3444e72e"
 dependencies = [
  "arbitrary",
  "bytes-lit",
@@ -1133,9 +1133,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3eda569fe4c3aa2b45f2366e07d9476127e141c7f376d625b6a8217ee99f81f"
+checksum = "be8cf8fa10f3ad62509ff7b25cd696fb837da692c40264d1abb393e117aad75c"
 dependencies = [
  "crate-git-revision",
  "darling",
@@ -1153,9 +1153,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cfbe92fbabaea20517dc76fc89227735ffda2f19a10e2fe96db0ecb19b72b1"
+checksum = "12d306f61ef5c1247dca1562e04cc74b6e3adf107631c168b2ce0d5f1cf1fa13"
 dependencies = [
  "base64 0.13.1",
  "stellar-xdr",
@@ -1165,9 +1165,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-rust"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6569ea39d9f4d8cafadd0a2a77fc94991f7870d4d3c2a1fa401db9cb02d6082b"
+checksum = "bed06e0f622fb878fc439643f2fd86163223ac33a468beeea96e5d33f79b08b3"
 dependencies = [
  "prettyplease",
  "proc-macro2",

--- a/other_custom_types/Cargo.lock
+++ b/other_custom_types/Cargo.lock
@@ -1092,9 +1092,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07a2c3aeb3dba21530133f7f1dc533f53d96abff0df6497a5a2fad8f0fbda200"
+checksum = "15263ad07a3e0ec3f2ee3aea83b7c1a0610ad26ba76819f5092afcfaf0f3a3ed"
 dependencies = [
  "serde",
  "serde_json",
@@ -1113,9 +1113,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab66a39d18a5d8ed60df8cb77fc51067ef45a69af3c8fec52b6bc3bf7190351"
+checksum = "73e995a8604a01ec7a8c1e1f60a890981eb00f1cd25c3b15f5194364f27993cc"
 dependencies = [
  "arbitrary",
  "bytes-lit",
@@ -1133,9 +1133,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d92e9fb43bc3ca5180ff7f115156e732817fe27f8328787991c5eb38b30c26c"
+checksum = "c3eda569fe4c3aa2b45f2366e07d9476127e141c7f376d625b6a8217ee99f81f"
 dependencies = [
  "crate-git-revision",
  "darling",
@@ -1153,9 +1153,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f92a657578b121b06a29ab630bf24f02a32327cf9858c474157f0a8c25bfdb2"
+checksum = "87cfbe92fbabaea20517dc76fc89227735ffda2f19a10e2fe96db0ecb19b72b1"
 dependencies = [
  "base64 0.13.1",
  "stellar-xdr",
@@ -1165,9 +1165,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-rust"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7d95644321515640288dae87e71264ed070454c22b6bdf3527423dcaccdfff0"
+checksum = "6569ea39d9f4d8cafadd0a2a77fc94991f7870d4d3c2a1fa401db9cb02d6082b"
 dependencies = [
  "prettyplease",
  "proc-macro2",

--- a/other_custom_types/Cargo.toml
+++ b/other_custom_types/Cargo.toml
@@ -9,10 +9,10 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = { version = "21.7.1" }
+soroban-sdk = { version = "21.7.4" }
 
 [dev-dependencies]
-soroban-sdk = { version = "21.7.1", features = ["testutils"] }
+soroban-sdk = { version = "21.7.4", features = ["testutils"] }
 
 [profile.release]
 opt-level = "z"

--- a/other_custom_types/Cargo.toml
+++ b/other_custom_types/Cargo.toml
@@ -9,10 +9,10 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = { version = "21.6.0" }
+soroban-sdk = { version = "21.7.1" }
 
 [dev-dependencies]
-soroban-sdk = { version = "21.6.0", features = ["testutils"] }
+soroban-sdk = { version = "21.7.1", features = ["testutils"] }
 
 [profile.release]
 opt-level = "z"

--- a/other_custom_types/Makefile
+++ b/other_custom_types/Makefile
@@ -6,7 +6,7 @@ test: build
 	cargo test
 
 build:
-	soroban contract build
+	stellar contract build
 	@ls -l target/wasm32-unknown-unknown/release/*.wasm
 
 fmt:

--- a/simple_account/Cargo.lock
+++ b/simple_account/Cargo.lock
@@ -1229,9 +1229,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15263ad07a3e0ec3f2ee3aea83b7c1a0610ad26ba76819f5092afcfaf0f3a3ed"
+checksum = "956476365ff3f9bf429ff23fa11ac75798347a2bfc3c9e5e12638dbe3a6b17a8"
 dependencies = [
  "serde",
  "serde_json",
@@ -1243,9 +1243,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73e995a8604a01ec7a8c1e1f60a890981eb00f1cd25c3b15f5194364f27993cc"
+checksum = "c7767472f00a4053e86d5c37b3c814a6bc01c9230004713328d73d2a3444e72e"
 dependencies = [
  "arbitrary",
  "bytes-lit",
@@ -1263,9 +1263,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3eda569fe4c3aa2b45f2366e07d9476127e141c7f376d625b6a8217ee99f81f"
+checksum = "be8cf8fa10f3ad62509ff7b25cd696fb837da692c40264d1abb393e117aad75c"
 dependencies = [
  "crate-git-revision",
  "darling",
@@ -1292,9 +1292,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cfbe92fbabaea20517dc76fc89227735ffda2f19a10e2fe96db0ecb19b72b1"
+checksum = "12d306f61ef5c1247dca1562e04cc74b6e3adf107631c168b2ce0d5f1cf1fa13"
 dependencies = [
  "base64 0.13.1",
  "stellar-xdr",
@@ -1304,9 +1304,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-rust"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6569ea39d9f4d8cafadd0a2a77fc94991f7870d4d3c2a1fa401db9cb02d6082b"
+checksum = "bed06e0f622fb878fc439643f2fd86163223ac33a468beeea96e5d33f79b08b3"
 dependencies = [
  "prettyplease",
  "proc-macro2",

--- a/simple_account/Cargo.lock
+++ b/simple_account/Cargo.lock
@@ -1229,9 +1229,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07a2c3aeb3dba21530133f7f1dc533f53d96abff0df6497a5a2fad8f0fbda200"
+checksum = "15263ad07a3e0ec3f2ee3aea83b7c1a0610ad26ba76819f5092afcfaf0f3a3ed"
 dependencies = [
  "serde",
  "serde_json",
@@ -1243,9 +1243,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab66a39d18a5d8ed60df8cb77fc51067ef45a69af3c8fec52b6bc3bf7190351"
+checksum = "73e995a8604a01ec7a8c1e1f60a890981eb00f1cd25c3b15f5194364f27993cc"
 dependencies = [
  "arbitrary",
  "bytes-lit",
@@ -1263,9 +1263,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d92e9fb43bc3ca5180ff7f115156e732817fe27f8328787991c5eb38b30c26c"
+checksum = "c3eda569fe4c3aa2b45f2366e07d9476127e141c7f376d625b6a8217ee99f81f"
 dependencies = [
  "crate-git-revision",
  "darling",
@@ -1292,9 +1292,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f92a657578b121b06a29ab630bf24f02a32327cf9858c474157f0a8c25bfdb2"
+checksum = "87cfbe92fbabaea20517dc76fc89227735ffda2f19a10e2fe96db0ecb19b72b1"
 dependencies = [
  "base64 0.13.1",
  "stellar-xdr",
@@ -1304,9 +1304,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-rust"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7d95644321515640288dae87e71264ed070454c22b6bdf3527423dcaccdfff0"
+checksum = "6569ea39d9f4d8cafadd0a2a77fc94991f7870d4d3c2a1fa401db9cb02d6082b"
 dependencies = [
  "prettyplease",
  "proc-macro2",

--- a/simple_account/Cargo.toml
+++ b/simple_account/Cargo.toml
@@ -9,10 +9,10 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = { version = "21.6.0" }
+soroban-sdk = { version = "21.7.1" }
 
 [dev-dependencies]
-soroban-sdk = { version = "21.6.0", features = ["testutils"] }
+soroban-sdk = { version = "21.7.1", features = ["testutils"] }
 ed25519-dalek = { version = "1.0.1" }
 rand = { version = "0.7.3" }
 

--- a/simple_account/Cargo.toml
+++ b/simple_account/Cargo.toml
@@ -9,10 +9,10 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = { version = "21.7.1" }
+soroban-sdk = { version = "21.7.4" }
 
 [dev-dependencies]
-soroban-sdk = { version = "21.7.1", features = ["testutils"] }
+soroban-sdk = { version = "21.7.4", features = ["testutils"] }
 ed25519-dalek = { version = "1.0.1" }
 rand = { version = "0.7.3" }
 

--- a/simple_account/Makefile
+++ b/simple_account/Makefile
@@ -6,7 +6,7 @@ test: build
 	cargo test
 
 build:
-	soroban contract build
+	stellar contract build
 	@ls -l target/wasm32-unknown-unknown/release/*.wasm
 
 fmt:

--- a/single_offer/Cargo.lock
+++ b/single_offer/Cargo.lock
@@ -1092,9 +1092,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07a2c3aeb3dba21530133f7f1dc533f53d96abff0df6497a5a2fad8f0fbda200"
+checksum = "15263ad07a3e0ec3f2ee3aea83b7c1a0610ad26ba76819f5092afcfaf0f3a3ed"
 dependencies = [
  "serde",
  "serde_json",
@@ -1106,9 +1106,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab66a39d18a5d8ed60df8cb77fc51067ef45a69af3c8fec52b6bc3bf7190351"
+checksum = "73e995a8604a01ec7a8c1e1f60a890981eb00f1cd25c3b15f5194364f27993cc"
 dependencies = [
  "arbitrary",
  "bytes-lit",
@@ -1126,9 +1126,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d92e9fb43bc3ca5180ff7f115156e732817fe27f8328787991c5eb38b30c26c"
+checksum = "c3eda569fe4c3aa2b45f2366e07d9476127e141c7f376d625b6a8217ee99f81f"
 dependencies = [
  "crate-git-revision",
  "darling",
@@ -1153,9 +1153,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f92a657578b121b06a29ab630bf24f02a32327cf9858c474157f0a8c25bfdb2"
+checksum = "87cfbe92fbabaea20517dc76fc89227735ffda2f19a10e2fe96db0ecb19b72b1"
 dependencies = [
  "base64 0.13.1",
  "stellar-xdr",
@@ -1165,9 +1165,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-rust"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7d95644321515640288dae87e71264ed070454c22b6bdf3527423dcaccdfff0"
+checksum = "6569ea39d9f4d8cafadd0a2a77fc94991f7870d4d3c2a1fa401db9cb02d6082b"
 dependencies = [
  "prettyplease",
  "proc-macro2",

--- a/single_offer/Cargo.lock
+++ b/single_offer/Cargo.lock
@@ -1092,9 +1092,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15263ad07a3e0ec3f2ee3aea83b7c1a0610ad26ba76819f5092afcfaf0f3a3ed"
+checksum = "956476365ff3f9bf429ff23fa11ac75798347a2bfc3c9e5e12638dbe3a6b17a8"
 dependencies = [
  "serde",
  "serde_json",
@@ -1106,9 +1106,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73e995a8604a01ec7a8c1e1f60a890981eb00f1cd25c3b15f5194364f27993cc"
+checksum = "c7767472f00a4053e86d5c37b3c814a6bc01c9230004713328d73d2a3444e72e"
 dependencies = [
  "arbitrary",
  "bytes-lit",
@@ -1126,9 +1126,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3eda569fe4c3aa2b45f2366e07d9476127e141c7f376d625b6a8217ee99f81f"
+checksum = "be8cf8fa10f3ad62509ff7b25cd696fb837da692c40264d1abb393e117aad75c"
 dependencies = [
  "crate-git-revision",
  "darling",
@@ -1153,9 +1153,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cfbe92fbabaea20517dc76fc89227735ffda2f19a10e2fe96db0ecb19b72b1"
+checksum = "12d306f61ef5c1247dca1562e04cc74b6e3adf107631c168b2ce0d5f1cf1fa13"
 dependencies = [
  "base64 0.13.1",
  "stellar-xdr",
@@ -1165,9 +1165,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-rust"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6569ea39d9f4d8cafadd0a2a77fc94991f7870d4d3c2a1fa401db9cb02d6082b"
+checksum = "bed06e0f622fb878fc439643f2fd86163223ac33a468beeea96e5d33f79b08b3"
 dependencies = [
  "prettyplease",
  "proc-macro2",

--- a/single_offer/Cargo.toml
+++ b/single_offer/Cargo.toml
@@ -8,10 +8,10 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
-soroban-sdk = { version = "21.6.0" }
+soroban-sdk = { version = "21.7.1" }
 
 [dev-dependencies]
-soroban-sdk = { version = "21.6.0", features = ["testutils"] }
+soroban-sdk = { version = "21.7.1", features = ["testutils"] }
 
 [profile.release]
 opt-level = "z"
@@ -26,4 +26,3 @@ lto = true
 [profile.release-with-logs]
 inherits = "release"
 debug-assertions = true
-

--- a/single_offer/Cargo.toml
+++ b/single_offer/Cargo.toml
@@ -8,10 +8,10 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
-soroban-sdk = { version = "21.7.1" }
+soroban-sdk = { version = "21.7.4" }
 
 [dev-dependencies]
-soroban-sdk = { version = "21.7.1", features = ["testutils"] }
+soroban-sdk = { version = "21.7.4", features = ["testutils"] }
 
 [profile.release]
 opt-level = "z"

--- a/single_offer/Makefile
+++ b/single_offer/Makefile
@@ -6,7 +6,7 @@ test: build
 	cargo test
 
 build:
-	soroban contract build
+	stellar contract build
 	@ls -l target/wasm32-unknown-unknown/release/*.wasm
 
 fmt:

--- a/timelock/Cargo.lock
+++ b/timelock/Cargo.lock
@@ -1092,9 +1092,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07a2c3aeb3dba21530133f7f1dc533f53d96abff0df6497a5a2fad8f0fbda200"
+checksum = "15263ad07a3e0ec3f2ee3aea83b7c1a0610ad26ba76819f5092afcfaf0f3a3ed"
 dependencies = [
  "serde",
  "serde_json",
@@ -1106,9 +1106,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab66a39d18a5d8ed60df8cb77fc51067ef45a69af3c8fec52b6bc3bf7190351"
+checksum = "73e995a8604a01ec7a8c1e1f60a890981eb00f1cd25c3b15f5194364f27993cc"
 dependencies = [
  "arbitrary",
  "bytes-lit",
@@ -1126,9 +1126,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d92e9fb43bc3ca5180ff7f115156e732817fe27f8328787991c5eb38b30c26c"
+checksum = "c3eda569fe4c3aa2b45f2366e07d9476127e141c7f376d625b6a8217ee99f81f"
 dependencies = [
  "crate-git-revision",
  "darling",
@@ -1146,9 +1146,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f92a657578b121b06a29ab630bf24f02a32327cf9858c474157f0a8c25bfdb2"
+checksum = "87cfbe92fbabaea20517dc76fc89227735ffda2f19a10e2fe96db0ecb19b72b1"
 dependencies = [
  "base64 0.13.1",
  "stellar-xdr",
@@ -1158,9 +1158,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-rust"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7d95644321515640288dae87e71264ed070454c22b6bdf3527423dcaccdfff0"
+checksum = "6569ea39d9f4d8cafadd0a2a77fc94991f7870d4d3c2a1fa401db9cb02d6082b"
 dependencies = [
  "prettyplease",
  "proc-macro2",

--- a/timelock/Cargo.lock
+++ b/timelock/Cargo.lock
@@ -1092,9 +1092,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15263ad07a3e0ec3f2ee3aea83b7c1a0610ad26ba76819f5092afcfaf0f3a3ed"
+checksum = "956476365ff3f9bf429ff23fa11ac75798347a2bfc3c9e5e12638dbe3a6b17a8"
 dependencies = [
  "serde",
  "serde_json",
@@ -1106,9 +1106,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73e995a8604a01ec7a8c1e1f60a890981eb00f1cd25c3b15f5194364f27993cc"
+checksum = "c7767472f00a4053e86d5c37b3c814a6bc01c9230004713328d73d2a3444e72e"
 dependencies = [
  "arbitrary",
  "bytes-lit",
@@ -1126,9 +1126,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3eda569fe4c3aa2b45f2366e07d9476127e141c7f376d625b6a8217ee99f81f"
+checksum = "be8cf8fa10f3ad62509ff7b25cd696fb837da692c40264d1abb393e117aad75c"
 dependencies = [
  "crate-git-revision",
  "darling",
@@ -1146,9 +1146,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cfbe92fbabaea20517dc76fc89227735ffda2f19a10e2fe96db0ecb19b72b1"
+checksum = "12d306f61ef5c1247dca1562e04cc74b6e3adf107631c168b2ce0d5f1cf1fa13"
 dependencies = [
  "base64 0.13.1",
  "stellar-xdr",
@@ -1158,9 +1158,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-rust"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6569ea39d9f4d8cafadd0a2a77fc94991f7870d4d3c2a1fa401db9cb02d6082b"
+checksum = "bed06e0f622fb878fc439643f2fd86163223ac33a468beeea96e5d33f79b08b3"
 dependencies = [
  "prettyplease",
  "proc-macro2",

--- a/timelock/Cargo.toml
+++ b/timelock/Cargo.toml
@@ -9,10 +9,10 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = { version = "21.7.1" }
+soroban-sdk = { version = "21.7.4" }
 
 [dev-dependencies]
-soroban-sdk = { version = "21.7.1", features = ["testutils"] }
+soroban-sdk = { version = "21.7.4", features = ["testutils"] }
 
 [profile.release]
 opt-level = "z"

--- a/timelock/Cargo.toml
+++ b/timelock/Cargo.toml
@@ -9,10 +9,10 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = { version = "21.6.0" }
+soroban-sdk = { version = "21.7.1" }
 
 [dev-dependencies]
-soroban-sdk = { version = "21.6.0", features = ["testutils"] }
+soroban-sdk = { version = "21.7.1", features = ["testutils"] }
 
 [profile.release]
 opt-level = "z"

--- a/timelock/Makefile
+++ b/timelock/Makefile
@@ -6,7 +6,7 @@ test: build
 	cargo test
 
 build:
-	soroban contract build
+	stellar contract build
 	@ls -l target/wasm32-unknown-unknown/release/*.wasm
 
 fmt:

--- a/token/Cargo.lock
+++ b/token/Cargo.lock
@@ -1092,9 +1092,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15263ad07a3e0ec3f2ee3aea83b7c1a0610ad26ba76819f5092afcfaf0f3a3ed"
+checksum = "956476365ff3f9bf429ff23fa11ac75798347a2bfc3c9e5e12638dbe3a6b17a8"
 dependencies = [
  "serde",
  "serde_json",
@@ -1106,9 +1106,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73e995a8604a01ec7a8c1e1f60a890981eb00f1cd25c3b15f5194364f27993cc"
+checksum = "c7767472f00a4053e86d5c37b3c814a6bc01c9230004713328d73d2a3444e72e"
 dependencies = [
  "arbitrary",
  "bytes-lit",
@@ -1126,9 +1126,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3eda569fe4c3aa2b45f2366e07d9476127e141c7f376d625b6a8217ee99f81f"
+checksum = "be8cf8fa10f3ad62509ff7b25cd696fb837da692c40264d1abb393e117aad75c"
 dependencies = [
  "crate-git-revision",
  "darling",
@@ -1146,9 +1146,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cfbe92fbabaea20517dc76fc89227735ffda2f19a10e2fe96db0ecb19b72b1"
+checksum = "12d306f61ef5c1247dca1562e04cc74b6e3adf107631c168b2ce0d5f1cf1fa13"
 dependencies = [
  "base64 0.13.1",
  "stellar-xdr",
@@ -1158,9 +1158,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-rust"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6569ea39d9f4d8cafadd0a2a77fc94991f7870d4d3c2a1fa401db9cb02d6082b"
+checksum = "bed06e0f622fb878fc439643f2fd86163223ac33a468beeea96e5d33f79b08b3"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -1182,9 +1182,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-token-sdk"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43ede9e8dc3e3590cdc7be4829248fb0db9ce8fe1fb8f9e15833425dc0e5f6da"
+checksum = "cc6820708e02fae047679562237c6a0220f411d943312537c03c238edabba84e"
 dependencies = [
  "soroban-sdk",
 ]

--- a/token/Cargo.lock
+++ b/token/Cargo.lock
@@ -1092,9 +1092,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07a2c3aeb3dba21530133f7f1dc533f53d96abff0df6497a5a2fad8f0fbda200"
+checksum = "15263ad07a3e0ec3f2ee3aea83b7c1a0610ad26ba76819f5092afcfaf0f3a3ed"
 dependencies = [
  "serde",
  "serde_json",
@@ -1106,9 +1106,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab66a39d18a5d8ed60df8cb77fc51067ef45a69af3c8fec52b6bc3bf7190351"
+checksum = "73e995a8604a01ec7a8c1e1f60a890981eb00f1cd25c3b15f5194364f27993cc"
 dependencies = [
  "arbitrary",
  "bytes-lit",
@@ -1126,9 +1126,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d92e9fb43bc3ca5180ff7f115156e732817fe27f8328787991c5eb38b30c26c"
+checksum = "c3eda569fe4c3aa2b45f2366e07d9476127e141c7f376d625b6a8217ee99f81f"
 dependencies = [
  "crate-git-revision",
  "darling",
@@ -1146,9 +1146,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f92a657578b121b06a29ab630bf24f02a32327cf9858c474157f0a8c25bfdb2"
+checksum = "87cfbe92fbabaea20517dc76fc89227735ffda2f19a10e2fe96db0ecb19b72b1"
 dependencies = [
  "base64 0.13.1",
  "stellar-xdr",
@@ -1158,9 +1158,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-rust"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7d95644321515640288dae87e71264ed070454c22b6bdf3527423dcaccdfff0"
+checksum = "6569ea39d9f4d8cafadd0a2a77fc94991f7870d4d3c2a1fa401db9cb02d6082b"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -1182,9 +1182,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-token-sdk"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e879bfcb7d00ac9c0f91ba65babd6dde713037181df13b2163fafd1e3edf271"
+checksum = "43ede9e8dc3e3590cdc7be4829248fb0db9ce8fe1fb8f9e15833425dc0e5f6da"
 dependencies = [
  "soroban-sdk",
 ]

--- a/token/Cargo.toml
+++ b/token/Cargo.toml
@@ -8,11 +8,11 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-soroban-sdk = { version = "21.6.0" }
-soroban-token-sdk = { version = "21.6.0" }
+soroban-sdk = { version = "21.7.1" }
+soroban-token-sdk = { version = "21.7.1" }
 
 [dev-dependencies]
-soroban-sdk = { version = "21.6.0", features = ["testutils"] }
+soroban-sdk = { version = "21.7.1", features = ["testutils"] }
 
 [profile.release]
 opt-level = "z"

--- a/token/Cargo.toml
+++ b/token/Cargo.toml
@@ -8,11 +8,11 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-soroban-sdk = { version = "21.7.1" }
-soroban-token-sdk = { version = "21.7.1" }
+soroban-sdk = { version = "21.7.4" }
+soroban-token-sdk = { version = "21.7.4" }
 
 [dev-dependencies]
-soroban-sdk = { version = "21.7.1", features = ["testutils"] }
+soroban-sdk = { version = "21.7.4", features = ["testutils"] }
 
 [profile.release]
 opt-level = "z"

--- a/token/Makefile
+++ b/token/Makefile
@@ -6,7 +6,7 @@ test: build
 	cargo test
 
 build:
-	soroban contract build
+	stellar contract build
 	@ls -l target/wasm32-unknown-unknown/release/*.wasm
 
 fmt:

--- a/ttl/Cargo.lock
+++ b/ttl/Cargo.lock
@@ -1092,9 +1092,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07a2c3aeb3dba21530133f7f1dc533f53d96abff0df6497a5a2fad8f0fbda200"
+checksum = "15263ad07a3e0ec3f2ee3aea83b7c1a0610ad26ba76819f5092afcfaf0f3a3ed"
 dependencies = [
  "serde",
  "serde_json",
@@ -1106,9 +1106,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab66a39d18a5d8ed60df8cb77fc51067ef45a69af3c8fec52b6bc3bf7190351"
+checksum = "73e995a8604a01ec7a8c1e1f60a890981eb00f1cd25c3b15f5194364f27993cc"
 dependencies = [
  "arbitrary",
  "bytes-lit",
@@ -1126,9 +1126,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d92e9fb43bc3ca5180ff7f115156e732817fe27f8328787991c5eb38b30c26c"
+checksum = "c3eda569fe4c3aa2b45f2366e07d9476127e141c7f376d625b6a8217ee99f81f"
 dependencies = [
  "crate-git-revision",
  "darling",
@@ -1146,9 +1146,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f92a657578b121b06a29ab630bf24f02a32327cf9858c474157f0a8c25bfdb2"
+checksum = "87cfbe92fbabaea20517dc76fc89227735ffda2f19a10e2fe96db0ecb19b72b1"
 dependencies = [
  "base64 0.13.1",
  "stellar-xdr",
@@ -1158,9 +1158,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-rust"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7d95644321515640288dae87e71264ed070454c22b6bdf3527423dcaccdfff0"
+checksum = "6569ea39d9f4d8cafadd0a2a77fc94991f7870d4d3c2a1fa401db9cb02d6082b"
 dependencies = [
  "prettyplease",
  "proc-macro2",

--- a/ttl/Cargo.lock
+++ b/ttl/Cargo.lock
@@ -1092,9 +1092,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15263ad07a3e0ec3f2ee3aea83b7c1a0610ad26ba76819f5092afcfaf0f3a3ed"
+checksum = "956476365ff3f9bf429ff23fa11ac75798347a2bfc3c9e5e12638dbe3a6b17a8"
 dependencies = [
  "serde",
  "serde_json",
@@ -1106,9 +1106,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73e995a8604a01ec7a8c1e1f60a890981eb00f1cd25c3b15f5194364f27993cc"
+checksum = "c7767472f00a4053e86d5c37b3c814a6bc01c9230004713328d73d2a3444e72e"
 dependencies = [
  "arbitrary",
  "bytes-lit",
@@ -1126,9 +1126,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3eda569fe4c3aa2b45f2366e07d9476127e141c7f376d625b6a8217ee99f81f"
+checksum = "be8cf8fa10f3ad62509ff7b25cd696fb837da692c40264d1abb393e117aad75c"
 dependencies = [
  "crate-git-revision",
  "darling",
@@ -1146,9 +1146,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cfbe92fbabaea20517dc76fc89227735ffda2f19a10e2fe96db0ecb19b72b1"
+checksum = "12d306f61ef5c1247dca1562e04cc74b6e3adf107631c168b2ce0d5f1cf1fa13"
 dependencies = [
  "base64 0.13.1",
  "stellar-xdr",
@@ -1158,9 +1158,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-rust"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6569ea39d9f4d8cafadd0a2a77fc94991f7870d4d3c2a1fa401db9cb02d6082b"
+checksum = "bed06e0f622fb878fc439643f2fd86163223ac33a468beeea96e5d33f79b08b3"
 dependencies = [
  "prettyplease",
  "proc-macro2",

--- a/ttl/Cargo.toml
+++ b/ttl/Cargo.toml
@@ -9,10 +9,10 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = { version = "21.7.1" }
+soroban-sdk = { version = "21.7.4" }
 
 [dev-dependencies]
-soroban-sdk = { version = "21.7.1", features = ["testutils"] }
+soroban-sdk = { version = "21.7.4", features = ["testutils"] }
 
 [profile.release]
 opt-level = "z"

--- a/ttl/Cargo.toml
+++ b/ttl/Cargo.toml
@@ -9,10 +9,10 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = { version = "21.6.0" }
+soroban-sdk = { version = "21.7.1" }
 
 [dev-dependencies]
-soroban-sdk = { version = "21.6.0", features = ["testutils"] }
+soroban-sdk = { version = "21.7.1", features = ["testutils"] }
 
 [profile.release]
 opt-level = "z"

--- a/ttl/Makefile
+++ b/ttl/Makefile
@@ -6,7 +6,7 @@ test: build
 	cargo test
 
 build:
-	soroban contract build
+	stellar contract build
 	@ls -l target/wasm32-unknown-unknown/release/*.wasm
 
 fmt:

--- a/upgradeable_contract/new_contract/Cargo.lock
+++ b/upgradeable_contract/new_contract/Cargo.lock
@@ -1092,9 +1092,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07a2c3aeb3dba21530133f7f1dc533f53d96abff0df6497a5a2fad8f0fbda200"
+checksum = "15263ad07a3e0ec3f2ee3aea83b7c1a0610ad26ba76819f5092afcfaf0f3a3ed"
 dependencies = [
  "serde",
  "serde_json",
@@ -1106,9 +1106,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab66a39d18a5d8ed60df8cb77fc51067ef45a69af3c8fec52b6bc3bf7190351"
+checksum = "73e995a8604a01ec7a8c1e1f60a890981eb00f1cd25c3b15f5194364f27993cc"
 dependencies = [
  "arbitrary",
  "bytes-lit",
@@ -1126,9 +1126,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d92e9fb43bc3ca5180ff7f115156e732817fe27f8328787991c5eb38b30c26c"
+checksum = "c3eda569fe4c3aa2b45f2366e07d9476127e141c7f376d625b6a8217ee99f81f"
 dependencies = [
  "crate-git-revision",
  "darling",
@@ -1146,9 +1146,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f92a657578b121b06a29ab630bf24f02a32327cf9858c474157f0a8c25bfdb2"
+checksum = "87cfbe92fbabaea20517dc76fc89227735ffda2f19a10e2fe96db0ecb19b72b1"
 dependencies = [
  "base64 0.13.1",
  "stellar-xdr",
@@ -1158,9 +1158,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-rust"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7d95644321515640288dae87e71264ed070454c22b6bdf3527423dcaccdfff0"
+checksum = "6569ea39d9f4d8cafadd0a2a77fc94991f7870d4d3c2a1fa401db9cb02d6082b"
 dependencies = [
  "prettyplease",
  "proc-macro2",

--- a/upgradeable_contract/new_contract/Cargo.toml
+++ b/upgradeable_contract/new_contract/Cargo.toml
@@ -9,10 +9,10 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = { version = "21.7.1" }
+soroban-sdk = { version = "21.7.4" }
 
 [dev-dependencies]
-soroban-sdk = { version = "21.7.1", features = ["testutils"] }
+soroban-sdk = { version = "21.7.4", features = ["testutils"] }
 
 [profile.release]
 opt-level = "z"

--- a/upgradeable_contract/new_contract/Cargo.toml
+++ b/upgradeable_contract/new_contract/Cargo.toml
@@ -9,10 +9,10 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = { version = "21.6.0" }
+soroban-sdk = { version = "21.7.1" }
 
 [dev-dependencies]
-soroban-sdk = { version = "21.6.0", features = ["testutils"] }
+soroban-sdk = { version = "21.7.1", features = ["testutils"] }
 
 [profile.release]
 opt-level = "z"

--- a/upgradeable_contract/new_contract/Makefile
+++ b/upgradeable_contract/new_contract/Makefile
@@ -6,7 +6,7 @@ test: build
 	cargo test
 
 build:
-	soroban contract build
+	stellar contract build
 	@ls -l target/wasm32-unknown-unknown/release/*.wasm
 
 fmt:

--- a/upgradeable_contract/old_contract/Cargo.lock
+++ b/upgradeable_contract/old_contract/Cargo.lock
@@ -1092,9 +1092,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07a2c3aeb3dba21530133f7f1dc533f53d96abff0df6497a5a2fad8f0fbda200"
+checksum = "15263ad07a3e0ec3f2ee3aea83b7c1a0610ad26ba76819f5092afcfaf0f3a3ed"
 dependencies = [
  "serde",
  "serde_json",
@@ -1106,9 +1106,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab66a39d18a5d8ed60df8cb77fc51067ef45a69af3c8fec52b6bc3bf7190351"
+checksum = "73e995a8604a01ec7a8c1e1f60a890981eb00f1cd25c3b15f5194364f27993cc"
 dependencies = [
  "arbitrary",
  "bytes-lit",
@@ -1126,9 +1126,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d92e9fb43bc3ca5180ff7f115156e732817fe27f8328787991c5eb38b30c26c"
+checksum = "c3eda569fe4c3aa2b45f2366e07d9476127e141c7f376d625b6a8217ee99f81f"
 dependencies = [
  "crate-git-revision",
  "darling",
@@ -1146,9 +1146,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f92a657578b121b06a29ab630bf24f02a32327cf9858c474157f0a8c25bfdb2"
+checksum = "87cfbe92fbabaea20517dc76fc89227735ffda2f19a10e2fe96db0ecb19b72b1"
 dependencies = [
  "base64 0.13.1",
  "stellar-xdr",
@@ -1158,9 +1158,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-rust"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7d95644321515640288dae87e71264ed070454c22b6bdf3527423dcaccdfff0"
+checksum = "6569ea39d9f4d8cafadd0a2a77fc94991f7870d4d3c2a1fa401db9cb02d6082b"
 dependencies = [
  "prettyplease",
  "proc-macro2",

--- a/upgradeable_contract/old_contract/Cargo.toml
+++ b/upgradeable_contract/old_contract/Cargo.toml
@@ -9,10 +9,10 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = { version = "21.7.1" }
+soroban-sdk = { version = "21.7.4" }
 
 [dev-dependencies]
-soroban-sdk = { version = "21.7.1", features = ["testutils"] }
+soroban-sdk = { version = "21.7.4", features = ["testutils"] }
 
 [profile.release]
 opt-level = "z"

--- a/upgradeable_contract/old_contract/Cargo.toml
+++ b/upgradeable_contract/old_contract/Cargo.toml
@@ -9,10 +9,10 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = { version = "21.6.0" }
+soroban-sdk = { version = "21.7.1" }
 
 [dev-dependencies]
-soroban-sdk = { version = "21.6.0", features = ["testutils"] }
+soroban-sdk = { version = "21.7.1", features = ["testutils"] }
 
 [profile.release]
 opt-level = "z"

--- a/upgradeable_contract/old_contract/Makefile
+++ b/upgradeable_contract/old_contract/Makefile
@@ -7,7 +7,7 @@ test: build
 
 build:
 	$(MAKE) -C ../new_contract || break;
-	soroban contract build
+	stellar contract build
 	@ls -l target/wasm32-unknown-unknown/release/*.wasm
 
 fmt:

--- a/workspace/Cargo.lock
+++ b/workspace/Cargo.lock
@@ -1037,9 +1037,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07a2c3aeb3dba21530133f7f1dc533f53d96abff0df6497a5a2fad8f0fbda200"
+checksum = "15263ad07a3e0ec3f2ee3aea83b7c1a0610ad26ba76819f5092afcfaf0f3a3ed"
 dependencies = [
  "serde",
  "serde_json",
@@ -1051,9 +1051,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab66a39d18a5d8ed60df8cb77fc51067ef45a69af3c8fec52b6bc3bf7190351"
+checksum = "73e995a8604a01ec7a8c1e1f60a890981eb00f1cd25c3b15f5194364f27993cc"
 dependencies = [
  "arbitrary",
  "bytes-lit",
@@ -1071,9 +1071,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d92e9fb43bc3ca5180ff7f115156e732817fe27f8328787991c5eb38b30c26c"
+checksum = "c3eda569fe4c3aa2b45f2366e07d9476127e141c7f376d625b6a8217ee99f81f"
 dependencies = [
  "crate-git-revision",
  "darling",
@@ -1091,9 +1091,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f92a657578b121b06a29ab630bf24f02a32327cf9858c474157f0a8c25bfdb2"
+checksum = "87cfbe92fbabaea20517dc76fc89227735ffda2f19a10e2fe96db0ecb19b72b1"
 dependencies = [
  "base64 0.13.1",
  "stellar-xdr",
@@ -1103,9 +1103,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-rust"
-version = "21.6.0"
+version = "21.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7d95644321515640288dae87e71264ed070454c22b6bdf3527423dcaccdfff0"
+checksum = "6569ea39d9f4d8cafadd0a2a77fc94991f7870d4d3c2a1fa401db9cb02d6082b"
 dependencies = [
  "prettyplease",
  "proc-macro2",

--- a/workspace/Cargo.lock
+++ b/workspace/Cargo.lock
@@ -1037,9 +1037,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15263ad07a3e0ec3f2ee3aea83b7c1a0610ad26ba76819f5092afcfaf0f3a3ed"
+checksum = "956476365ff3f9bf429ff23fa11ac75798347a2bfc3c9e5e12638dbe3a6b17a8"
 dependencies = [
  "serde",
  "serde_json",
@@ -1051,9 +1051,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73e995a8604a01ec7a8c1e1f60a890981eb00f1cd25c3b15f5194364f27993cc"
+checksum = "c7767472f00a4053e86d5c37b3c814a6bc01c9230004713328d73d2a3444e72e"
 dependencies = [
  "arbitrary",
  "bytes-lit",
@@ -1071,9 +1071,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3eda569fe4c3aa2b45f2366e07d9476127e141c7f376d625b6a8217ee99f81f"
+checksum = "be8cf8fa10f3ad62509ff7b25cd696fb837da692c40264d1abb393e117aad75c"
 dependencies = [
  "crate-git-revision",
  "darling",
@@ -1091,9 +1091,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cfbe92fbabaea20517dc76fc89227735ffda2f19a10e2fe96db0ecb19b72b1"
+checksum = "12d306f61ef5c1247dca1562e04cc74b6e3adf107631c168b2ce0d5f1cf1fa13"
 dependencies = [
  "base64 0.13.1",
  "stellar-xdr",
@@ -1103,9 +1103,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-rust"
-version = "21.7.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6569ea39d9f4d8cafadd0a2a77fc94991f7870d4d3c2a1fa401db9cb02d6082b"
+checksum = "bed06e0f622fb878fc439643f2fd86163223ac33a468beeea96e5d33f79b08b3"
 dependencies = [
  "prettyplease",
  "proc-macro2",

--- a/workspace/Cargo.toml
+++ b/workspace/Cargo.toml
@@ -1,17 +1,13 @@
 [workspace]
 resolver = "2"
 
-members = [
-    "contract_a_interface",
-    "contract_a",
-    "contract_b",
-]
+members = ["contract_a_interface", "contract_a", "contract_b"]
 
 [workspace.package]
 version = "0.0.0"
 
 [workspace.dependencies]
-soroban-sdk = { version = "21.6.0" }
+soroban-sdk = { version = "21.7.1" }
 soroban-workspace-contract-a-interface = { path = "contract_a_interface" }
 soroban-workspace-contract-a = { path = "contract_a" }
 

--- a/workspace/Cargo.toml
+++ b/workspace/Cargo.toml
@@ -1,7 +1,11 @@
 [workspace]
 resolver = "2"
 
-members = ["contract_a_interface", "contract_a", "contract_b"]
+members = [
+    "contract_a_interface",
+    "contract_a",
+    "contract_b",
+]
 
 [workspace.package]
 version = "0.0.0"

--- a/workspace/Cargo.toml
+++ b/workspace/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 version = "0.0.0"
 
 [workspace.dependencies]
-soroban-sdk = { version = "21.7.1" }
+soroban-sdk = { version = "21.7.4" }
 soroban-workspace-contract-a-interface = { path = "contract_a_interface" }
 soroban-workspace-contract-a = { path = "contract_a" }
 

--- a/workspace/Makefile
+++ b/workspace/Makefile
@@ -6,7 +6,7 @@ test:
 	cargo test
 
 build:
-	soroban contract build
+	stellar contract build
 	@ls -l target/wasm32-unknown-unknown/release/*.wasm
 
 fmt:


### PR DESCRIPTION
### What


- Software used in Gitpod has been updated
- GitPod now uses the testnet Soroban RPC by default
- Soroban SDK updated to version 21.7.1

### Why

Make the GitPod environment available again. This is very helpful for beginners, as they do not need to configure the environment locally.

### Known limitations

N/A
