### PR TITLE
Update target and rust version in rust-toolchain

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -9,7 +9,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
     SCCACHE_DIRECT=true \
     RUSTC_WRAPPER=sccache \
     SCCACHE_CACHE_SIZE=5G \
-    RUST_VERSION=1.81
+    RUST_VERSION=1.85
 
 RUN apt-get update && apt-get install -y \
   libdbus-1-dev \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -27,7 +27,7 @@
 	"ghcr.io/devcontainers/features/rust:1.3.1": {
 	  "targets": "wasm32v1-none",
 	  "profile": "default",
-	  "version": "1.81"
+	  "version": "1.85"
 	},
 	"ghcr.io/devcontainers-extra/features/gh-release:1.0.25": {
 	  "repo": "stellar/stellar-cli",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -25,7 +25,7 @@
 	  "configureZshAsDefaultShell": true
 	},
 	"ghcr.io/devcontainers/features/rust:1.3.1": {
-	  "targets": "wasm32-unknown-unknown",
+	  "targets": "wasm32v1-none",
 	  "profile": "default",
 	  "version": "1.81"
 	},

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -91,7 +91,11 @@ jobs:
     - run: rustup update
     - run: cargo version
     - run: rustup target add ${{ matrix.sys.target }}
-    - run: rustup target add wasm32v1-none
+    - if: matrix.rust != 'msrv'
+      run: rustup target add wasm32v1-none
+    - if: matrix.rust == 'msrv'
+      run: rustup target add wasm32-unknown-unknown
+
 
     # Setup Deno
     - uses: denoland/setup-deno@909cc5acb0fdd60627fb858598759246509fa755 # v2.0.2

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -91,10 +91,7 @@ jobs:
     - run: rustup update
     - run: cargo version
     - run: rustup target add ${{ matrix.sys.target }}
-    - if: matrix.rust != 'msrv'
-      run: rustup target add wasm32v1-none
-    - if: matrix.rust == 'msrv'
-      run: rustup target add wasm32-unknown-unknown
+    - run: rustup target add wasm32v1-none
 
 
     # Setup Deno

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -99,7 +99,7 @@ jobs:
         deno-version: v2.x
 
     # Setup Stellar CLI
-    - uses: stellar/stellar-cli@v22.8.0
+    - uses: stellar/stellar-cli@v23.0.0
 
     # Build and Test
     - run: make test

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -91,7 +91,7 @@ jobs:
     - run: rustup update
     - run: cargo version
     - run: rustup target add ${{ matrix.sys.target }}
-    - run: rustup target add wasm32-unknown-unknown
+    - run: rustup target add wasm32v1-none
 
     # Setup Deno
     - uses: denoland/setup-deno@909cc5acb0fdd60627fb858598759246509fa755 # v2.0.2

--- a/README.md
+++ b/README.md
@@ -112,14 +112,14 @@ cd increment
 stellar contract build
 ```
 
-A `.wasm` file will be outputted in the target directory, at `target/wasm32-unknown-unknown/release/soroban_increment_contract.wasm`. The `.wasm` file is the built contract.
+A `.wasm` file will be outputted in the target directory, at `target/wasm32v1-none/release/soroban_increment_contract.wasm`. The `.wasm` file is the built contract.
 
 #### Deploy
 The WASM file can now be deployed to the testnet by running this command:
 
 ```
 stellar contract deploy \
-  --wasm target/wasm32-unknown-unknown/release/soroban_increment_contract.wasm \
+  --wasm target/wasm32v1-none/release/soroban_increment_contract.wasm \
   --source alice \
   --network testnet \
   --alias increment_contract

--- a/account/Cargo.toml
+++ b/account/Cargo.toml
@@ -3,7 +3,7 @@ name = "soroban-account-contract"
 version = "0.0.0"
 edition = "2021"
 publish = false
-rust-version = "1.80.0"
+rust-version = "1.85.0"
 
 [lib]
 crate-type = ["cdylib"]

--- a/account/Makefile
+++ b/account/Makefile
@@ -7,7 +7,7 @@ test: build
 
 build:
 	stellar contract build
