### PR TITLE
Use arrays for event expectations

### DIFF
--- a/events/src/test.rs
+++ b/events/src/test.rs
@@ -17,7 +17,7 @@ fn test() {
     assert_eq!(client.increment(), 1);
     assert_eq!(
         env.events().all(),
-        std::vec![IncrementEvent { count: 1 }.to_xdr(&env, &contract_id)]
+        [IncrementEvent { count: 1 }.to_xdr(&env, &contract_id)]
     );
 
     // Assert on the events emitted by the last contract invocation that
@@ -26,7 +26,7 @@ fn test() {
     assert_eq!(client.increment(), 2);
     assert_eq!(
         env.events().all().filter_by_contract(&contract_id),
-        std::vec![IncrementEvent { count: 2 }.to_xdr(&env, &contract_id)]
+        [IncrementEvent { count: 2 }.to_xdr(&env, &contract_id)]
     );
 
     // Assert on the events emitted by the last contract invocation by

--- a/events/src/test.rs
+++ b/events/src/test.rs
@@ -1,7 +1,5 @@
 #![cfg(test)]
 
-extern crate std;
-
 use super::*;
 use soroban_sdk::{testutils::Events, Env, Event, IntoVal};
 


### PR DESCRIPTION
### What

Use arrays for expected events in the events example tests.

### Why

The expected values do not require `std::vec!`, matching the preferred API usage.

> [!NOTE]
> Companion documentation update: https://github.com/stellar/stellar-docs/pull/2721
>
> Origin: https://github.com/stellar/stellar-docs/pull/2687#discussion_r3708017178