### PR TITLE
Add ci to check gitpod docker builds

### DIFF
--- a/.github/workflows/gitpod.yml
+++ b/.github/workflows/gitpod.yml
@@ -1,4 +1,4 @@
-name: Rust
+name: Gitpod
 
 on:
   push:

--- a/.github/workflows/gitpod.yml
+++ b/.github/workflows/gitpod.yml
@@ -1,0 +1,26 @@
+name: Rust
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_protected == 'true' && github.sha || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+
+  complete:
+    if: always()
+    needs: [build-image]
+    runs-on: ubuntu-latest
+    steps:
+    - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+      run: exit 1
+
+  build-image:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - run: docker build -f .gitpod.Dockerfile .


### PR DESCRIPTION
### What
Add ci to check gitpod docker builds

### Why
It recently broke and we should check the image builds, and that's a simple thing we can do to improve it's stability.