### PR TITLE
Disable fail-fast on tests of examples

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -51,6 +51,7 @@ jobs:
   build-and-test:
     needs: dirs
     strategy:
+      fail-fast: false
       matrix:
         working-directory: ${{ fromJSON(needs.dirs.outputs.dirs) }}
         rust: [msrv, latest]

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -36,6 +36,7 @@ jobs:
   fmt:
     needs: dirs
     strategy:
+      fail-fast: false
       matrix:
         working-directory: ${{ fromJSON(needs.dirs.outputs.dirs) }}
     defaults:


### PR DESCRIPTION
### What
Disable fail-fast on tests of examples.

### Why
There are so many contracts, when one breaks, the entire build is in an unknown state because none of the tests complete. It'd be more helpful if we had all the other tests keep running so we know which contracts were broken.

Note that the build has a concurrency limit that prevents a PR from running more than one workflow at once, so this shouldn't cause a runaway many builds to run for a PR.