### PR TITLE
Use stable Rust toolchain channel

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.89"
+channel = "stable"
 targets = ["wasm32v1-none"]
 components = ["rustc", "cargo", "rustfmt", "clippy", "rust-src"]


### PR DESCRIPTION
### What
Change the Rust toolchain channel in `rust-toolchain.toml` from the pinned version `1.89` to `stable`.

### Why
There's no reason to pin the rust version during development. The examples should always work with new versions of rust and most people using it will be using a variety of versions of rust, not just this one so pinning isn't helpful for maintaining a realistic dev environment.

Also, this makes it hard to test with new soroban-sdk versions that need a newer rust version.