-	@ls -l target/wasm32-unknown-unknown/release/*.wasm
+	@ls -l target/wasm32v1-none/release/*.wasm
 
 fmt:
 	cargo fmt --all

--- a/account/Makefile
+++ b/account/Makefile
@@ -7,7 +7,12 @@ test: build
 
 build:
 	stellar contract build
-	@ls -l target/wasm32v1-none/release/*.wasm || ls -l target/wasm32-unknown-unknown/release/*.wasm
+	@RUST_VERSION=$$(rustc --version | cut -d' ' -f2); \
+	if [ "$$(printf '%s\n%s\n' $$RUST_VERSION 1.81.0 | sort -V | head -n1)" = "1.81.0" ]; then \
+		ls -l target/wasm32v1-none/release/*.wasm; \
+	else \
+		ls -l target/wasm32-unknown-unknown/release/*.wasm; \
+	fi
 
 fmt:
 	cargo fmt --all

--- a/account/Makefile
+++ b/account/Makefile
@@ -7,7 +7,7 @@ test: build
 
 build:
 	stellar contract build
-	@ls -l target/wasm32v1-none/release/*.wasm
+	@ls -l target/wasm32v1-none/release/*.wasm || ls -l target/wasm32-unknown-unknown/release/*.wasm
 
 fmt:
 	cargo fmt --all

--- a/account/Makefile
+++ b/account/Makefile
@@ -7,12 +7,7 @@ test: build
 
 build:
 	stellar contract build
-	@RUST_VERSION=$$(rustc --version | cut -d' ' -f2); \
-	if [ "$$(printf '%s\n%s\n' $$RUST_VERSION 1.81.0 | sort -V | head -n1)" = "1.81.0" ]; then \
-		ls -l target/wasm32v1-none/release/*.wasm; \
-	else \
-		ls -l target/wasm32-unknown-unknown/release/*.wasm; \
-	fi
+	@ls -l target/wasm32v1-none/release/*.wasm
 
 fmt:
 	cargo fmt --all

--- a/alloc/Cargo.lock
+++ b/alloc/Cargo.lock
@@ -1158,9 +1158,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "22.0.7"
+version = "22.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80bbe59497cb50e81861187e6bd2a2c805df253573d44ed56e7d373f79530758"
+checksum = "2826e2c9d364edbb2ea112dc861077c74557bdad0a7a00487969088c7c648169"
 dependencies = [
  "serde",
  "serde_json",
@@ -1172,9 +1172,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "22.0.7"
+version = "22.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c85edd55eb09aa5dd7ba5ab595d2be7ac3f453e90e2f26d704ff26c130f2926f"
+checksum = "c7ac27d7573e62b745513fa1be8dab7a09b9676a7f39db97164f1d458a344749"
 dependencies = [
  "arbitrary",
  "bytes-lit",
@@ -1194,9 +1194,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "22.0.7"
+version = "22.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a141230aa65006d4b3eeee9d0589172d734a2abfbe15b84670e38e76e200b370"
+checksum = "9ef0d7d62b2584696d306b8766728971c7d0731a03a5e047f1fc68722ac8cf0c"
 dependencies = [
  "crate-git-revision",
  "darling",
@@ -1214,9 +1214,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec"
-version = "22.0.7"
+version = "22.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b54326e9516b33be99c701b37242b27efb8e66cc1f1eff994b9d9a013a4be136"
+checksum = "a4ad0867aec99770ed614fedbec7ac4591791df162ff9e548ab7ebd07cd23a9c"
 dependencies = [
  "base64 0.13.1",
  "stellar-xdr",
@@ -1226,9 +1226,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-rust"
-version = "22.0.7"
+version = "22.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f009cab4dfd653bc94a06c5022f1ca9d30e198b0e451f84cf307231563d11de2"
+checksum = "aebe31c042adfa2885ec47b67b08fcead8707da80a3fe737eaf2a9ae1a8cfdc3"
 dependencies = [
  "prettyplease",
  "proc-macro2",

--- a/alloc/Cargo.toml
+++ b/alloc/Cargo.toml
@@ -10,10 +10,10 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = { version = "22.0.7", features = ["alloc"] }
+soroban-sdk = { version = "22.0.8", features = ["alloc"] }
 
 [dev-dependencies]
-soroban-sdk = { version = "22.0.7", features = ["testutils", "alloc"] }
+soroban-sdk = { version = "22.0.8", features = ["testutils", "alloc"] }
 
 [profile.release]
 opt-level = "z"

--- a/alloc/Cargo.toml
+++ b/alloc/Cargo.toml
@@ -3,7 +3,7 @@ name = "soroban-alloc-contract"
 version = "0.0.0"
 edition = "2021"
 publish = false
-rust-version = "1.80.0"
+rust-version = "1.85.0"
 
 [lib]
 crate-type = ["cdylib"]

--- a/alloc/Makefile
+++ b/alloc/Makefile
@@ -7,7 +7,7 @@ test: build
 
 build:
 	stellar contract build
-	@ls -l target/wasm32-unknown-unknown/release/*.wasm
+	@ls -l target/wasm32v1-none/release/*.wasm
 
 fmt:
 	cargo fmt --all

--- a/alloc/Makefile
+++ b/alloc/Makefile
@@ -7,7 +7,12 @@ test: build
 
 build:
 	stellar contract build
-	@ls -l target/wasm32v1-none/release/*.wasm
+	@RUST_VERSION=$$(rustc --version | cut -d' ' -f2); \
+	if [ "$$(printf '%s\n%s\n' $$RUST_VERSION 1.81.0 | sort -V | head -n1)" = "1.81.0" ]; then \
+		ls -l target/wasm32v1-none/release/*.wasm; \
+	else \
+		ls -l target/wasm32-unknown-unknown/release/*.wasm; \
+	fi
 
 fmt:
 	cargo fmt --all

--- a/alloc/Makefile
+++ b/alloc/Makefile
@@ -7,12 +7,7 @@ test: build
 
 build:
 	stellar contract build
-	@RUST_VERSION=$$(rustc --version | cut -d' ' -f2); \
-	if [ "$$(printf '%s\n%s\n' $$RUST_VERSION 1.81.0 | sort -V | head -n1)" = "1.81.0" ]; then \
-		ls -l target/wasm32v1-none/release/*.wasm; \
-	else \
-		ls -l target/wasm32-unknown-unknown/release/*.wasm; \
-	fi
+	@ls -l target/wasm32v1-none/release/*.wasm
 
 fmt:
 	cargo fmt --all

--- a/atomic_multiswap/Cargo.toml
+++ b/atomic_multiswap/Cargo.toml
@@ -3,7 +3,7 @@ name = "soroban-atomic-multiswap-contract"
 version = "0.0.0"
 edition = "2021"
 publish = false
-rust-version = "1.80.0"
+rust-version = "1.85.0"
 
 [lib]
 crate-type = ["cdylib"]

--- a/atomic_multiswap/Makefile
+++ b/atomic_multiswap/Makefile
@@ -8,7 +8,12 @@ test: build
 build:
 	$(MAKE) -C ../atomic_swap || break; 
 	stellar contract build
-	@ls -l target/wasm32v1-none/release/*.wasm
+	@RUST_VERSION=$$(rustc --version | cut -d' ' -f2); \
+	if [ "$$(printf '%s\n%s\n' $$RUST_VERSION 1.81.0 | sort -V | head -n1)" = "1.81.0" ]; then \
+		ls -l target/wasm32v1-none/release/*.wasm; \
+	else \
+		ls -l target/wasm32-unknown-unknown/release/*.wasm; \
+	fi
 
 fmt:
 	cargo fmt --all

--- a/atomic_multiswap/Makefile
+++ b/atomic_multiswap/Makefile
@@ -8,12 +8,7 @@ test: build
 build:
 	$(MAKE) -C ../atomic_swap || break; 
 	stellar contract build
-	@RUST_VERSION=$$(rustc --version | cut -d' ' -f2); \
-	if [ "$$(printf '%s\n%s\n' $$RUST_VERSION 1.81.0 | sort -V | head -n1)" = "1.81.0" ]; then \
-		ls -l target/wasm32v1-none/release/*.wasm; \
-	else \
-		ls -l target/wasm32-unknown-unknown/release/*.wasm; \
-	fi
+	@ls -l target/wasm32v1-none/release/*.wasm
 
 fmt:
 	cargo fmt --all

--- a/atomic_multiswap/Makefile
+++ b/atomic_multiswap/Makefile
@@ -8,7 +8,7 @@ test: build
 build:
 	$(MAKE) -C ../atomic_swap || break; 
 	stellar contract build
-	@ls -l target/wasm32-unknown-unknown/release/*.wasm
+	@ls -l target/wasm32v1-none/release/*.wasm
 
 fmt:
 	cargo fmt --all

--- a/atomic_multiswap/src/lib.rs
+++ b/atomic_multiswap/src/lib.rs
@@ -11,7 +11,7 @@ use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, Vec};
 
 mod atomic_swap {
     soroban_sdk::contractimport!(
-        file = "../atomic_swap/target/wasm32-unknown-unknown/release/soroban_atomic_swap_contract.wasm"
+        file = "../atomic_swap/target/wasm32v1-none/release/soroban_atomic_swap_contract.wasm"
     );
 }
 

--- a/atomic_swap/Cargo.toml
+++ b/atomic_swap/Cargo.toml
@@ -3,7 +3,7 @@ name = "soroban-atomic-swap-contract"
 version = "0.0.0"
 edition = "2021"
 publish = false
-rust-version = "1.80.0"
+rust-version = "1.85.0"
 
 [lib]
 crate-type = ["cdylib"]

--- a/atomic_swap/Makefile
+++ b/atomic_swap/Makefile
@@ -7,7 +7,7 @@ test: build
 
 build:
 	stellar contract build
-	@ls -l target/wasm32-unknown-unknown/release/*.wasm
+	@ls -l target/wasm32v1-none/release/*.wasm
 
 fmt:
 	cargo fmt --all

--- a/atomic_swap/Makefile
+++ b/atomic_swap/Makefile
@@ -7,7 +7,12 @@ test: build
 
 build:
 	stellar contract build
-	@ls -l target/wasm32v1-none/release/*.wasm
+	@RUST_VERSION=$$(rustc --version | cut -d' ' -f2); \
+	if [ "$$(printf '%s\n%s\n' $$RUST_VERSION 1.81.0 | sort -V | head -n1)" = "1.81.0" ]; then \
+		ls -l target/wasm32v1-none/release/*.wasm; \
+	else \
+		ls -l target/wasm32-unknown-unknown/release/*.wasm; \
+	fi
 
 fmt:
 	cargo fmt --all

--- a/atomic_swap/Makefile
+++ b/atomic_swap/Makefile
@@ -7,12 +7,7 @@ test: build
 
 build:
 	stellar contract build
-	@RUST_VERSION=$$(rustc --version | cut -d' ' -f2); \
-	if [ "$$(printf '%s\n%s\n' $$RUST_VERSION 1.81.0 | sort -V | head -n1)" = "1.81.0" ]; then \
-		ls -l target/wasm32v1-none/release/*.wasm; \
-	else \
-		ls -l target/wasm32-unknown-unknown/release/*.wasm; \
-	fi
+	@ls -l target/wasm32v1-none/release/*.wasm
 
 fmt:
 	cargo fmt --all

--- a/auth/Cargo.toml
+++ b/auth/Cargo.toml
@@ -3,7 +3,7 @@ name = "soroban-auth-contract"
 version = "0.0.0"
 edition = "2021"
 publish = false
-rust-version = "1.80.0"
+rust-version = "1.85.0"
 
 [lib]
 crate-type = ["cdylib"]

--- a/auth/Makefile
+++ b/auth/Makefile
@@ -7,7 +7,7 @@ test: build
 
 build:
 	stellar contract build
-	@ls -l target/wasm32-unknown-unknown/release/*.wasm
+	@ls -l target/wasm32v1-none/release/*.wasm
 
 fmt:
 	cargo fmt --all

--- a/auth/Makefile
+++ b/auth/Makefile
@@ -7,7 +7,12 @@ test: build
 
 build:
 	stellar contract build
-	@ls -l target/wasm32v1-none/release/*.wasm
+	@RUST_VERSION=$$(rustc --version | cut -d' ' -f2); \
+	if [ "$$(printf '%s\n%s\n' $$RUST_VERSION 1.81.0 | sort -V | head -n1)" = "1.81.0" ]; then \
+		ls -l target/wasm32v1-none/release/*.wasm; \
+	else \
+		ls -l target/wasm32-unknown-unknown/release/*.wasm; \
+	fi
 
 fmt:
 	cargo fmt --all

--- a/auth/Makefile
+++ b/auth/Makefile
@@ -7,12 +7,7 @@ test: build
 
 build:
 	stellar contract build
-	@RUST_VERSION=$$(rustc --version | cut -d' ' -f2); \
-	if [ "$$(printf '%s\n%s\n' $$RUST_VERSION 1.81.0 | sort -V | head -n1)" = "1.81.0" ]; then \
-		ls -l target/wasm32v1-none/release/*.wasm; \
-	else \
-		ls -l target/wasm32-unknown-unknown/release/*.wasm; \
-	fi
+	@ls -l target/wasm32v1-none/release/*.wasm
 
 fmt:
 	cargo fmt --all

--- a/bls_signature/Cargo.toml
+++ b/bls_signature/Cargo.toml
@@ -3,7 +3,7 @@ name = "soroban-bls-signature"
 version = "0.0.0"
 edition = "2021"
 publish = false
-rust-version = "1.80.0"
+rust-version = "1.85.0"
 description = """
 WARNING: DO NOT USE THIS LIBRARY IN PRODUCTION OR FOR SECURE APPLICATIONS!
 

--- a/bls_signature/Makefile
+++ b/bls_signature/Makefile
@@ -7,7 +7,7 @@ test: build
 
 build:
 	stellar contract build
-	@ls -l target/wasm32-unknown-unknown/release/*.wasm
+	@ls -l target/wasm32v1-none/release/*.wasm
 
 fmt:
 	cargo fmt --all

--- a/bls_signature/Makefile
+++ b/bls_signature/Makefile
@@ -7,7 +7,12 @@ test: build
 
 build:
 	stellar contract build
-	@ls -l target/wasm32v1-none/release/*.wasm
+	@RUST_VERSION=$$(rustc --version | cut -d' ' -f2); \
+	if [ "$$(printf '%s\n%s\n' $$RUST_VERSION 1.81.0 | sort -V | head -n1)" = "1.81.0" ]; then \
+		ls -l target/wasm32v1-none/release/*.wasm; \
+	else \
+		ls -l target/wasm32-unknown-unknown/release/*.wasm; \
+	fi
 
 fmt:
 	cargo fmt --all

--- a/bls_signature/Makefile
+++ b/bls_signature/Makefile
@@ -7,12 +7,7 @@ test: build
 
 build:
 	stellar contract build
-	@RUST_VERSION=$$(rustc --version | cut -d' ' -f2); \
-	if [ "$$(printf '%s\n%s\n' $$RUST_VERSION 1.81.0 | sort -V | head -n1)" = "1.81.0" ]; then \
-		ls -l target/wasm32v1-none/release/*.wasm; \
-	else \
-		ls -l target/wasm32-unknown-unknown/release/*.wasm; \
-	fi
+	@ls -l target/wasm32v1-none/release/*.wasm
 
 fmt:
 	cargo fmt --all

--- a/cross_contract/contract_a/Cargo.toml
+++ b/cross_contract/contract_a/Cargo.toml
@@ -3,7 +3,7 @@ name = "soroban-cross-contract-a-contract"
 version = "0.0.0"
 edition = "2021"
 publish = false
-rust-version = "1.80.0"
+rust-version = "1.85.0"
 
 [lib]
 crate-type = ["cdylib"]

--- a/cross_contract/contract_a/Makefile
+++ b/cross_contract/contract_a/Makefile
@@ -7,7 +7,7 @@ test: build
 
 build:
 	stellar contract build
-	@ls -l target/wasm32-unknown-unknown/release/*.wasm
+	@ls -l target/wasm32v1-none/release/*.wasm
 
 fmt:
 	cargo fmt --all

--- a/cross_contract/contract_a/Makefile
+++ b/cross_contract/contract_a/Makefile
@@ -7,7 +7,12 @@ test: build
 
 build:
 	stellar contract build
-	@ls -l target/wasm32v1-none/release/*.wasm
+	@RUST_VERSION=$$(rustc --version | cut -d' ' -f2); \
+	if [ "$$(printf '%s\n%s\n' $$RUST_VERSION 1.81.0 | sort -V | head -n1)" = "1.81.0" ]; then \
+		ls -l target/wasm32v1-none/release/*.wasm; \
+	else \
+		ls -l target/wasm32-unknown-unknown/release/*.wasm; \
+	fi
 
 fmt:
 	cargo fmt --all

--- a/cross_contract/contract_a/Makefile
+++ b/cross_contract/contract_a/Makefile
@@ -7,12 +7,7 @@ test: build
 
 build:
 	stellar contract build
-	@RUST_VERSION=$$(rustc --version | cut -d' ' -f2); \
-	if [ "$$(printf '%s\n%s\n' $$RUST_VERSION 1.81.0 | sort -V | head -n1)" = "1.81.0" ]; then \
-		ls -l target/wasm32v1-none/release/*.wasm; \
-	else \
-		ls -l target/wasm32-unknown-unknown/release/*.wasm; \
-	fi
+	@ls -l target/wasm32v1-none/release/*.wasm
 
 fmt:
 	cargo fmt --all

--- a/cross_contract/contract_b/Cargo.toml
+++ b/cross_contract/contract_b/Cargo.toml
@@ -3,7 +3,7 @@ name = "soroban-cross-contract-b-contract"
 version = "0.0.0"
 edition = "2021"
 publish = false
-rust-version = "1.80.0"
+rust-version = "1.85.0"
 
 [lib]
 crate-type = ["cdylib"]

--- a/cross_contract/contract_b/Makefile
+++ b/cross_contract/contract_b/Makefile
@@ -8,7 +8,7 @@ test: build
 build:
 	$(MAKE) -C ../contract_a || break; 
 	stellar contract build
-	@ls -l target/wasm32-unknown-unknown/release/*.wasm
+	@ls -l target/wasm32v1-none/release/*.wasm
 
 fmt:
 	cargo fmt --all

--- a/cross_contract/contract_b/Makefile
+++ b/cross_contract/contract_b/Makefile
@@ -8,12 +8,7 @@ test: build
 build:
 	$(MAKE) -C ../contract_a || break; 
 	stellar contract build
-	@RUST_VERSION=$$(rustc --version | cut -d' ' -f2); \
-	if [ "$$(printf '%s\n%s\n' $$RUST_VERSION 1.81.0 | sort -V | head -n1)" = "1.81.0" ]; then \
-		ls -l target/wasm32v1-none/release/*.wasm; \
-	else \
-		ls -l target/wasm32-unknown-unknown/release/*.wasm; \
-	fi
+	@ls -l target/wasm32v1-none/release/*.wasm
 
 fmt:
 	cargo fmt --all

--- a/cross_contract/contract_b/Makefile
+++ b/cross_contract/contract_b/Makefile
@@ -8,7 +8,12 @@ test: build
 build:
 	$(MAKE) -C ../contract_a || break; 
 	stellar contract build
-	@ls -l target/wasm32v1-none/release/*.wasm
+	@RUST_VERSION=$$(rustc --version | cut -d' ' -f2); \
+	if [ "$$(printf '%s\n%s\n' $$RUST_VERSION 1.81.0 | sort -V | head -n1)" = "1.81.0" ]; then \
+		ls -l target/wasm32v1-none/release/*.wasm; \
+	else \
+		ls -l target/wasm32-unknown-unknown/release/*.wasm; \
+	fi
 
 fmt:
 	cargo fmt --all

--- a/cross_contract/contract_b/src/lib.rs
+++ b/cross_contract/contract_b/src/lib.rs
@@ -4,7 +4,7 @@ use soroban_sdk::{contract, contractimpl, Address, Env};
 
 mod contract_a {
     soroban_sdk::contractimport!(
-        file = "../contract_a/target/wasm32-unknown-unknown/release/soroban_cross_contract_a_contract.wasm"
+        file = "../contract_a/target/wasm32v1-none/release/soroban_cross_contract_a_contract.wasm"
     );
 }
 

--- a/custom_types/Cargo.toml
+++ b/custom_types/Cargo.toml
@@ -3,7 +3,7 @@ name = "soroban-custom-types-contract"
 version = "0.0.0"
 edition = "2021"
 publish = false
-rust-version = "1.80.0"
+rust-version = "1.85.0"
 
 [lib]
 crate-type = ["cdylib"]

--- a/custom_types/Makefile
+++ b/custom_types/Makefile
@@ -7,7 +7,7 @@ test: build
 
 build:
 	stellar contract build
-	@ls -l target/wasm32-unknown-unknown/release/*.wasm
+	@ls -l target/wasm32v1-none/release/*.wasm
 
 fmt:
 	cargo fmt --all

--- a/custom_types/Makefile
+++ b/custom_types/Makefile
@@ -7,7 +7,12 @@ test: build
 
 build:
 	stellar contract build
-	@ls -l target/wasm32v1-none/release/*.wasm
+	@RUST_VERSION=$$(rustc --version | cut -d' ' -f2); \
+	if [ "$$(printf '%s\n%s\n' $$RUST_VERSION 1.81.0 | sort -V | head -n1)" = "1.81.0" ]; then \
+		ls -l target/wasm32v1-none/release/*.wasm; \
+	else \
+		ls -l target/wasm32-unknown-unknown/release/*.wasm; \
+	fi
 
 fmt:
 	cargo fmt --all

--- a/custom_types/Makefile
+++ b/custom_types/Makefile
@@ -7,12 +7,7 @@ test: build
 
 build:
 	stellar contract build
-	@RUST_VERSION=$$(rustc --version | cut -d' ' -f2); \
-	if [ "$$(printf '%s\n%s\n' $$RUST_VERSION 1.81.0 | sort -V | head -n1)" = "1.81.0" ]; then \
-		ls -l target/wasm32v1-none/release/*.wasm; \
-	else \
-		ls -l target/wasm32-unknown-unknown/release/*.wasm; \
-	fi
+	@ls -l target/wasm32v1-none/release/*.wasm
 
 fmt:
 	cargo fmt --all

--- a/deep_contract_auth/Cargo.toml
+++ b/deep_contract_auth/Cargo.toml
@@ -3,7 +3,7 @@ name = "soroban-deployer-contract"
 version = "0.0.0"
 edition = "2021"
 publish = false
-rust-version = "1.80.0"
+rust-version = "1.85.0"
 
 [lib]
 crate-type = ["cdylib"]

--- a/deep_contract_auth/Makefile
+++ b/deep_contract_auth/Makefile
@@ -7,7 +7,7 @@ test: build
 
 build:
 	stellar contract build
-	@ls -l target/wasm32-unknown-unknown/release/*.wasm
+	@ls -l target/wasm32v1-none/release/*.wasm
 
 fmt:
 	cargo fmt --all

--- a/deep_contract_auth/Makefile
+++ b/deep_contract_auth/Makefile
@@ -7,7 +7,12 @@ test: build
 
 build:
 	stellar contract build
-	@ls -l target/wasm32v1-none/release/*.wasm
+	@RUST_VERSION=$$(rustc --version | cut -d' ' -f2); \
+	if [ "$$(printf '%s\n%s\n' $$RUST_VERSION 1.81.0 | sort -V | head -n1)" = "1.81.0" ]; then \
+		ls -l target/wasm32v1-none/release/*.wasm; \
+	else \
+		ls -l target/wasm32-unknown-unknown/release/*.wasm; \
+	fi
 
 fmt:
 	cargo fmt --all

--- a/deep_contract_auth/Makefile
+++ b/deep_contract_auth/Makefile
@@ -7,12 +7,7 @@ test: build
 
 build:
 	stellar contract build
-	@RUST_VERSION=$$(rustc --version | cut -d' ' -f2); \
-	if [ "$$(printf '%s\n%s\n' $$RUST_VERSION 1.81.0 | sort -V | head -n1)" = "1.81.0" ]; then \
-		ls -l target/wasm32v1-none/release/*.wasm; \
-	else \
-		ls -l target/wasm32-unknown-unknown/release/*.wasm; \
-	fi
+	@ls -l target/wasm32v1-none/release/*.wasm
 
 fmt:
 	cargo fmt --all

--- a/deployer/contract/Cargo.toml
+++ b/deployer/contract/Cargo.toml
@@ -3,7 +3,7 @@ name = "soroban-deployer-test-contract"
 version = "0.0.0"
 edition = "2021"
 publish = false
-rust-version = "1.80.0"
+rust-version = "1.85.0"
 
 [lib]
 crate-type = ["cdylib"]

--- a/deployer/contract/Makefile
+++ b/deployer/contract/Makefile
@@ -7,7 +7,7 @@ test: build
 
 build:
 	stellar contract build
-	@ls -l target/wasm32-unknown-unknown/release/*.wasm
+	@ls -l target/wasm32v1-none/release/*.wasm
 
 fmt:
 	cargo fmt --all

--- a/deployer/contract/Makefile
+++ b/deployer/contract/Makefile
@@ -7,7 +7,12 @@ test: build
 
 build:
 	stellar contract build
-	@ls -l target/wasm32v1-none/release/*.wasm
+	@RUST_VERSION=$$(rustc --version | cut -d' ' -f2); \
+	if [ "$$(printf '%s\n%s\n' $$RUST_VERSION 1.81.0 | sort -V | head -n1)" = "1.81.0" ]; then \
+		ls -l target/wasm32v1-none/release/*.wasm; \
+	else \
+		ls -l target/wasm32-unknown-unknown/release/*.wasm; \
+	fi
 
 fmt:
 	cargo fmt --all

--- a/deployer/contract/Makefile
+++ b/deployer/contract/Makefile
@@ -7,12 +7,7 @@ test: build
 
 build:
 	stellar contract build
-	@RUST_VERSION=$$(rustc --version | cut -d' ' -f2); \
-	if [ "$$(printf '%s\n%s\n' $$RUST_VERSION 1.81.0 | sort -V | head -n1)" = "1.81.0" ]; then \
-		ls -l target/wasm32v1-none/release/*.wasm; \
-	else \
-		ls -l target/wasm32-unknown-unknown/release/*.wasm; \
-	fi
+	@ls -l target/wasm32v1-none/release/*.wasm
 
 fmt:
 	cargo fmt --all

--- a/deployer/deployer/Cargo.toml
+++ b/deployer/deployer/Cargo.toml
@@ -3,7 +3,7 @@ name = "soroban-deployer-contract"
 version = "0.0.0"
 edition = "2021"
 publish = false
-rust-version = "1.80.0"
+rust-version = "1.85.0"
 
 [lib]
 crate-type = ["cdylib"]

--- a/deployer/deployer/Makefile
+++ b/deployer/deployer/Makefile
@@ -8,12 +8,7 @@ test: build
 build:
 	$(MAKE) -C ../contract || break;
 	stellar contract build
-	@RUST_VERSION=$$(rustc --version | cut -d' ' -f2); \
-	if [ "$$(printf '%s\n%s\n' $$RUST_VERSION 1.81.0 | sort -V | head -n1)" = "1.81.0" ]; then \
-		ls -l target/wasm32v1-none/release/*.wasm; \
-	else \
-		ls -l target/wasm32-unknown-unknown/release/*.wasm; \
-	fi
+	@ls -l target/wasm32v1-none/release/*.wasm
 
 fmt:
 	cargo fmt --all

--- a/deployer/deployer/Makefile
+++ b/deployer/deployer/Makefile
@@ -8,7 +8,12 @@ test: build
 build:
 	$(MAKE) -C ../contract || break;
 	stellar contract build
-	@ls -l target/wasm32-unknown-unknown/release/*.wasm
+	@RUST_VERSION=$$(rustc --version | cut -d' ' -f2); \
+	if [ "$$(printf '%s\n%s\n' $$RUST_VERSION 1.81.0 | sort -V | head -n1)" = "1.81.0" ]; then \
+		ls -l target/wasm32v1-none/release/*.wasm; \
+	else \
+		ls -l target/wasm32-unknown-unknown/release/*.wasm; \
+	fi
 
 fmt:
 	cargo fmt --all

--- a/deployer/deployer/src/test.rs
+++ b/deployer/deployer/src/test.rs
@@ -14,7 +14,7 @@ use soroban_sdk::{
 mod contract {
     soroban_sdk::contractimport!(
         file =
-            "../contract/target/wasm32-unknown-unknown/release/soroban_deployer_test_contract.wasm"
+            "../contract/target/wasm32v1-none/release/soroban_deployer_test_contract.wasm"
     );
 }
 

--- a/deployer/deployer/src/test.rs
+++ b/deployer/deployer/src/test.rs
@@ -13,8 +13,7 @@ use soroban_sdk::{
 // The contract that will be deployed by the deployer contract.
 mod contract {
     soroban_sdk::contractimport!(
-        file =
-            "../contract/target/wasm32v1-none/release/soroban_deployer_test_contract.wasm"
+        file = "../contract/target/wasm32v1-none/release/soroban_deployer_test_contract.wasm"
     );
 }
 

--- a/errors/Cargo.toml
+++ b/errors/Cargo.toml
@@ -3,7 +3,7 @@ name = "soroban-errors-contract"
 version = "0.0.0"
 edition = "2021"
 publish = false
-rust-version = "1.80.0"
+rust-version = "1.85.0"
 
 [lib]
 crate-type = ["cdylib"]

--- a/errors/Makefile
+++ b/errors/Makefile
@@ -7,7 +7,7 @@ test: build
 
 build:
 	stellar contract build
-	@ls -l target/wasm32-unknown-unknown/release/*.wasm
+	@ls -l target/wasm32v1-none/release/*.wasm
 
 fmt:
 	cargo fmt --all

--- a/errors/Makefile
+++ b/errors/Makefile
@@ -7,7 +7,12 @@ test: build
 
 build:
 	stellar contract build
-	@ls -l target/wasm32v1-none/release/*.wasm
+	@RUST_VERSION=$$(rustc --version | cut -d' ' -f2); \
+	if [ "$$(printf '%s\n%s\n' $$RUST_VERSION 1.81.0 | sort -V | head -n1)" = "1.81.0" ]; then \
+		ls -l target/wasm32v1-none/release/*.wasm; \
+	else \
+		ls -l target/wasm32-unknown-unknown/release/*.wasm; \
+	fi
 
 fmt:
 	cargo fmt --all

--- a/errors/Makefile
+++ b/errors/Makefile
@@ -7,12 +7,7 @@ test: build
 
 build:
 	stellar contract build
-	@RUST_VERSION=$$(rustc --version | cut -d' ' -f2); \
-	if [ "$$(printf '%s\n%s\n' $$RUST_VERSION 1.81.0 | sort -V | head -n1)" = "1.81.0" ]; then \
-		ls -l target/wasm32v1-none/release/*.wasm; \
-	else \
-		ls -l target/wasm32-unknown-unknown/release/*.wasm; \
-	fi
+	@ls -l target/wasm32v1-none/release/*.wasm
 
 fmt:
 	cargo fmt --all

--- a/eth_abi/Cargo.lock
+++ b/eth_abi/Cargo.lock
@@ -1334,9 +1334,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "22.0.7"
+version = "22.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80bbe59497cb50e81861187e6bd2a2c805df253573d44ed56e7d373f79530758"
+checksum = "2826e2c9d364edbb2ea112dc861077c74557bdad0a7a00487969088c7c648169"
 dependencies = [
  "serde",
  "serde_json",
@@ -1348,9 +1348,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "22.0.7"
+version = "22.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c85edd55eb09aa5dd7ba5ab595d2be7ac3f453e90e2f26d704ff26c130f2926f"
+checksum = "c7ac27d7573e62b745513fa1be8dab7a09b9676a7f39db97164f1d458a344749"
 dependencies = [
  "arbitrary",
  "bytes-lit",
@@ -1370,9 +1370,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "22.0.7"
+version = "22.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a141230aa65006d4b3eeee9d0589172d734a2abfbe15b84670e38e76e200b370"
+checksum = "9ef0d7d62b2584696d306b8766728971c7d0731a03a5e047f1fc68722ac8cf0c"
 dependencies = [
  "crate-git-revision",
  "darling",
@@ -1390,9 +1390,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec"
-version = "22.0.7"
+version = "22.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b54326e9516b33be99c701b37242b27efb8e66cc1f1eff994b9d9a013a4be136"
+checksum = "a4ad0867aec99770ed614fedbec7ac4591791df162ff9e548ab7ebd07cd23a9c"
 dependencies = [
  "base64 0.13.1",
  "stellar-xdr",
@@ -1402,9 +1402,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-rust"
-version = "22.0.7"
+version = "22.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f009cab4dfd653bc94a06c5022f1ca9d30e198b0e451f84cf307231563d11de2"
+checksum = "aebe31c042adfa2885ec47b67b08fcead8707da80a3fe737eaf2a9ae1a8cfdc3"
 dependencies = [
  "prettyplease",
  "proc-macro2",

--- a/eth_abi/Cargo.lock
+++ b/eth_abi/Cargo.lock
@@ -20,30 +20,14 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "600d34d8de81e23b6d909c094e23b3d357e01ca36b78a8c5424c501eedbe86f0"
 dependencies = [
- "alloy-rlp",
  "bytes",
  "cfg-if",
  "const-hex",
  "derive_more",
  "hex-literal",
  "itoa",
- "k256",
- "keccak-asm",
- "proptest",
- "rand",
  "ruint",
- "serde",
  "tiny-keccak",
-]
-
-[[package]]
-name = "alloy-rlp"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26154390b1d205a4a7ac7352aa2eb4f81f391399d4e2f546fb81a2f8bb383f62"
-dependencies = [
- "arrayvec",
- "bytes",
 ]
 
 [[package]]
@@ -73,7 +57,6 @@ dependencies = [
  "alloy-primitives",
  "alloy-sol-macro",
  "const-hex",
- "serde",
 ]
 
 [[package]]
@@ -107,9 +90,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c775f0d12169cba7aae4caeb547bb6a50781c7449a8aa53793827c9ec4abf488"
 dependencies = [
  "ark-ec",
- "ark-ff 0.4.2",
- "ark-serialize 0.4.2",
- "ark-std 0.4.0",
+ "ark-ff",
+ "ark-serialize",
+ "ark-std",
 ]
 
 [[package]]
@@ -118,10 +101,10 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "defd9a439d56ac24968cca0571f598a61bc8c55f71d50a89cda591cb750670ba"
 dependencies = [
- "ark-ff 0.4.2",
+ "ark-ff",
  "ark-poly",
- "ark-serialize 0.4.2",
- "ark-std 0.4.0",
+ "ark-serialize",
+ "ark-std",
  "derivative",
  "hashbrown 0.13.2",
  "itertools",
@@ -131,50 +114,22 @@ dependencies = [
 
 [[package]]
 name = "ark-ff"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b3235cc41ee7a12aaaf2c575a2ad7b46713a8a50bda2fc3b003a04845c05dd6"
-dependencies = [
- "ark-ff-asm 0.3.0",
- "ark-ff-macros 0.3.0",
- "ark-serialize 0.3.0",
- "ark-std 0.3.0",
- "derivative",
- "num-bigint",
- "num-traits",
- "paste",
- "rustc_version 0.3.3",
- "zeroize",
-]
-
-[[package]]
-name = "ark-ff"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec847af850f44ad29048935519032c33da8aa03340876d351dfab5660d2966ba"
 dependencies = [
- "ark-ff-asm 0.4.2",
- "ark-ff-macros 0.4.2",
- "ark-serialize 0.4.2",
- "ark-std 0.4.0",
+ "ark-ff-asm",
+ "ark-ff-macros",
+ "ark-serialize",
+ "ark-std",
  "derivative",
- "digest 0.10.7",
+ "digest",
  "itertools",
  "num-bigint",
  "num-traits",
  "paste",
- "rustc_version 0.4.1",
+ "rustc_version",
  "zeroize",
-]
-
-[[package]]
-name = "ark-ff-asm"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db02d390bf6643fb404d3d22d31aee1c4bc4459600aef9113833d17e786c6e44"
-dependencies = [
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -183,18 +138,6 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
 dependencies = [
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "ark-ff-macros"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2fd794a08ccb318058009eefdf15bcaaaaf6f8161eb3345f907222bac38b20"
-dependencies = [
- "num-bigint",
- "num-traits",
  "quote",
  "syn 1.0.109",
 ]
@@ -218,21 +161,11 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d320bfc44ee185d899ccbadfa8bc31aab923ce1558716e1997a1e74057fe86bf"
 dependencies = [
- "ark-ff 0.4.2",
- "ark-serialize 0.4.2",
- "ark-std 0.4.0",
+ "ark-ff",
+ "ark-serialize",
+ "ark-std",
  "derivative",
  "hashbrown 0.13.2",
-]
-
-[[package]]
-name = "ark-serialize"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d6c2b318ee6e10f8c2853e73a83adc0ccb88995aa978d8a3408d492ab2ee671"
-dependencies = [
- "ark-std 0.3.0",
- "digest 0.9.0",
 ]
 
 [[package]]
@@ -242,8 +175,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
 dependencies = [
  "ark-serialize-derive",
- "ark-std 0.4.0",
- "digest 0.10.7",
+ "ark-std",
+ "digest",
  "num-bigint",
 ]
 
@@ -260,39 +193,12 @@ dependencies = [
 
 [[package]]
 name = "ark-std"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
-dependencies = [
- "num-traits",
- "rand",
-]
-
-[[package]]
-name = "ark-std"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
 dependencies = [
  "num-traits",
  "rand",
-]
-
-[[package]]
-name = "arrayvec"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
-
-[[package]]
-name = "auto_impl"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c87f3f15e7794432337fc718554eaa4dc8f04c9677a950ffe366f20a162ae42"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.79",
 ]
 
 [[package]]
@@ -326,37 +232,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
-name = "bit-set"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
-dependencies = [
- "bit-vec",
-]
-
-[[package]]
-name = "bit-vec"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
-
-[[package]]
 name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
-
-[[package]]
-name = "bitvec"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
-dependencies = [
- "funty",
- "radium",
- "tap",
- "wyz",
-]
 
 [[package]]
 name = "block-buffer"
@@ -372,12 +251,6 @@ name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
-
-[[package]]
-name = "byte-slice-cast"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
 
 [[package]]
 name = "byteorder"
@@ -529,9 +402,9 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "curve25519-dalek-derive",
- "digest 0.10.7",
+ "digest",
  "fiat-crypto",
- "rustc_version 0.4.1",
+ "rustc_version",
  "subtle",
  "zeroize",
 ]
@@ -639,17 +512,8 @@ dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
- "rustc_version 0.4.1",
+ "rustc_version",
  "syn 2.0.79",
-]
-
-[[package]]
-name = "digest"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
-dependencies = [
- "generic-array",
 ]
 
 [[package]]
@@ -683,11 +547,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
- "digest 0.10.7",
+ "digest",
  "elliptic-curve",
  "rfc6979",
  "signature",
- "spki",
 ]
 
 [[package]]
@@ -729,11 +592,10 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest 0.10.7",
+ "digest",
  "ff",
  "generic-array",
  "group",
- "pkcs8",
  "rand_core",
  "sec1",
  "subtle",
@@ -747,16 +609,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
-name = "errno"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "escape-bytes"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -767,23 +619,6 @@ name = "ethnum"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b90ca2580b73ab6a1f724b76ca11ab632df820fd6040c336200d2c1df7b3c82c"
-
-[[package]]
-name = "fastrand"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
-
-[[package]]
-name = "fastrlp"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139834ddba373bbdd213dffe02c8d110508dcf1726c2be27e8d1f7d7e1856418"
-dependencies = [
- "arrayvec",
- "auto_impl",
- "bytes",
-]
 
 [[package]]
 name = "ff"
@@ -802,28 +637,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
-name = "fixed-hash"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
-dependencies = [
- "byteorder",
- "rand",
- "rustc-hex",
- "static_assertions",
-]
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "funty"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "generic-array"
@@ -908,7 +725,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -939,26 +756,6 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
-
-[[package]]
-name = "impl-codec"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba6a270039626615617f3f36d15fc827041df3b78c439da2cadfa47455a77f2f"
-dependencies = [
- "parity-scale-codec",
-]
-
-[[package]]
-name = "impl-trait-for-tuples"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11d7a9f6330b71fea57921c9b61c47ee6e84f72d394754eff6163ae67e7395eb"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "indexmap"
@@ -1021,9 +818,7 @@ dependencies = [
  "cfg-if",
  "ecdsa",
  "elliptic-curve",
- "once_cell",
  "sha2",
- "signature",
 ]
 
 [[package]]
@@ -1036,22 +831,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "keccak-asm"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "505d1856a39b200489082f90d897c3f07c455563880bc5952e38eabf731c83b6"
-dependencies = [
- "digest 0.10.7",
- "sha3-asm",
-]
-
-[[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
 name = "libc"
 version = "0.2.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1062,12 +841,6 @@ name = "libm"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "log"
@@ -1146,47 +919,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "parity-scale-codec"
-version = "3.6.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "306800abfa29c7f16596b5970a588435e3d5b3149683d00c12b699cc19f895ee"
-dependencies = [
- "arrayvec",
- "bitvec",
- "byte-slice-cast",
- "impl-trait-for-tuples",
- "parity-scale-codec-derive",
- "serde",
-]
-
-[[package]]
-name = "parity-scale-codec-derive"
-version = "3.6.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d830939c76d294956402033aee57a6da7b438f2294eb94864c37b0569053a42c"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
-name = "pest"
-version = "2.7.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdbef9d1d47087a895abd220ed25eb4ad973a5e26f6a4367b038c25e28dfc2d9"
-dependencies = [
- "memchr",
- "thiserror",
- "ucd-trie",
-]
 
 [[package]]
 name = "pkcs8"
@@ -1233,26 +969,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "primitive-types"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b34d9fd68ae0b74a41b21c03c2f62847aa0ffea044eee893b4c140b37e244e2"
-dependencies = [
- "fixed-hash",
- "impl-codec",
- "uint",
-]
-
-[[package]]
-name = "proc-macro-crate"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
-dependencies = [
- "toml_edit",
-]
-
-[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1291,25 +1007,13 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c2511913b88df1637da85cc8d96ec8e43a3f8bb8ccb71ee1ac240d6f3df58d"
 dependencies = [
- "bit-set",
- "bit-vec",
  "bitflags",
- "lazy_static",
  "num-traits",
  "rand",
  "rand_chacha",
  "rand_xorshift",
- "regex-syntax",
- "rusty-fork",
- "tempfile",
  "unarray",
 ]
-
-[[package]]
-name = "quick-error"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
@@ -1319,12 +1023,6 @@ checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "radium"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -1366,12 +1064,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex-syntax"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
-
-[[package]]
 name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1382,33 +1074,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "rlp"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb919243f34364b6bd2fc10ef797edbfa75f33c252e7998527479c6d6b47e1ec"
-dependencies = [
- "bytes",
- "rustc-hex",
-]
-
-[[package]]
 name = "ruint"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c3cc4c2511671f327125da14133d0c5c5d137f006a1017a16f557bc85b16286"
 dependencies = [
- "alloy-rlp",
- "ark-ff 0.3.0",
- "ark-ff 0.4.2",
- "bytes",
- "fastrlp",
- "num-bigint",
- "num-traits",
- "parity-scale-codec",
- "primitive-types",
  "proptest",
  "rand",
- "rlp",
  "ruint-macro",
  "serde",
  "valuable",
@@ -1422,52 +1094,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
 
 [[package]]
-name = "rustc-hex"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
-
-[[package]]
-name = "rustc_version"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
-dependencies = [
- "semver 0.11.0",
-]
-
-[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
- "semver 1.0.23",
-]
-
-[[package]]
-name = "rustix"
-version = "0.38.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811"
-dependencies = [
- "bitflags",
- "errno",
- "libc",
- "linux-raw-sys",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "rusty-fork"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
-dependencies = [
- "fnv",
- "quick-error",
- "tempfile",
- "wait-timeout",
+ "semver",
 ]
 
 [[package]]
@@ -1485,18 +1117,8 @@ dependencies = [
  "base16ct",
  "der",
  "generic-array",
- "pkcs8",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "semver"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
-dependencies = [
- "semver-parser",
 ]
 
 [[package]]
@@ -1504,15 +1126,6 @@ name = "semver"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
-
-[[package]]
-name = "semver-parser"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
-dependencies = [
- "pest",
-]
 
 [[package]]
 name = "serde"
@@ -1584,7 +1197,7 @@ checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -1593,18 +1206,8 @@ version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
- "digest 0.10.7",
+ "digest",
  "keccak",
-]
-
-[[package]]
-name = "sha3-asm"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28efc5e327c837aa837c59eae585fc250715ef939ac32881bcc11677cd02d46"
-dependencies = [
- "cc",
- "cfg-if",
 ]
 
 [[package]]
@@ -1619,7 +1222,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest 0.10.7",
+ "digest",
  "rand_core",
 ]
 
@@ -1678,8 +1281,8 @@ checksum = "66e8b03a4191d485eab03f066336112b2a50541a7553179553dc838b986b94dd"
 dependencies = [
  "ark-bls12-381",
  "ark-ec",
- "ark-ff 0.4.2",
- "ark-serialize 0.4.2",
+ "ark-ff",
+ "ark-serialize",
  "curve25519-dalek",
  "ecdsa",
  "ed25519-dalek",
@@ -1755,7 +1358,7 @@ dependencies = [
  "derive_arbitrary",
  "ed25519-dalek",
  "rand",
- "rustc_version 0.4.1",
+ "rustc_version",
  "serde",
  "serde_json",
  "soroban-env-guest",
@@ -1776,7 +1379,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "rustc_version 0.4.1",
+ "rustc_version",
  "sha2",
  "soroban-env-common",
  "soroban-spec",
@@ -1922,25 +1525,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
-
-[[package]]
-name = "tempfile"
-version = "3.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f2c9fc62d0beef6951ccffd757e241266a2c833136efbe35af6cd2567dca5b"
-dependencies = [
- "cfg-if",
- "fastrand",
- "once_cell",
- "rustix",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "thiserror"
 version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2001,45 +1585,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_datetime"
-version = "0.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
-
-[[package]]
-name = "toml_edit"
-version = "0.22.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
-dependencies = [
- "indexmap 2.6.0",
- "toml_datetime",
- "winnow",
-]
-
-[[package]]
 name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
-
-[[package]]
-name = "ucd-trie"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
-
-[[package]]
-name = "uint"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
-dependencies = [
- "byteorder",
- "crunchy",
- "hex",
- "static_assertions",
-]
 
 [[package]]
 name = "unarray"
@@ -2064,15 +1613,6 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "wait-timeout"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "wasi"
@@ -2160,7 +1700,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a58e28b80dd8340cb07b8242ae654756161f6fc8d0038123d679b7b99964fa50"
 dependencies = [
  "indexmap 2.6.0",
- "semver 1.0.23",
+ "semver",
 ]
 
 [[package]]
@@ -2177,24 +1717,6 @@ name = "windows-core"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
 ]
@@ -2262,24 +1784,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "winnow"
-version = "0.6.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "wyz"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
-dependencies = [
- "tap",
-]
 
 [[package]]
 name = "zerocopy"

--- a/eth_abi/Cargo.toml
+++ b/eth_abi/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-soroban-sdk = { version = "22.0.7", features = ["alloc"] }
+soroban-sdk = { version = "22.0.8", features = ["alloc"] }
 alloy-sol-types = { version="0.6.3", default-features = false }
 
 [dev-dependencies]

--- a/eth_abi/Cargo.toml
+++ b/eth_abi/Cargo.toml
@@ -3,7 +3,7 @@ name = "soroban-eth-abi"
 version = "0.1.0"
 edition = "2021"
 publish = false
-rust-version = "1.80.0"
+rust-version = "1.85.0"
 
 [lib]
 crate-type = ["cdylib"]

--- a/eth_abi/Cargo.toml
+++ b/eth_abi/Cargo.toml
@@ -11,7 +11,7 @@ doctest = false
 
 [dependencies]
 soroban-sdk = { version = "22.0.7", features = ["alloc"] }
-alloy-sol-types = {version="0.6.3" }
+alloy-sol-types = { version="0.6.3", default-features = false }
 
 [dev-dependencies]
 soroban-sdk = { version = "22.0.7", features = ["testutils"] }

--- a/eth_abi/Makefile
+++ b/eth_abi/Makefile
@@ -7,7 +7,7 @@ test: build
 
 build:
 	stellar contract build
-	@ls -l target/wasm32-unknown-unknown/release/*.wasm
+	@ls -l target/wasm32v1-none/release/*.wasm
 
 fmt:
 	cargo fmt --all

--- a/eth_abi/Makefile
+++ b/eth_abi/Makefile
@@ -7,7 +7,12 @@ test: build
 
 build:
 	stellar contract build
-	@ls -l target/wasm32v1-none/release/*.wasm
+	@RUST_VERSION=$$(rustc --version | cut -d' ' -f2); \
+	if [ "$$(printf '%s\n%s\n' $$RUST_VERSION 1.81.0 | sort -V | head -n1)" = "1.81.0" ]; then \
+		ls -l target/wasm32v1-none/release/*.wasm; \
+	else \
+		ls -l target/wasm32-unknown-unknown/release/*.wasm; \
+	fi
 
 fmt:
 	cargo fmt --all

--- a/eth_abi/Makefile
+++ b/eth_abi/Makefile
@@ -7,12 +7,7 @@ test: build
 
 build:
 	stellar contract build
-	@RUST_VERSION=$$(rustc --version | cut -d' ' -f2); \
-	if [ "$$(printf '%s\n%s\n' $$RUST_VERSION 1.81.0 | sort -V | head -n1)" = "1.81.0" ]; then \
-		ls -l target/wasm32v1-none/release/*.wasm; \
-	else \
-		ls -l target/wasm32-unknown-unknown/release/*.wasm; \
-	fi
+	@ls -l target/wasm32v1-none/release/*.wasm
 
 fmt:
 	cargo fmt --all

--- a/events/Cargo.toml
+++ b/events/Cargo.toml
@@ -3,7 +3,7 @@ name = "soroban-events-contract"
 version = "0.0.0"
 edition = "2021"
 publish = false
-rust-version = "1.80.0"
+rust-version = "1.85.0"
 
 [lib]
 crate-type = ["cdylib"]

--- a/events/Makefile
+++ b/events/Makefile
@@ -7,7 +7,7 @@ test: build
 
 build:
 	stellar contract build
-	@ls -l target/wasm32-unknown-unknown/release/*.wasm
+	@ls -l target/wasm32v1-none/release/*.wasm
 
 fmt:
 	cargo fmt --all

--- a/events/Makefile
+++ b/events/Makefile
@@ -7,7 +7,12 @@ test: build
 
 build:
 	stellar contract build
-	@ls -l target/wasm32v1-none/release/*.wasm
+	@RUST_VERSION=$$(rustc --version | cut -d' ' -f2); \
+	if [ "$$(printf '%s\n%s\n' $$RUST_VERSION 1.81.0 | sort -V | head -n1)" = "1.81.0" ]; then \
+		ls -l target/wasm32v1-none/release/*.wasm; \
+	else \
+		ls -l target/wasm32-unknown-unknown/release/*.wasm; \
+	fi
 
 fmt:
 	cargo fmt --all

--- a/events/Makefile
+++ b/events/Makefile
@@ -7,12 +7,7 @@ test: build
 
 build:
 	stellar contract build
-	@RUST_VERSION=$$(rustc --version | cut -d' ' -f2); \
-	if [ "$$(printf '%s\n%s\n' $$RUST_VERSION 1.81.0 | sort -V | head -n1)" = "1.81.0" ]; then \
-		ls -l target/wasm32v1-none/release/*.wasm; \
-	else \
-		ls -l target/wasm32-unknown-unknown/release/*.wasm; \
-	fi
+	@ls -l target/wasm32v1-none/release/*.wasm
 
 fmt:
 	cargo fmt --all

--- a/fuzzing/Cargo.toml
+++ b/fuzzing/Cargo.toml
@@ -3,7 +3,7 @@ name = "soroban-fuzzing-contract"
 version = "0.0.0"
 edition = "2021"
 publish = false
-rust-version = "1.80.0"
+rust-version = "1.85.0"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/fuzzing/Makefile
+++ b/fuzzing/Makefile
@@ -8,12 +8,7 @@ test: build
 
 build:
 	stellar contract build
-	@RUST_VERSION=$$(rustc --version | cut -d' ' -f2); \
-	if [ "$$(printf '%s\n%s\n' $$RUST_VERSION 1.81.0 | sort -V | head -n1)" = "1.81.0" ]; then \
-		ls -l target/wasm32v1-none/release/*.wasm; \
-	else \
-		ls -l target/wasm32-unknown-unknown/release/*.wasm; \
-	fi
+	@ls -l target/wasm32v1-none/release/*.wasm
 
 fmt:
 	cargo fmt --all

--- a/fuzzing/Makefile
+++ b/fuzzing/Makefile
@@ -8,7 +8,12 @@ test: build
 
 build:
 	stellar contract build
-	@ls -l target/wasm32v1-none/release/*.wasm
+	@RUST_VERSION=$$(rustc --version | cut -d' ' -f2); \
+	if [ "$$(printf '%s\n%s\n' $$RUST_VERSION 1.81.0 | sort -V | head -n1)" = "1.81.0" ]; then \
+		ls -l target/wasm32v1-none/release/*.wasm; \
+	else \
+		ls -l target/wasm32-unknown-unknown/release/*.wasm; \
+	fi
 
 fmt:
 	cargo fmt --all

--- a/fuzzing/Makefile
+++ b/fuzzing/Makefile
@@ -8,7 +8,7 @@ test: build
 
 build:
 	stellar contract build
-	@ls -l target/wasm32-unknown-unknown/release/*.wasm
+	@ls -l target/wasm32v1-none/release/*.wasm
 
 fmt:
 	cargo fmt --all

--- a/groth16_verifier/Cargo.toml
+++ b/groth16_verifier/Cargo.toml
@@ -3,7 +3,7 @@ name = "soroban-groth16-verifier-contract"
 version = "0.0.0"
 edition = "2021"
 publish = false
-rust-version = "1.84.0"
+rust-version = "1.85.0"
 
 [lib]
 crate-type = ["cdylib"]

--- a/groth16_verifier/Makefile
+++ b/groth16_verifier/Makefile
@@ -7,7 +7,12 @@ test: build
 
 build:
 	stellar contract build
-	@ls -l target/wasm32v1-none/release/*.wasm
+	@RUST_VERSION=$$(rustc --version | cut -d' ' -f2); \
+	if [ "$$(printf '%s\n%s\n' $$RUST_VERSION 1.81.0 | sort -V | head -n1)" = "1.81.0" ]; then \
+		ls -l target/wasm32v1-none/release/*.wasm; \
+	else \
+		ls -l target/wasm32-unknown-unknown/release/*.wasm; \
+	fi
 
 fmt:
 	cargo fmt --all

--- a/groth16_verifier/Makefile
+++ b/groth16_verifier/Makefile
@@ -7,12 +7,7 @@ test: build
 
 build:
 	stellar contract build
-	@RUST_VERSION=$$(rustc --version | cut -d' ' -f2); \
-	if [ "$$(printf '%s\n%s\n' $$RUST_VERSION 1.81.0 | sort -V | head -n1)" = "1.81.0" ]; then \
-		ls -l target/wasm32v1-none/release/*.wasm; \
-	else \
-		ls -l target/wasm32-unknown-unknown/release/*.wasm; \
-	fi
+	@ls -l target/wasm32v1-none/release/*.wasm
 
 fmt:
 	cargo fmt --all

--- a/groth16_verifier/rust-toolchain.toml
+++ b/groth16_verifier/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.84.0"
+channel = "1.85.0"
 targets = ["wasm32v1-none"]
 components = ["rustc", "cargo", "rustfmt", "clippy", "rust-src"]

--- a/hello_world/Cargo.toml
+++ b/hello_world/Cargo.toml
@@ -3,7 +3,7 @@ name = "soroban-hello-world-contract"
 version = "0.0.0"
 edition = "2021"
 publish = false
-rust-version = "1.80.0"
+rust-version = "1.85.0"
 
 [lib]
 crate-type = ["cdylib"]

--- a/hello_world/Makefile
+++ b/hello_world/Makefile
@@ -7,7 +7,7 @@ test: build
 
 build:
 	stellar contract build
-	@ls -l target/wasm32-unknown-unknown/release/*.wasm
+	@ls -l target/wasm32v1-none/release/*.wasm
 
 fmt:
 	cargo fmt --all

--- a/hello_world/Makefile
+++ b/hello_world/Makefile
@@ -7,7 +7,12 @@ test: build
 
 build:
 	stellar contract build
-	@ls -l target/wasm32v1-none/release/*.wasm
+	@RUST_VERSION=$$(rustc --version | cut -d' ' -f2); \
+	if [ "$$(printf '%s\n%s\n' $$RUST_VERSION 1.81.0 | sort -V | head -n1)" = "1.81.0" ]; then \
+		ls -l target/wasm32v1-none/release/*.wasm; \
+	else \
+		ls -l target/wasm32-unknown-unknown/release/*.wasm; \
+	fi
 
 fmt:
 	cargo fmt --all

--- a/hello_world/Makefile
+++ b/hello_world/Makefile
@@ -7,12 +7,7 @@ test: build
 
 build:
 	stellar contract build
-	@RUST_VERSION=$$(rustc --version | cut -d' ' -f2); \
-	if [ "$$(printf '%s\n%s\n' $$RUST_VERSION 1.81.0 | sort -V | head -n1)" = "1.81.0" ]; then \
-		ls -l target/wasm32v1-none/release/*.wasm; \
-	else \
-		ls -l target/wasm32-unknown-unknown/release/*.wasm; \
-	fi
+	@ls -l target/wasm32v1-none/release/*.wasm
 
 fmt:
 	cargo fmt --all

--- a/import_ark_bn254/Cargo.toml
+++ b/import_ark_bn254/Cargo.toml
@@ -3,7 +3,7 @@ name = "soroban-ark-bn254-contract"
 version = "0.0.0"
 edition = "2021"
 publish = false
-rust-version = "1.84.0"
+rust-version = "1.85.0"
 
 [lib]
 crate-type = ["cdylib"]

--- a/import_ark_bn254/rust-toolchain.toml
+++ b/import_ark_bn254/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.84.0"
+channel = "1.85.0"
 targets = ["wasm32v1-none"]
 components = ["rustc", "cargo", "rustfmt", "clippy", "rust-src"]

--- a/increment/Cargo.toml
+++ b/increment/Cargo.toml
@@ -3,7 +3,7 @@ name = "soroban-increment-contract"
 version = "0.0.0"
 edition = "2021"
 publish = false
-rust-version = "1.80.0"
+rust-version = "1.85.0"
 
 [lib]
 crate-type = ["cdylib"]

--- a/increment/Makefile
+++ b/increment/Makefile
@@ -7,7 +7,7 @@ test: build
 
 build:
 	stellar contract build
-	@ls -l target/wasm32-unknown-unknown/release/*.wasm
+	@ls -l target/wasm32v1-none/release/*.wasm
 
 fmt:
 	cargo fmt --all

--- a/increment/Makefile
+++ b/increment/Makefile
@@ -7,7 +7,12 @@ test: build
 
 build:
 	stellar contract build
-	@ls -l target/wasm32v1-none/release/*.wasm
+	@RUST_VERSION=$$(rustc --version | cut -d' ' -f2); \
+	if [ "$$(printf '%s\n%s\n' $$RUST_VERSION 1.81.0 | sort -V | head -n1)" = "1.81.0" ]; then \
+		ls -l target/wasm32v1-none/release/*.wasm; \
+	else \
+		ls -l target/wasm32-unknown-unknown/release/*.wasm; \
+	fi
 
 fmt:
 	cargo fmt --all

--- a/increment/Makefile
+++ b/increment/Makefile
@@ -7,12 +7,7 @@ test: build
 
 build:
 	stellar contract build
-	@RUST_VERSION=$$(rustc --version | cut -d' ' -f2); \
-	if [ "$$(printf '%s\n%s\n' $$RUST_VERSION 1.81.0 | sort -V | head -n1)" = "1.81.0" ]; then \
-		ls -l target/wasm32v1-none/release/*.wasm; \
-	else \
-		ls -l target/wasm32-unknown-unknown/release/*.wasm; \
-	fi
+	@ls -l target/wasm32v1-none/release/*.wasm
 
 fmt:
 	cargo fmt --all

--- a/increment_with_fuzz/Cargo.toml
+++ b/increment_with_fuzz/Cargo.toml
@@ -3,7 +3,7 @@ name = "soroban-increment-with-fuzz-contract"
 version = "0.0.0"
 edition = "2021"
 publish = false
-rust-version = "1.80.0"
+rust-version = "1.85.0"
 
 [lib]
 crate-type = ["lib", "cdylib"]

--- a/increment_with_fuzz/Makefile
+++ b/increment_with_fuzz/Makefile
@@ -8,12 +8,7 @@ test: build
 
 build:
 	stellar contract build
-	@RUST_VERSION=$$(rustc --version | cut -d' ' -f2); \
-	if [ "$$(printf '%s\n%s\n' $$RUST_VERSION 1.81.0 | sort -V | head -n1)" = "1.81.0" ]; then \
-		ls -l target/wasm32v1-none/release/*.wasm; \
-	else \
-		ls -l target/wasm32-unknown-unknown/release/*.wasm; \
-	fi
+	@ls -l target/wasm32v1-none/release/*.wasm
 
 fmt:
 	cargo fmt --all

--- a/increment_with_fuzz/Makefile
+++ b/increment_with_fuzz/Makefile
@@ -8,7 +8,12 @@ test: build
 
 build:
 	stellar contract build
-	@ls -l target/wasm32v1-none/release/*.wasm
+	@RUST_VERSION=$$(rustc --version | cut -d' ' -f2); \
+	if [ "$$(printf '%s\n%s\n' $$RUST_VERSION 1.81.0 | sort -V | head -n1)" = "1.81.0" ]; then \
+		ls -l target/wasm32v1-none/release/*.wasm; \
+	else \
+		ls -l target/wasm32-unknown-unknown/release/*.wasm; \
+	fi
 
 fmt:
 	cargo fmt --all

--- a/increment_with_fuzz/Makefile
+++ b/increment_with_fuzz/Makefile
@@ -8,7 +8,7 @@ test: build
 
 build:
 	stellar contract build
-	@ls -l target/wasm32-unknown-unknown/release/*.wasm
+	@ls -l target/wasm32v1-none/release/*.wasm
 
 fmt:
 	cargo fmt --all

--- a/increment_with_pause/Cargo.toml
+++ b/increment_with_pause/Cargo.toml
@@ -3,7 +3,7 @@ name = "soroban-increment-with-pause-contract"
 version = "0.0.0"
 edition = "2021"
 publish = false
-rust-version = "1.80.0"
+rust-version = "1.85.0"
 
 [lib]
 crate-type = ["cdylib"]

--- a/increment_with_pause/Makefile
+++ b/increment_with_pause/Makefile
@@ -8,12 +8,7 @@ test: build
 
 build:
 	stellar contract build
-	@RUST_VERSION=$$(rustc --version | cut -d' ' -f2); \
-	if [ "$$(printf '%s\n%s\n' $$RUST_VERSION 1.81.0 | sort -V | head -n1)" = "1.81.0" ]; then \
-		ls -l target/wasm32v1-none/release/*.wasm; \
-	else \
-		ls -l target/wasm32-unknown-unknown/release/*.wasm; \
-	fi
+	@ls -l target/wasm32v1-none/release/*.wasm
 
 fmt:
 	cargo fmt --all

--- a/increment_with_pause/Makefile
+++ b/increment_with_pause/Makefile
@@ -8,7 +8,12 @@ test: build
 
 build:
 	stellar contract build
-	@ls -l target/wasm32v1-none/release/*.wasm
+	@RUST_VERSION=$$(rustc --version | cut -d' ' -f2); \
+	if [ "$$(printf '%s\n%s\n' $$RUST_VERSION 1.81.0 | sort -V | head -n1)" = "1.81.0" ]; then \
+		ls -l target/wasm32v1-none/release/*.wasm; \
+	else \
+		ls -l target/wasm32-unknown-unknown/release/*.wasm; \
+	fi
 
 fmt:
 	cargo fmt --all

--- a/increment_with_pause/Makefile
+++ b/increment_with_pause/Makefile
@@ -8,7 +8,7 @@ test: build
 
 build:
 	stellar contract build
-	@ls -l target/wasm32-unknown-unknown/release/*.wasm
+	@ls -l target/wasm32v1-none/release/*.wasm
 
 fmt:
 	cargo fmt --all

--- a/increment_with_pause/src/test_real.rs
+++ b/increment_with_pause/src/test_real.rs
@@ -4,7 +4,7 @@ use soroban_sdk::Env;
 
 mod pause {
     soroban_sdk::contractimport!(
-        file = "../pause/target/wasm32-unknown-unknown/release/soroban_pause_contract.wasm"
+        file = "../pause/target/wasm32v1-none/release/soroban_pause_contract.wasm"
     );
 }
 

--- a/liquidity_pool/Cargo.toml
+++ b/liquidity_pool/Cargo.toml
@@ -3,7 +3,7 @@ name = "soroban-liquidity-pool-contract"
 version = "0.0.0"
 edition = "2021"
 publish = false
-rust-version = "1.80.0"
+rust-version = "1.85.0"
 
 [lib]
 crate-type = ["cdylib"]

--- a/liquidity_pool/Makefile
+++ b/liquidity_pool/Makefile
@@ -8,7 +8,7 @@ test: build
 build:
 	$(MAKE) -C ../token || break;
 	stellar contract build
-	@ls -l target/wasm32-unknown-unknown/release/*.wasm
+	@ls -l target/wasm32v1-none/release/*.wasm
 fmt:
 	cargo fmt --all
 

--- a/liquidity_pool/Makefile
+++ b/liquidity_pool/Makefile
@@ -7,12 +7,7 @@ test: build
 
 build:
 	stellar contract build
-	@RUST_VERSION=$$(rustc --version | cut -d' ' -f2); \
-	if [ "$$(printf '%s\n%s\n' $$RUST_VERSION 1.81.0 | sort -V | head -n1)" = "1.81.0" ]; then \
-		ls -l target/wasm32v1-none/release/*.wasm; \
-	else \
-		ls -l target/wasm32-unknown-unknown/release/*.wasm; \
-	fi
+	@ls -l target/wasm32v1-none/release/*.wasm
 fmt:
 	cargo fmt --all
 

--- a/liquidity_pool/Makefile
+++ b/liquidity_pool/Makefile
@@ -6,9 +6,13 @@ test: build
 	cargo test
 
 build:
-	$(MAKE) -C ../token || break;
 	stellar contract build
-	@ls -l target/wasm32v1-none/release/*.wasm
+	@RUST_VERSION=$$(rustc --version | cut -d' ' -f2); \
+	if [ "$$(printf '%s\n%s\n' $$RUST_VERSION 1.81.0 | sort -V | head -n1)" = "1.81.0" ]; then \
+		ls -l target/wasm32v1-none/release/*.wasm; \
+	else \
+		ls -l target/wasm32-unknown-unknown/release/*.wasm; \
+	fi
 fmt:
 	cargo fmt --all
 

--- a/logging/Cargo.toml
+++ b/logging/Cargo.toml
@@ -3,7 +3,7 @@ name = "soroban-logging-contract"
 version = "0.0.0"
 edition = "2021"
 publish = false
-rust-version = "1.80.0"
+rust-version = "1.85.0"
 
 [lib]
 crate-type = ["cdylib"]

--- a/logging/Makefile
+++ b/logging/Makefile
@@ -7,7 +7,7 @@ test: build
 
 build:
 	stellar contract build
-	@ls -l target/wasm32-unknown-unknown/release/*.wasm
+	@ls -l target/wasm32v1-none/release/*.wasm
 
 fmt:
 	cargo fmt --all

--- a/logging/Makefile
+++ b/logging/Makefile
@@ -7,7 +7,12 @@ test: build
 
 build:
 	stellar contract build
-	@ls -l target/wasm32v1-none/release/*.wasm
+	@RUST_VERSION=$$(rustc --version | cut -d' ' -f2); \
+	if [ "$$(printf '%s\n%s\n' $$RUST_VERSION 1.81.0 | sort -V | head -n1)" = "1.81.0" ]; then \
+		ls -l target/wasm32v1-none/release/*.wasm; \
+	else \
+		ls -l target/wasm32-unknown-unknown/release/*.wasm; \
+	fi
 
 fmt:
 	cargo fmt --all

--- a/logging/Makefile
+++ b/logging/Makefile
@@ -7,12 +7,7 @@ test: build
 
 build:
 	stellar contract build
-	@RUST_VERSION=$$(rustc --version | cut -d' ' -f2); \
-	if [ "$$(printf '%s\n%s\n' $$RUST_VERSION 1.81.0 | sort -V | head -n1)" = "1.81.0" ]; then \
-		ls -l target/wasm32v1-none/release/*.wasm; \
-	else \
-		ls -l target/wasm32-unknown-unknown/release/*.wasm; \
-	fi
+	@ls -l target/wasm32v1-none/release/*.wasm
 
 fmt:
 	cargo fmt --all

--- a/mint-lock/Cargo.toml
+++ b/mint-lock/Cargo.toml
@@ -3,7 +3,7 @@ name = "soroban-mint-lock-contract"
 version = "0.0.0"
 edition = "2021"
 publish = false
-rust-version = "1.80.0"
+rust-version = "1.85.0"
 
 [lib]
 crate-type = ["cdylib"]

--- a/mint-lock/Makefile
+++ b/mint-lock/Makefile
@@ -7,7 +7,7 @@ test: build
 
 build:
 	stellar contract build
-	@ls -l target/wasm32-unknown-unknown/release/*.wasm
+	@ls -l target/wasm32v1-none/release/*.wasm
 
 fmt:
 	cargo fmt --all

--- a/mint-lock/Makefile
+++ b/mint-lock/Makefile
@@ -7,7 +7,12 @@ test: build
 
 build:
 	stellar contract build
-	@ls -l target/wasm32v1-none/release/*.wasm
+	@RUST_VERSION=$$(rustc --version | cut -d' ' -f2); \
+	if [ "$$(printf '%s\n%s\n' $$RUST_VERSION 1.81.0 | sort -V | head -n1)" = "1.81.0" ]; then \
+		ls -l target/wasm32v1-none/release/*.wasm; \
+	else \
+		ls -l target/wasm32-unknown-unknown/release/*.wasm; \
+	fi
 
 fmt:
 	cargo fmt --all

--- a/mint-lock/Makefile
+++ b/mint-lock/Makefile
@@ -7,12 +7,7 @@ test: build
 
 build:
 	stellar contract build
-	@RUST_VERSION=$$(rustc --version | cut -d' ' -f2); \
-	if [ "$$(printf '%s\n%s\n' $$RUST_VERSION 1.81.0 | sort -V | head -n1)" = "1.81.0" ]; then \
-		ls -l target/wasm32v1-none/release/*.wasm; \
-	else \
-		ls -l target/wasm32-unknown-unknown/release/*.wasm; \
-	fi
+	@ls -l target/wasm32v1-none/release/*.wasm
 
 fmt:
 	cargo fmt --all

--- a/multisig_1_of_n_account/contract/Cargo.toml
+++ b/multisig_1_of_n_account/contract/Cargo.toml
@@ -3,7 +3,7 @@ name = "soroban-multisig-1-of-n-account-contract"
 version = "0.0.0"
 edition = "2021"
 publish = false
-rust-version = "1.80.0"
+rust-version = "1.85.0"
 
 [lib]
 crate-type = ["cdylib"]

--- a/multisig_1_of_n_account/contract/Makefile
+++ b/multisig_1_of_n_account/contract/Makefile
@@ -7,7 +7,7 @@ test: build
 
 build:
 	stellar contract build
-	@ls -l target/wasm32-unknown-unknown/release/*.wasm
+	@ls -l target/wasm32v1-none/release/*.wasm
 
 fmt:
 	cargo fmt --all

--- a/multisig_1_of_n_account/contract/Makefile
+++ b/multisig_1_of_n_account/contract/Makefile
@@ -7,7 +7,12 @@ test: build
 
 build:
 	stellar contract build
-	@ls -l target/wasm32v1-none/release/*.wasm
+	@RUST_VERSION=$$(rustc --version | cut -d' ' -f2); \
+	if [ "$$(printf '%s\n%s\n' $$RUST_VERSION 1.81.0 | sort -V | head -n1)" = "1.81.0" ]; then \
+		ls -l target/wasm32v1-none/release/*.wasm; \
+	else \
+		ls -l target/wasm32-unknown-unknown/release/*.wasm; \
+	fi
 
 fmt:
 	cargo fmt --all

--- a/multisig_1_of_n_account/contract/Makefile
+++ b/multisig_1_of_n_account/contract/Makefile
@@ -7,12 +7,7 @@ test: build
 
 build:
 	stellar contract build
-	@RUST_VERSION=$$(rustc --version | cut -d' ' -f2); \
-	if [ "$$(printf '%s\n%s\n' $$RUST_VERSION 1.81.0 | sort -V | head -n1)" = "1.81.0" ]; then \
-		ls -l target/wasm32v1-none/release/*.wasm; \
-	else \
-		ls -l target/wasm32-unknown-unknown/release/*.wasm; \
-	fi
+	@ls -l target/wasm32v1-none/release/*.wasm
 
 fmt:
 	cargo fmt --all

--- a/multisig_1_of_n_account/stellar-cli-sign-auth-ed25519/Cargo.toml
+++ b/multisig_1_of_n_account/stellar-cli-sign-auth-ed25519/Cargo.toml
@@ -3,7 +3,7 @@ name = "stellar-sign-auth-ed25519"
 version = "0.1.0"
 edition = "2021"
 publish = false
-rust-version = "1.80.0"
+rust-version = "1.85.0"
 
 [dependencies]
 stellar-xdr = { version = "22.2.0", features = ["base64", "serde"] }

--- a/multisig_1_of_n_account/stellar-cli-sign-auth-ed25519/rust-toolchain.toml
+++ b/multisig_1_of_n_account/stellar-cli-sign-auth-ed25519/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.84"
+channel = "1.85"
 targets = []
 components = ["rustc", "cargo", "rustfmt", "clippy", "rust-src"]

--- a/other_custom_types/Cargo.toml
+++ b/other_custom_types/Cargo.toml
@@ -3,7 +3,7 @@ name = "soroban-other-custom-types-contract"
 version = "0.0.0"
 edition = "2021"
 publish = false
-rust-version = "1.80.0"
+rust-version = "1.85.0"
 
 [lib]
 crate-type = ["cdylib"]

--- a/other_custom_types/Makefile
+++ b/other_custom_types/Makefile
@@ -7,7 +7,7 @@ test: build
 
 build:
 	stellar contract build
-	@ls -l target/wasm32-unknown-unknown/release/*.wasm
+	@ls -l target/wasm32v1-none/release/*.wasm
 
 fmt:
 	cargo fmt --all

--- a/other_custom_types/Makefile
+++ b/other_custom_types/Makefile
@@ -7,7 +7,12 @@ test: build
 
 build:
 	stellar contract build
-	@ls -l target/wasm32v1-none/release/*.wasm
+	@RUST_VERSION=$$(rustc --version | cut -d' ' -f2); \
+	if [ "$$(printf '%s\n%s\n' $$RUST_VERSION 1.81.0 | sort -V | head -n1)" = "1.81.0" ]; then \
+		ls -l target/wasm32v1-none/release/*.wasm; \
+	else \
+		ls -l target/wasm32-unknown-unknown/release/*.wasm; \
+	fi
 
 fmt:
 	cargo fmt --all

--- a/other_custom_types/Makefile
+++ b/other_custom_types/Makefile
@@ -7,12 +7,7 @@ test: build
 
 build:
 	stellar contract build
-	@RUST_VERSION=$$(rustc --version | cut -d' ' -f2); \
-	if [ "$$(printf '%s\n%s\n' $$RUST_VERSION 1.81.0 | sort -V | head -n1)" = "1.81.0" ]; then \
-		ls -l target/wasm32v1-none/release/*.wasm; \
-	else \
-		ls -l target/wasm32-unknown-unknown/release/*.wasm; \
-	fi
+	@ls -l target/wasm32v1-none/release/*.wasm
 
 fmt:
 	cargo fmt --all

--- a/pause/Cargo.toml
+++ b/pause/Cargo.toml
@@ -3,7 +3,7 @@ name = "soroban-pause-contract"
 version = "0.0.0"
 edition = "2021"
 publish = false
-rust-version = "1.80.0"
+rust-version = "1.85.0"
 
 [lib]
 crate-type = ["cdylib"]

--- a/pause/Makefile
+++ b/pause/Makefile
@@ -7,7 +7,7 @@ test: build
 
 build:
 	stellar contract build
-	@ls -l target/wasm32-unknown-unknown/release/*.wasm
+	@ls -l target/wasm32v1-none/release/*.wasm
 
 fmt:
 	cargo fmt --all

--- a/pause/Makefile
+++ b/pause/Makefile
@@ -7,13 +7,7 @@ test: build
 
 build:
 	stellar contract build
-	@RUST_VERSION=$$(rustc --version | cut -d' ' -f2); \
-	if [ "$$(printf '%s\n%s\n' $$RUST_VERSION 1.81.0 | sort -V | head -n1)" = "1.81.0" ]; then \
-		ls -l target/wasm32v1-none/release/*.wasm; \
-	else \
-		ls -l target/wasm32-unknown-unknown/release/*.wasm; \
-	fi
-
+	@ls -l target/wasm32v1-none/release/*.wasm
 fmt:
 	cargo fmt --all
 

--- a/pause/Makefile
+++ b/pause/Makefile
@@ -7,7 +7,12 @@ test: build
 
 build:
 	stellar contract build
-	@ls -l target/wasm32v1-none/release/*.wasm
+	@RUST_VERSION=$$(rustc --version | cut -d' ' -f2); \
+	if [ "$$(printf '%s\n%s\n' $$RUST_VERSION 1.81.0 | sort -V | head -n1)" = "1.81.0" ]; then \
+		ls -l target/wasm32v1-none/release/*.wasm; \
+	else \
+		ls -l target/wasm32-unknown-unknown/release/*.wasm; \
+	fi
 
 fmt:
 	cargo fmt --all

--- a/pause/Makefile
+++ b/pause/Makefile
@@ -8,6 +8,7 @@ test: build
 build:
 	stellar contract build
 	@ls -l target/wasm32v1-none/release/*.wasm
+
 fmt:
 	cargo fmt --all
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.81"
-targets = ["wasm32-unknown-unknown"]
+channel = "1.84"
+targets = ["wasm32v1-none"]
 components = ["rustc", "cargo", "rustfmt", "clippy", "rust-src"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.84"
+channel = "1.85"
 targets = ["wasm32v1-none"]
 components = ["rustc", "cargo", "rustfmt", "clippy", "rust-src"]

--- a/simple_account/Cargo.toml
+++ b/simple_account/Cargo.toml
@@ -3,7 +3,7 @@ name = "soroban-simple-account-contract"
 version = "0.0.0"
 edition = "2021"
 publish = false
-rust-version = "1.80.0"
+rust-version = "1.85.0"
 
 [lib]
 crate-type = ["cdylib"]

--- a/simple_account/Makefile
+++ b/simple_account/Makefile
@@ -7,7 +7,7 @@ test: build
 
 build:
 	stellar contract build
-	@ls -l target/wasm32-unknown-unknown/release/*.wasm
+	@ls -l target/wasm32v1-none/release/*.wasm
 
 fmt:
 	cargo fmt --all

--- a/simple_account/Makefile
+++ b/simple_account/Makefile
@@ -7,7 +7,12 @@ test: build
 
 build:
 	stellar contract build
-	@ls -l target/wasm32v1-none/release/*.wasm
+	@RUST_VERSION=$$(rustc --version | cut -d' ' -f2); \
+	if [ "$$(printf '%s\n%s\n' $$RUST_VERSION 1.81.0 | sort -V | head -n1)" = "1.81.0" ]; then \
+		ls -l target/wasm32v1-none/release/*.wasm; \
+	else \
+		ls -l target/wasm32-unknown-unknown/release/*.wasm; \
+	fi
 
 fmt:
 	cargo fmt --all

--- a/simple_account/Makefile
+++ b/simple_account/Makefile
@@ -7,12 +7,7 @@ test: build
 
 build:
 	stellar contract build
-	@RUST_VERSION=$$(rustc --version | cut -d' ' -f2); \
-	if [ "$$(printf '%s\n%s\n' $$RUST_VERSION 1.81.0 | sort -V | head -n1)" = "1.81.0" ]; then \
-		ls -l target/wasm32v1-none/release/*.wasm; \
-	else \
-		ls -l target/wasm32-unknown-unknown/release/*.wasm; \
-	fi
+	@ls -l target/wasm32v1-none/release/*.wasm
 
 fmt:
 	cargo fmt --all

--- a/single_offer/Cargo.toml
+++ b/single_offer/Cargo.toml
@@ -3,7 +3,7 @@ name = "soroban-single-offer-contract"
 version = "0.0.0"
 edition = "2021"
 publish = false
-rust-version = "1.80.0"
+rust-version = "1.85.0"
 
 [lib]
 crate-type = ["cdylib"]

--- a/single_offer/Makefile
+++ b/single_offer/Makefile
@@ -7,7 +7,7 @@ test: build
 
 build:
 	stellar contract build
-	@ls -l target/wasm32-unknown-unknown/release/*.wasm
+	@ls -l target/wasm32v1-none/release/*.wasm
 
 fmt:
 	cargo fmt --all

--- a/single_offer/Makefile
+++ b/single_offer/Makefile
@@ -7,7 +7,12 @@ test: build
 
 build:
 	stellar contract build
-	@ls -l target/wasm32v1-none/release/*.wasm
+	@RUST_VERSION=$$(rustc --version | cut -d' ' -f2); \
+	if [ "$$(printf '%s\n%s\n' $$RUST_VERSION 1.81.0 | sort -V | head -n1)" = "1.81.0" ]; then \
+		ls -l target/wasm32v1-none/release/*.wasm; \
+	else \
+		ls -l target/wasm32-unknown-unknown/release/*.wasm; \
+	fi
 
 fmt:
 	cargo fmt --all

--- a/single_offer/Makefile
+++ b/single_offer/Makefile
@@ -7,12 +7,7 @@ test: build
 
 build:
 	stellar contract build
-	@RUST_VERSION=$$(rustc --version | cut -d' ' -f2); \
-	if [ "$$(printf '%s\n%s\n' $$RUST_VERSION 1.81.0 | sort -V | head -n1)" = "1.81.0" ]; then \
-		ls -l target/wasm32v1-none/release/*.wasm; \
-	else \
-		ls -l target/wasm32-unknown-unknown/release/*.wasm; \
-	fi
+	@ls -l target/wasm32v1-none/release/*.wasm
 
 fmt:
 	cargo fmt --all

--- a/timelock/Cargo.toml
+++ b/timelock/Cargo.toml
@@ -3,7 +3,7 @@ name = "soroban-timelock-contract"
 version = "0.0.0"
 edition = "2021"
 publish = false
-rust-version = "1.80.0"
+rust-version = "1.85.0"
 
 [lib]
 crate-type = ["cdylib"]

--- a/timelock/Makefile
+++ b/timelock/Makefile
@@ -7,7 +7,7 @@ test: build
 
 build:
 	stellar contract build
-	@ls -l target/wasm32-unknown-unknown/release/*.wasm
+	@ls -l target/wasm32v1-none/release/*.wasm
 
 fmt:
 	cargo fmt --all

--- a/timelock/Makefile
+++ b/timelock/Makefile
@@ -7,7 +7,12 @@ test: build
 
 build:
 	stellar contract build
-	@ls -l target/wasm32v1-none/release/*.wasm
+	@RUST_VERSION=$$(rustc --version | cut -d' ' -f2); \
+	if [ "$$(printf '%s\n%s\n' $$RUST_VERSION 1.81.0 | sort -V | head -n1)" = "1.81.0" ]; then \
+		ls -l target/wasm32v1-none/release/*.wasm; \
+	else \
+		ls -l target/wasm32-unknown-unknown/release/*.wasm; \
+	fi
 
 fmt:
 	cargo fmt --all

--- a/timelock/Makefile
+++ b/timelock/Makefile
@@ -7,12 +7,7 @@ test: build
 
 build:
 	stellar contract build
-	@RUST_VERSION=$$(rustc --version | cut -d' ' -f2); \
-	if [ "$$(printf '%s\n%s\n' $$RUST_VERSION 1.81.0 | sort -V | head -n1)" = "1.81.0" ]; then \
-		ls -l target/wasm32v1-none/release/*.wasm; \
-	else \
-		ls -l target/wasm32-unknown-unknown/release/*.wasm; \
-	fi
+	@ls -l target/wasm32v1-none/release/*.wasm
 
 fmt:
 	cargo fmt --all

--- a/token/Cargo.toml
+++ b/token/Cargo.toml
@@ -3,7 +3,7 @@ name = "soroban-token-contract"
 description = "Soroban standard token contract"
 version = "0.0.6"
 edition = "2021"
-rust-version = "1.80.0"
+rust-version = "1.85.0"
 
 [lib]
 crate-type = ["cdylib"]

--- a/token/Makefile
+++ b/token/Makefile
@@ -7,7 +7,7 @@ test: build
 
 build:
 	stellar contract build
-	@ls -l target/wasm32-unknown-unknown/release/*.wasm
+	@ls -l target/wasm32v1-none/release/*.wasm
 
 fmt:
 	cargo fmt --all

--- a/token/Makefile
+++ b/token/Makefile
@@ -7,7 +7,12 @@ test: build
 
 build:
 	stellar contract build
-	@ls -l target/wasm32v1-none/release/*.wasm
+	@RUST_VERSION=$$(rustc --version | cut -d' ' -f2); \
+	if [ "$$(printf '%s\n%s\n' $$RUST_VERSION 1.81.0 | sort -V | head -n1)" = "1.81.0" ]; then \
+		ls -l target/wasm32v1-none/release/*.wasm; \
+	else \
+		ls -l target/wasm32-unknown-unknown/release/*.wasm; \
+	fi
 
 fmt:
 	cargo fmt --all

--- a/token/Makefile
+++ b/token/Makefile
@@ -7,12 +7,7 @@ test: build
 
 build:
 	stellar contract build
-	@RUST_VERSION=$$(rustc --version | cut -d' ' -f2); \
-	if [ "$$(printf '%s\n%s\n' $$RUST_VERSION 1.81.0 | sort -V | head -n1)" = "1.81.0" ]; then \
-		ls -l target/wasm32v1-none/release/*.wasm; \
-	else \
-		ls -l target/wasm32-unknown-unknown/release/*.wasm; \
-	fi
+	@ls -l target/wasm32v1-none/release/*.wasm
 
 fmt:
 	cargo fmt --all

--- a/ttl/Cargo.toml
+++ b/ttl/Cargo.toml
@@ -3,7 +3,7 @@ name = "soroban-ttl-example"
 version = "0.0.0"
 edition = "2021"
 publish = false
-rust-version = "1.80.0"
+rust-version = "1.85.0"
 
 [lib]
 crate-type = ["cdylib"]

--- a/ttl/Makefile
+++ b/ttl/Makefile
@@ -7,7 +7,7 @@ test: build
 
 build:
 	stellar contract build
-	@ls -l target/wasm32-unknown-unknown/release/*.wasm
+	@ls -l target/wasm32v1-none/release/*.wasm
 
 fmt:
 	cargo fmt --all

--- a/ttl/Makefile
+++ b/ttl/Makefile
@@ -7,13 +7,7 @@ test: build
 
 build:
 	stellar contract build
-	@RUST_VERSION=$$(rustc --version | cut -d' ' -f2); \
-	if [ "$$(printf '%s\n%s\n' $$RUST_VERSION 1.81.0 | sort -V | head -n1)" = "1.81.0" ]; then \
-		ls -l target/wasm32v1-none/release/*.wasm; \
-	else \
-		ls -l target/wasm32-unknown-unknown/release/*.wasm; \
-	fi
-
+	@ls -l target/wasm32v1-none/release/*.wasm
 fmt:
 	cargo fmt --all
 

--- a/ttl/Makefile
+++ b/ttl/Makefile
@@ -7,7 +7,12 @@ test: build
 
 build:
 	stellar contract build
-	@ls -l target/wasm32v1-none/release/*.wasm
+	@RUST_VERSION=$$(rustc --version | cut -d' ' -f2); \
+	if [ "$$(printf '%s\n%s\n' $$RUST_VERSION 1.81.0 | sort -V | head -n1)" = "1.81.0" ]; then \
+		ls -l target/wasm32v1-none/release/*.wasm; \
+	else \
+		ls -l target/wasm32-unknown-unknown/release/*.wasm; \
+	fi
 
 fmt:
 	cargo fmt --all

--- a/upgradeable_contract/new_contract/Cargo.toml
+++ b/upgradeable_contract/new_contract/Cargo.toml
@@ -3,7 +3,7 @@ name = "soroban-upgradeable-contract-new-contract"
 version = "0.0.0"
 edition = "2021"
 publish = false
-rust-version = "1.80.0"
+rust-version = "1.85.0"
 
 [lib]
 crate-type = ["cdylib"]

--- a/upgradeable_contract/new_contract/Makefile
+++ b/upgradeable_contract/new_contract/Makefile
@@ -7,7 +7,7 @@ test: build
 
 build:
 	stellar contract build
-	@ls -l target/wasm32-unknown-unknown/release/*.wasm
+	@ls -l target/wasm32v1-none/release/*.wasm
 
 fmt:
 	cargo fmt --all

--- a/upgradeable_contract/new_contract/Makefile
+++ b/upgradeable_contract/new_contract/Makefile
@@ -7,7 +7,12 @@ test: build
 
 build:
 	stellar contract build
-	@ls -l target/wasm32v1-none/release/*.wasm
+	@RUST_VERSION=$$(rustc --version | cut -d' ' -f2); \
+	if [ "$$(printf '%s\n%s\n' $$RUST_VERSION 1.81.0 | sort -V | head -n1)" = "1.81.0" ]; then \
+		ls -l target/wasm32v1-none/release/*.wasm; \
+	else \
+		ls -l target/wasm32-unknown-unknown/release/*.wasm; \
+	fi
 
 fmt:
 	cargo fmt --all

--- a/upgradeable_contract/new_contract/Makefile
+++ b/upgradeable_contract/new_contract/Makefile
@@ -7,12 +7,7 @@ test: build
 
 build:
 	stellar contract build
-	@RUST_VERSION=$$(rustc --version | cut -d' ' -f2); \
-	if [ "$$(printf '%s\n%s\n' $$RUST_VERSION 1.81.0 | sort -V | head -n1)" = "1.81.0" ]; then \
-		ls -l target/wasm32v1-none/release/*.wasm; \
-	else \
-		ls -l target/wasm32-unknown-unknown/release/*.wasm; \
-	fi
+	@ls -l target/wasm32v1-none/release/*.wasm
 
 fmt:
 	cargo fmt --all

--- a/upgradeable_contract/old_contract/Cargo.toml
+++ b/upgradeable_contract/old_contract/Cargo.toml
@@ -3,7 +3,7 @@ name = "soroban-upgradeable-contract-old-contract"
 version = "0.0.0"
 edition = "2021"
 publish = false
-rust-version = "1.80.0"
+rust-version = "1.85.0"
 
 [lib]
 crate-type = ["cdylib"]

--- a/upgradeable_contract/old_contract/Makefile
+++ b/upgradeable_contract/old_contract/Makefile
@@ -8,12 +8,7 @@ test: build
 build:
 	$(MAKE) -C ../new_contract || break;
 	stellar contract build
-	@RUST_VERSION=$$(rustc --version | cut -d' ' -f2); \
-	if [ "$$(printf '%s\n%s\n' $$RUST_VERSION 1.81.0 | sort -V | head -n1)" = "1.81.0" ]; then \
-		ls -l target/wasm32v1-none/release/*.wasm; \
-	else \
-		ls -l target/wasm32-unknown-unknown/release/*.wasm; \
-	fi
+	@ls -l target/wasm32v1-none/release/*.wasm
 
 fmt:
 	cargo fmt --all

--- a/upgradeable_contract/old_contract/Makefile
+++ b/upgradeable_contract/old_contract/Makefile
@@ -8,7 +8,12 @@ test: build
 build:
 	$(MAKE) -C ../new_contract || break;
 	stellar contract build
-	@ls -l target/wasm32v1-none/release/*.wasm
+	@RUST_VERSION=$$(rustc --version | cut -d' ' -f2); \
+	if [ "$$(printf '%s\n%s\n' $$RUST_VERSION 1.81.0 | sort -V | head -n1)" = "1.81.0" ]; then \
+		ls -l target/wasm32v1-none/release/*.wasm; \
+	else \
+		ls -l target/wasm32-unknown-unknown/release/*.wasm; \
+	fi
 
 fmt:
 	cargo fmt --all

--- a/upgradeable_contract/old_contract/Makefile
+++ b/upgradeable_contract/old_contract/Makefile
@@ -8,7 +8,7 @@ test: build
 build:
 	$(MAKE) -C ../new_contract || break;
 	stellar contract build
-	@ls -l target/wasm32-unknown-unknown/release/*.wasm
+	@ls -l target/wasm32v1-none/release/*.wasm
 
 fmt:
 	cargo fmt --all

--- a/upgradeable_contract/old_contract/src/test.rs
+++ b/upgradeable_contract/old_contract/src/test.rs
@@ -12,7 +12,7 @@ use crate::{UpgradeableContract, UpgradeableContractClient};
 
 mod new_contract {
     soroban_sdk::contractimport!(
-        file = "../new_contract/target/wasm32-unknown-unknown/release/soroban_upgradeable_contract_new_contract.wasm"
+        file = "../new_contract/target/wasm32v1-none/release/soroban_upgradeable_contract_new_contract.wasm"
     );
 }
 

--- a/workspace/Makefile
+++ b/workspace/Makefile
@@ -7,7 +7,12 @@ test:
 
 build:
 	stellar contract build
-	@ls -l target/wasm32v1-none/release/*.wasm
+	@RUST_VERSION=$$(rustc --version | cut -d' ' -f2); \
+	if [ "$$(printf '%s\n%s\n' $$RUST_VERSION 1.81.0 | sort -V | head -n1)" = "1.81.0" ]; then \
+		ls -l target/wasm32v1-none/release/*.wasm; \
+	else \
+		ls -l target/wasm32-unknown-unknown/release/*.wasm; \
+	fi
 
 fmt:
 	cargo fmt --all

--- a/workspace/Makefile
+++ b/workspace/Makefile
@@ -7,12 +7,7 @@ test:
 
 build:
 	stellar contract build
-	@RUST_VERSION=$$(rustc --version | cut -d' ' -f2); \
-	if [ "$$(printf '%s\n%s\n' $$RUST_VERSION 1.81.0 | sort -V | head -n1)" = "1.81.0" ]; then \
-		ls -l target/wasm32v1-none/release/*.wasm; \
-	else \
-		ls -l target/wasm32-unknown-unknown/release/*.wasm; \
-	fi
+	@ls -l target/wasm32v1-none/release/*.wasm
 
 fmt:
 	cargo fmt --all

--- a/workspace/Makefile
+++ b/workspace/Makefile
@@ -7,7 +7,7 @@ test:
 
 build:
 	stellar contract build
-	@ls -l target/wasm32-unknown-unknown/release/*.wasm
+	@ls -l target/wasm32v1-none/release/*.wasm
 
 fmt:
 	cargo fmt --all

--- a/workspace/contract_a/Cargo.toml
+++ b/workspace/contract_a/Cargo.toml
@@ -3,7 +3,7 @@ name = "soroban-workspace-contract-a"
 version.workspace = true
 edition = "2021"
 publish = false
-rust-version = "1.80.0"
+rust-version = "1.85.0"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/workspace/contract_a_interface/Cargo.toml
+++ b/workspace/contract_a_interface/Cargo.toml
@@ -3,7 +3,7 @@ name = "soroban-workspace-contract-a-interface"
 version.workspace = true
 edition = "2021"
 publish = false
-rust-version = "1.80.0"
+rust-version = "1.85.0"
 
 [lib]
 crate-type = ["rlib"]

--- a/workspace/contract_b/Cargo.toml
+++ b/workspace/contract_b/Cargo.toml
@@ -3,7 +3,7 @@ name = "soroban-workspace-contract-b"
 version.workspace = true
 edition = "2021"
 publish = false
-rust-version = "1.80.0"
+rust-version = "1.85.0"
 
 [lib]
 crate-type = ["cdylib"]


### PR DESCRIPTION
### What

Update wasm target and rust version in rust-toolchain.toml

### Why
 
The e2e tests in the system-test repo clone soroban-examples and to build and test. As of https://github.com/stellar/system-test/pull/141 we are expecting contracts to be built with a target of `wasm32v1-none` and expecting the wasm to be put in a `target/wasm32v1-none/release` dir, however this repo still builds contracts with `wasm32-unknown-unknown` and puts them in a `target/wasm32-unknown-unknown/release` dir.

### Known limitations

There are other places in this repo that mention wasm32-unknown-unknown that likely should change as well. 