### PR TITLE
Disable resource limits in bn254 wasm test

### DIFF
--- a/import_ark_bn254/src/test.rs
+++ b/import_ark_bn254/src/test.rs
@@ -61,9 +61,11 @@ mod bn254_contract {
 #[test]
 fn test_running_contract_as_wasm() {
     let env = Env::default();
-    // This contract is too expensive to run with production budget, let's first
-    // reset the budget to unlimited
+    // This contract is too expensive to run with production budget and mainnet
+    // resource limits, so first reset the budget to unlimited and disable the
+    // resource limit enforcement.
     env.cost_estimate().budget().reset_unlimited();
+    env.cost_estimate().disable_resource_limits();
 
     let contract_id = env.register(bn254_contract::WASM, ());
     let client = bn254_contract::Client::new(&env, &contract_id);

--- a/import_ark_bn254/src/test.rs
+++ b/import_ark_bn254/src/test.rs
@@ -64,7 +64,6 @@ fn test_running_contract_as_wasm() {
     // This contract is too expensive to run with production budget and mainnet
     // resource limits, so first reset the budget to unlimited and disable the
     // resource limit enforcement.
-    env.cost_estimate().budget().reset_unlimited();
     env.cost_estimate().disable_resource_limits();
 
     let contract_id = env.register(bn254_contract::WASM, ());

--- a/import_ark_bn254/src/test.rs
+++ b/import_ark_bn254/src/test.rs
@@ -64,6 +64,7 @@ fn test_running_contract_as_wasm() {
     // This contract is too expensive to run with production budget and mainnet
     // resource limits, so first reset the budget to unlimited and disable the
     // resource limit enforcement.
+    env.cost_estimate().budget().reset_unlimited();
     env.cost_estimate().disable_resource_limits();
 
     let contract_id = env.register(bn254_contract::WASM, ());


### PR DESCRIPTION
### What

Disable resource limits in the `import_ark_bn254` example.

### Why

`Env::default()` in tests enforces mainnet limits. The refresh in stellar/rs-soroban-sdk#1946 (issue stellar/rs-soroban-sdk#1931) updates those limits to match current mainnet, lowering the per-transaction instruction ceiling from 600,000,000 to the true value of 400,000,000. This example consumes ~404,556,039 instructions, so under the refreshed ceiling it panics with `HostError: Error(Budget, ExceededLimit)`.

### Known limitations

N/A

---
_Generated by [Claude Code](https://claude.ai/code/session_01Grhpc1bfnRpvtKtTK5Y2EC)_