### PR TITLE
Remove unnecessary feature use in workspace testutils

### DIFF
--- a/workspace/contract_a/Cargo.toml
+++ b/workspace/contract_a/Cargo.toml
@@ -17,4 +17,4 @@ soroban-workspace-contract-a-interface = { workspace = true }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }
-soroban-workspace-contract-a-interface = { workspace = true, features = ["testutils"] }
+soroban-workspace-contract-a-interface = { workspace = true }

--- a/workspace/contract_b/Cargo.toml
+++ b/workspace/contract_b/Cargo.toml
@@ -14,5 +14,5 @@ soroban-workspace-contract-a-interface = { workspace = true }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }
-soroban-workspace-contract-a-interface = { workspace = true, features = ["testutils"] }
-soroban-workspace-contract-a = { workspace = true, features = ["testutils"] }
+soroban-workspace-contract-a-interface = { workspace = true }
+soroban-workspace-contract-a = { workspace = true }


### PR DESCRIPTION
### What
Remove contgract testutils feature use in workspace.

### Why
Since v21.3.0 there is no need to enable testutils on contracts, since testutils are enabled now for all contracts automatically whenever the SDK has testutils enabled.