### PR TITLE
Use new stellar-xdr auth functionality for iterating auths

### DIFF
--- a/multisig_1_of_n_account/stellar-cli-sign-auth-ed25519/Cargo.lock
+++ b/multisig_1_of_n_account/stellar-cli-sign-auth-ed25519/Cargo.lock
@@ -713,20 +713,18 @@ dependencies = [
 
 [[package]]
 name = "stellar-strkey"
-version = "0.0.9"
+version = "0.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e3aa3ed00e70082cb43febc1c2afa5056b9bb3e348bbb43d0cd0aa88a611144"
+checksum = "ee1832fb50c651ad10f734aaf5d31ca5acdfb197a6ecda64d93fcdb8885af913"
 dependencies = [
  "crate-git-revision",
  "data-encoding",
- "thiserror",
 ]
 
 [[package]]
 name = "stellar-xdr"
-version = "22.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e09ea07e51f4123d8142f9b9f6924691413abfcba4ab642b333e795782c0141"
+version = "22.1.0"
+source = "git+https://github.com/stellar/rs-stellar-xdr?branch=authsiter#87d5e893178458bc2b054b7cf128b584142ab872"
 dependencies = [
  "base64 0.13.1",
  "crate-git-revision",
@@ -758,26 +756,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/multisig_1_of_n_account/stellar-cli-sign-auth-ed25519/Cargo.toml
+++ b/multisig_1_of_n_account/stellar-cli-sign-auth-ed25519/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-stellar-xdr = { version = "22.2.0", features = ["base64", "serde"] }
+stellar-xdr = { version = "*", features = ["base64", "serde"], git = "https://github.com/stellar/rs-stellar-xdr", branch = "authsiter" }
 serde_json = "1.0.140"
 ed25519-dalek = { version = "1.0.1" }
 hex = "0.4.3"


### PR DESCRIPTION
### What
Use the functionality being added to stellar-xdr for iterating over auths buried in a transaction instead of doing so manually.

### Why
Example usage of the new functionality being added in:
- 