### PR TITLE
docs: add Rust doc comments to hello_world, timelock, and events examples

### DIFF
--- a/events/src/lib.rs
+++ b/events/src/lib.rs
@@ -11,12 +11,21 @@ struct IncrementEvent {
     count: u32,
 }
 
+/// A counter contract that emits a Soroban event each time the counter is incremented.
 #[contract]
 pub struct IncrementContract;
 
 #[contractimpl]
 impl IncrementContract {
-    /// Increment increments an internal counter, and returns the value.
+    /// Increments an internal counter and emits a `COUNTER/increment` event.
+    ///
+    /// # Arguments
+    ///
+    /// * `env` - The Soroban environment.
+    ///
+    /// # Returns
+    ///
+    /// The new counter value after incrementing.
     pub fn increment(env: Env) -> u32 {
         // Get the current count.
         let mut count: u32 = env.storage().instance().get(&COUNTER).unwrap_or(0); // If no value set, assume 0.

--- a/hello_world/src/lib.rs
+++ b/hello_world/src/lib.rs
@@ -1,11 +1,22 @@
 #![no_std]
 use soroban_sdk::{contract, contractimpl, vec, Env, String, Vec};
 
+/// A simple greeting contract that returns a hello message.
 #[contract]
 pub struct HelloContract;
 
 #[contractimpl]
 impl HelloContract {
+    /// Returns a greeting for the given name.
+    ///
+    /// # Arguments
+    ///
+    /// * `env` - The Soroban environment.
+    /// * `to` - The name to greet.
+    ///
+    /// # Returns
+    ///
+    /// A vector containing two strings: `"Hello"` and the provided name.
     pub fn hello(env: Env, to: String) -> Vec<String> {
         vec![&env, String::from_str(&env, "Hello"), to]
     }

--- a/timelock/src/lib.rs
+++ b/timelock/src/lib.rs
@@ -11,33 +11,47 @@ use soroban_sdk::{contract, contractimpl, contracttype, token, Address, Env, Vec
 #[derive(Clone)]
 #[contracttype]
 pub enum DataKey {
+    /// Marks whether the contract has been initialized.
     Init,
+    /// Stores the claimable balance details.
     Balance,
 }
 
+/// Defines whether the timelock expires before or after a given timestamp.
 #[derive(Clone)]
 #[contracttype]
 pub enum TimeBoundKind {
+    /// The claim is only valid before the specified timestamp.
     Before,
+    /// The claim is only valid after the specified timestamp.
     After,
 }
 
+/// A time constraint that restricts when a claimable balance can be claimed.
 #[derive(Clone)]
 #[contracttype]
 pub struct TimeBound {
+    /// Specifies whether the claim must occur before or after the timestamp.
     pub kind: TimeBoundKind,
+    /// The Unix timestamp (in seconds) used for the time constraint.
     pub timestamp: u64,
 }
 
+/// Holds the state of a deposited claimable balance.
 #[derive(Clone)]
 #[contracttype]
 pub struct ClaimableBalance {
+    /// The address of the token contract.
     pub token: Address,
+    /// The token amount that has been deposited and can be claimed.
     pub amount: i128,
+    /// The list of addresses that are allowed to claim the balance.
     pub claimants: Vec<Address>,
+    /// The time constraint that determines when the balance can be claimed.
     pub time_bound: TimeBound,
 }
 
+/// A contract that implements a claimable balance with a time lock.
 #[contract]
 pub struct ClaimableBalanceContract;
 
@@ -54,6 +68,25 @@ fn check_time_bound(env: &Env, time_bound: &TimeBound) -> bool {
 
 #[contractimpl]
 impl ClaimableBalanceContract {
+    /// Deposits tokens into the contract to create a claimable balance.
+    ///
+    /// The balance can later be claimed by one of the specified claimants,
+    /// provided the time constraint is satisfied.
+    ///
+    /// # Arguments
+    ///
+    /// * `env` - The Soroban environment.
+    /// * `from` - The address of the depositor. Must authorize this call.
+    /// * `token` - The address of the token contract.
+    /// * `amount` - The number of tokens to deposit.
+    /// * `claimants` - A list of addresses eligible to claim the balance (max 10).
+    /// * `time_bound` - The time constraint that must be satisfied before the
+    ///   balance can be claimed.
+    ///
+    /// # Panics
+    ///
+    /// Panics if more than 10 claimants are provided, or if the contract has
+    /// already been initialized.
     pub fn deposit(
         env: Env,
         from: Address,
@@ -90,6 +123,18 @@ impl ClaimableBalanceContract {
         env.storage().instance().set(&DataKey::Init, &());
     }
 
+    /// Claims the deposited balance on behalf of an authorized claimant.
+    ///
+    /// # Arguments
+    ///
+    /// * `env` - The Soroban environment.
+    /// * `claimant` - The address attempting to claim. Must be in the claimants
+    ///   list and must authorize this call.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the time constraint is not satisfied, if the claimant is not
+    /// in the allowed list, or if there is no balance to claim.
     pub fn claim(env: Env, claimant: Address) {
         // Make sure claimant has authorized this call, which ensures their
         // identity.


### PR DESCRIPTION
## Summary

Adds Rust doc comments (`///`) to public types, functions, and enum variants in three core examples, following the [Google style guide for docstrings](https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings) as suggested in #280.

### Examples updated

**`hello_world`**
- Contract struct doc comment
- `hello()` function: Args and Returns sections

**`timelock`**
- `DataKey` enum variant docs
- `TimeBoundKind` enum and variant docs
- `TimeBound` struct and field docs
- `ClaimableBalance` struct and field docs
- `ClaimableBalanceContract` struct doc
- `deposit()`: Args and Panics sections
- `claim()`: Args and Panics sections

**`events`**
- `IncrementContract` struct doc
- `increment()`: Args and Returns sections

### Why this matters

Rust doc comments in Soroban contracts appear in:
1. **Generated TypeScript bindings** — enabling better autocomplete and hover docs in frontend IDEs
2. **soroban-cli help output** — operators see these when inspecting deployed contracts

Closes #280 (partial — more examples can be covered in follow-up PRs)

Made with [Cursor](https://cursor.com)