### PR TITLE
Set rust toolchain to stable for remaining examples

### DIFF
--- a/groth16_verifier/rust-toolchain.toml
+++ b/groth16_verifier/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.89.0"
+channel = "stable"
 targets = ["wasm32v1-none"]
 components = ["rustc", "cargo", "rustfmt", "clippy", "rust-src"]

--- a/import_ark_bn254/rust-toolchain.toml
+++ b/import_ark_bn254/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.89.0"
+channel = "stable"
 targets = ["wasm32v1-none"]
 components = ["rustc", "cargo", "rustfmt", "clippy", "rust-src"]

--- a/multisig_1_of_n_account/stellar-cli-sign-auth-ed25519/rust-toolchain.toml
+++ b/multisig_1_of_n_account/stellar-cli-sign-auth-ed25519/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.89.0"
+channel = "stable"
 targets = []
 components = ["rustc", "cargo", "rustfmt", "clippy", "rust-src"]


### PR DESCRIPTION
### What
Switch the rust toolchain channel from `1.89.0` to `stable` in `groth16_verifier`, `import_ark_bn254`, and `multisig_1_of_n_account/stellar-cli-sign-auth-ed25519`.

### Why
Completes the migration started in #404, which updated most examples to track the stable channel rather than a pinned version.