### PR TITLE
Replace math operators with checked/strict alternatives in contract examples

### DIFF
--- a/alloc/src/lib.rs
+++ b/alloc/src/lib.rs
@@ -13,9 +13,9 @@ impl AllocContract {
         let mut v1 = alloc::vec![];
         (0..count).for_each(|i| v1.push(i));
 
-        let mut sum = 0;
+        let mut sum: u32 = 0;
         for i in v1 {
-            sum += i;
+            sum = sum.checked_add(i).expect("overflow");
         }
 
         sum

--- a/auth/src/lib.rs
+++ b/auth/src/lib.rs
@@ -52,7 +52,7 @@ impl IncrementContract {
         let mut count: u32 = env.storage().persistent().get(&key).unwrap_or_default();
 
         // Increment the count.
-        count += value;
+        count = count.checked_add(value).expect("overflow");
 
         // Save the count.
         env.storage().persistent().set(&key, &count);

--- a/bls_signature/src/lib.rs
+++ b/bls_signature/src/lib.rs
@@ -59,7 +59,7 @@ impl IncrementContract {
     pub fn increment(env: Env) -> u32 {
         env.current_contract_address().require_auth();
         let mut count: u32 = env.storage().instance().get(&DataKey::Counter).unwrap_or(0);
-        count += 1;
+        count = count.checked_add(1).expect("overflow");
         env.storage().instance().set(&DataKey::Counter, &count);
         count
     }

--- a/custom_types/src/lib.rs
+++ b/custom_types/src/lib.rs
@@ -21,7 +21,7 @@ impl IncrementContract {
         let mut state = Self::get_state(env.clone());
 
         // Increment the count.
-        state.count += incr;
+        state.count = state.count.checked_add(incr).expect("overflow");
         state.last_incr = incr;
 
         // Save the count.

--- a/errors/src/lib.rs
+++ b/errors/src/lib.rs
@@ -24,7 +24,7 @@ impl IncrementContract {
         log!(&env, "count: {}", count);
 
         // Increment the count.
-        count += 1;
+        count = count.checked_add(1).expect("overflow");
 
         // Check if the count exceeds the max.
         if count <= MAX {

--- a/events/src/lib.rs
+++ b/events/src/lib.rs
@@ -22,7 +22,7 @@ impl IncrementContract {
         let mut count: u32 = env.storage().instance().get(&COUNTER).unwrap_or(0); // If no value set, assume 0.
 
         // Increment the count.
-        count += 1;
+        count = count.checked_add(1).expect("overflow");
 
         // Save the count.
         env.storage().instance().set(&COUNTER, &count);

--- a/increment/src/lib.rs
+++ b/increment/src/lib.rs
@@ -15,7 +15,7 @@ impl IncrementContract {
         log!(&env, "count: {}", count);
 
         // Increment the count.
-        count += 1;
+        count = count.checked_add(1).expect("overflow");
 
         // Save the count.
         env.storage().instance().set(&COUNTER, &count);

--- a/increment_with_fuzz/src/lib.rs
+++ b/increment_with_fuzz/src/lib.rs
@@ -15,7 +15,7 @@ impl IncrementContract {
         log!(&env, "count: {}", count);
 
         // Increment the count.
-        count += 1;
+        count = count.checked_add(1).expect("overflow");
 
         // Save the count.
         env.storage().instance().set(&COUNTER, &count);

--- a/increment_with_pause/src/lib.rs
+++ b/increment_with_pause/src/lib.rs
@@ -39,7 +39,7 @@ impl IncrementContract {
         let mut count: u32 = env.storage().instance().get(&COUNTER).unwrap_or(0); // If no value set, assume 0.
 
         // Increment the count.
-        count += 1;
+        count = count.checked_add(1).expect("overflow");
 
         // Save the count.
         env.storage().instance().set(&COUNTER, &count);

--- a/liquidity_pool/src/lib.rs
+++ b/liquidity_pool/src/lib.rs
@@ -87,15 +87,15 @@ fn burn_shares(e: &Env, from: &Address, amount: i128) {
         panic!("insufficient shares");
     }
     let total = get_total_shares(e);
-    put_shares(e, from, current_shares - amount);
-    put_total_shares(e, total - amount);
+    put_shares(e, from, current_shares.checked_sub(amount).expect("underflow"));
+    put_total_shares(e, total.checked_sub(amount).expect("underflow"));
 }
 
 fn mint_shares(e: &Env, to: &Address, amount: i128) {
     let current_shares = get_shares(e, to);
     let total = get_total_shares(e);
-    put_shares(e, to, current_shares + amount);
-    put_total_shares(e, total + amount);
+    put_shares(e, to, current_shares.checked_add(amount).expect("overflow"));
+    put_total_shares(e, total.checked_add(amount).expect("overflow"));
 }
 
 fn transfer(e: &Env, token: Address, to: Address, amount: i128) {
@@ -122,14 +122,14 @@ fn get_deposit_amounts(
         return (desired_a, desired_b);
     }
 
-    let amount_b = desired_a * reserve_b / reserve_a;
+    let amount_b = desired_a.checked_mul(reserve_b).expect("overflow").checked_div(reserve_a).expect("division by zero");
     if amount_b <= desired_b {
         if amount_b < min_b {
             panic!("amount_b less than min")
         }
         (desired_a, amount_b)
     } else {
-        let amount_a = desired_b * reserve_a / reserve_b;
+        let amount_a = desired_b.checked_mul(reserve_a).expect("overflow").checked_div(reserve_b).expect("division by zero");
         if amount_a > desired_a || amount_a < min_a {
             panic!("amount_a invalid")
         }
@@ -199,14 +199,14 @@ impl LiquidityPool {
 
         let zero = 0;
         let new_total_shares = if reserve_a > zero && reserve_b > zero {
-            let shares_a = (balance_a * total_shares) / reserve_a;
-            let shares_b = (balance_b * total_shares) / reserve_b;
+            let shares_a = balance_a.checked_mul(total_shares).expect("overflow").checked_div(reserve_a).expect("division by zero");
+            let shares_b = balance_b.checked_mul(total_shares).expect("overflow").checked_div(reserve_b).expect("division by zero");
             shares_a.min(shares_b)
         } else {
-            (balance_a * balance_b).sqrt()
+            balance_a.checked_mul(balance_b).expect("overflow").sqrt()
         };
 
-        mint_shares(&e, &to, new_total_shares - total_shares);
+        mint_shares(&e, &to, new_total_shares.checked_sub(total_shares).expect("underflow"));
         put_reserve_a(&e, balance_a);
         put_reserve_b(&e, balance_b);
     }
@@ -229,9 +229,9 @@ impl LiquidityPool {
         }
 
         // First calculate how much needs to be sold to buy amount out from the pool
-        let n = reserve_sell * out * 1000;
-        let d = (reserve_buy - out) * 997;
-        let sell_amount = (n / d) + 1;
+        let n = reserve_sell.checked_mul(out).expect("overflow").checked_mul(1000).expect("overflow");
+        let d = reserve_buy.checked_sub(out).expect("underflow").checked_mul(997).expect("overflow");
+        let sell_amount = n.checked_div(d).expect("division by zero").checked_add(1).expect("overflow");
         if sell_amount > in_max {
             panic!("in amount is over max")
         }
@@ -249,28 +249,28 @@ impl LiquidityPool {
 
         // residue_numerator and residue_denominator are the amount that the invariant considers after
         // deducting the fee, scaled up by 1000 to avoid fractions
-        let residue_numerator = 997;
-        let residue_denominator = 1000;
-        let zero = 0;
+        let residue_numerator: i128 = 997;
+        let residue_denominator: i128 = 1000;
+        let zero: i128 = 0;
 
         let new_invariant_factor = |balance: i128, reserve: i128, out: i128| {
-            let delta = balance - reserve - out;
+            let delta = balance.checked_sub(reserve).expect("underflow").checked_sub(out).expect("underflow");
             let adj_delta = if delta > zero {
-                residue_numerator * delta
+                residue_numerator.checked_mul(delta).expect("overflow")
             } else {
-                residue_denominator * delta
+                residue_denominator.checked_mul(delta).expect("overflow")
             };
-            residue_denominator * reserve + adj_delta
+            residue_denominator.checked_mul(reserve).expect("overflow").checked_add(adj_delta).expect("overflow")
         };
 
         let (out_a, out_b) = if buy_a { (out, 0) } else { (0, out) };
 
         let new_inv_a = new_invariant_factor(balance_a, reserve_a, out_a);
         let new_inv_b = new_invariant_factor(balance_b, reserve_b, out_b);
-        let old_inv_a = residue_denominator * reserve_a;
-        let old_inv_b = residue_denominator * reserve_b;
+        let old_inv_a = residue_denominator.checked_mul(reserve_a).expect("overflow");
+        let old_inv_b = residue_denominator.checked_mul(reserve_b).expect("overflow");
 
-        if new_inv_a * new_inv_b < old_inv_a * old_inv_b {
+        if new_inv_a.checked_mul(new_inv_b).expect("overflow") < old_inv_a.checked_mul(old_inv_b).expect("overflow") {
             panic!("constant product invariant does not hold");
         }
 
@@ -280,8 +280,8 @@ impl LiquidityPool {
             transfer_b(&e, to, out_b);
         }
 
-        let new_reserve_a = balance_a - out_a;
-        let new_reserve_b = balance_b - out_b;
+        let new_reserve_a = balance_a.checked_sub(out_a).expect("underflow");
+        let new_reserve_b = balance_b.checked_sub(out_b).expect("underflow");
 
         if new_reserve_a <= 0 || new_reserve_b <= 0 {
             panic!("new reserves must be strictly positive");
@@ -312,8 +312,8 @@ impl LiquidityPool {
         let total_shares = get_total_shares(&e);
 
         // Calculate withdrawal amounts
-        let out_a = (balance_a * share_amount) / total_shares;
-        let out_b = (balance_b * share_amount) / total_shares;
+        let out_a = balance_a.checked_mul(share_amount).expect("overflow").checked_div(total_shares).expect("division by zero");
+        let out_b = balance_b.checked_mul(share_amount).expect("overflow").checked_div(total_shares).expect("division by zero");
 
         if out_a < min_a || out_b < min_b {
             panic!("min not satisfied");
@@ -322,8 +322,8 @@ impl LiquidityPool {
         burn_shares(&e, &to, share_amount);
         transfer_a(&e, to.clone(), out_a);
         transfer_b(&e, to, out_b);
-        put_reserve_a(&e, balance_a - out_a);
-        put_reserve_b(&e, balance_b - out_b);
+        put_reserve_a(&e, balance_a.checked_sub(out_a).expect("underflow"));
+        put_reserve_b(&e, balance_b.checked_sub(out_b).expect("underflow"));
 
         (out_a, out_b)
     }

--- a/mint-lock/src/lib.rs
+++ b/mint-lock/src/lib.rs
@@ -88,7 +88,7 @@ impl Contract {
             .persistent()
             .get::<_, MinterConfig>(&StorageKey::Minter(contract.clone(), minter.clone()))
             .ok_or(Error::NotAuthorizedMinter)?;
-        let epoch = env.ledger().sequence() / config.epoch_length;
+        let epoch = env.ledger().sequence().checked_div(config.epoch_length).expect("division by zero");
         let stats = env
             .storage()
             .temporary()
@@ -132,7 +132,7 @@ impl Contract {
             };
 
             // Check and track daily limit.
-            let epoch = env.ledger().sequence() / config.epoch_length;
+            let epoch = env.ledger().sequence().checked_div(config.epoch_length).expect("division by zero");
             let minter_stats_key = StorageKey::MinterStats(
                 contract.clone(),
                 minter.clone(),
@@ -145,7 +145,7 @@ impl Contract {
                 .get::<_, MinterStats>(&minter_stats_key)
                 .unwrap_or_default();
             let new_minter_stats = MinterStats {
-                consumed_limit: minter_stats.consumed_limit + amount,
+                consumed_limit: minter_stats.consumed_limit.checked_add(amount).expect("overflow"),
             };
             if new_minter_stats.consumed_limit > config.limit {
                 return Err(Error::DailyLimitInsufficient);
@@ -155,7 +155,7 @@ impl Contract {
                 .set::<_, MinterStats>(&minter_stats_key, &new_minter_stats);
             // Extend the minter stats entry to live at least until the end
             // of the epoch.
-            let end_of_the_epoch_ledger = config.epoch_length * (epoch + 1) - 1;
+            let end_of_the_epoch_ledger = config.epoch_length.checked_mul(epoch.checked_add(1).expect("overflow")).expect("overflow").checked_sub(1).expect("underflow");
             env.storage().temporary().extend_ttl(
                 &minter_stats_key,
                 end_of_the_epoch_ledger,

--- a/other_custom_types/src/lib.rs
+++ b/other_custom_types/src/lib.rs
@@ -113,7 +113,7 @@ impl CustomTypesContract {
     // increment count and return new one
     pub fn inc(env: Env) -> u32 {
         let mut count: u32 = env.storage().persistent().get(&COUNTER).unwrap_or(0); // Panic if the value of COUNTER is not u32.
-        count += 1;
+        count = count.checked_add(1).expect("overflow");
         env.storage().persistent().set(&COUNTER, &count);
         count
     }


### PR DESCRIPTION
### What
Replace bare arithmetic operators (`+`, `-`, `*`, `/`, `+=`) with their checked equivalents (`checked_add`, `checked_sub`, `checked_mul`, `checked_div`) across 12 contract example source files.

### Why
Encourage developers to think about overflow failure cases when copying these examples as starting points for their own contracts. Raw arithmetic operators silently wrap or panic on overflow — checked functions make overflow handling explicit.

Ref: #383

### Changed examples
- `increment`, `events`, `errors`, `auth`, `bls_signature`, `increment_with_pause`, `increment_with_fuzz`, `other_custom_types` — simple counter increments
- `custom_types` — parameterized increment
- `alloc` — accumulator loop
- `liquidity_pool` — all pool arithmetic (deposit, swap, withdraw, mint, burn)
- `mint-lock` — epoch calculations

### Not changed (by design)
- Test files — test arithmetic is fine with operators
- `privacy-pools` — ZK/BLS math internals where checked ops would add noise
- Fuzzing targets — arbitrary generation uses range arithmetic

### Known limitations
N/A