### PR TITLE
Handle when rustup is not in the GitPod image

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -2,7 +2,7 @@ FROM gitpod/workspace-full:latest
 
 # Remove the existing rustup installation before updating due to:
 # https://github.com/gitpod-io/workspace-images/issues/933#issuecomment-1272616892
-RUN rustup self uninstall -y
+RUN rustup self uninstall -y || true
 RUN rm -rf .rustup
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain none -y
 


### PR DESCRIPTION
### What
Add failure tolerance to rustup uninstall command in Gitpod Dockerfile.

### Why
Prevents build failures when rustup is not already installed in the GitPod base image, which seems to change over time. It recently seemed to be removed calling an image build failure:
- https://github.com/stellar/soroban-examples/actions/runs/13535208424/job/37825492942?pr=366