### PR TITLE
Remove logging from increment example

### DIFF
--- a/increment/src/test.rs
+++ b/increment/src/test.rs
@@ -1,9 +1,6 @@
 #![cfg(test)]
-
-use super::{IncrementContract, IncrementContractClient};
-use soroban_sdk::{testutils::Logs, Env};
-
-extern crate std;
+use crate::{IncrementContract, IncrementContractClient};
+use soroban_sdk::Env;
 
 #[test]
 fn test() {
@@ -14,6 +11,4 @@ fn test() {
     assert_eq!(client.increment(), 1);
     assert_eq!(client.increment(), 2);
     assert_eq!(client.increment(), 3);
-
-    std::println!("{}", env.logs().all().join("\n"));
 }


### PR DESCRIPTION
### What

Remove logging from increment example.

### Why

It's additional noise that doesn't add much value to what is otherwise a very simple contract.

Logging is demonstrated in the developer docs in other places where there is relevant context.